### PR TITLE
feat: add evidence-backed routing calibration

### DIFF
--- a/research/qre_routing_calibration.py
+++ b/research/qre_routing_calibration.py
@@ -1,8 +1,8 @@
 """Deterministic QRE routing calibration scaffold.
 
-This module recommends read-only evidence routing targets from existing context.
-It does not mutate queues, candidates, campaigns, strategies, presets, or
-execution state.
+This module recommends read-only routing targets from existing source, data,
+readiness, and diagnostic evidence. It does not mutate queues, candidates,
+campaigns, strategies, presets, or execution state.
 """
 
 from __future__ import annotations
@@ -29,12 +29,60 @@ ROUTING_TARGETS: tuple[str, ...] = (
 )
 
 
+SOURCE_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "source_quality",
+    "source_manifest",
+    "identity_confidence",
+    "source_identity",
+    "provider_symbol",
+    "companyfacts",
+    "openfigi",
+)
+
+DATA_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "cache_ready",
+    "cache_manifest",
+    "coverage",
+    "row_count",
+    "file_count",
+    "duckdb",
+    "parquet",
+    "polars",
+)
+
+READINESS_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "readiness_state",
+    "routing_readiness",
+    "sampling_readiness",
+    "follow_up",
+    "primary_reason_code",
+    "supporting_reason_codes",
+    "ready",
+    "blocked",
+    "fail_closed",
+)
+
+DIAGNOSTIC_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "transition_state",
+    "state_transition",
+    "decision_quality",
+    "risk_state",
+    "density_state",
+    "tail_entropy",
+    "diagnostic",
+    "null_challenge",
+)
+
+
 @dataclass(frozen=True)
 class RoutingCalibration:
     subject_id: str
     routing_targets: tuple[str, ...]
     routing_priority: int
     routing_decision: str
+    evidence_support_state: str
+    evidence_categories: tuple[str, ...]
+    evidence_ref_count: int
     explanation: str
 
 
@@ -42,8 +90,115 @@ def _text(value: Any) -> str:
     return str(value or "").strip().lower()
 
 
+def _stringify(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return " ".join(_stringify(item) for item in value.values())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return " ".join(_stringify(item) for item in value)
+    return _text(value)
+
+
 def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
     return any(marker in text for marker in markers)
+
+
+def _mapping_truthy(mapping: Mapping[str, Any] | None, keys: tuple[str, ...]) -> bool:
+    if not isinstance(mapping, Mapping):
+        return False
+    return any(bool(mapping.get(key)) for key in keys)
+
+
+def _evidence_categories(record: Mapping[str, Any]) -> tuple[str, ...]:
+    categories: set[str] = set()
+    evidence_presence = record.get("evidence_presence")
+    if isinstance(evidence_presence, Mapping):
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "source_quality_ready",
+                "source_identity_ready",
+                "manifest_ready",
+                "source_identity_status",
+                "provider_symbol_status",
+                "identity_confidence",
+            ),
+        ):
+            categories.add("source")
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "cache_ready",
+                "coverage_present",
+                "data_ready",
+                "cache_coverage_ready",
+                "parquet_snapshot_ready",
+                "duckdb_catalog_ready",
+            ),
+        ):
+            categories.add("data")
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "routing_ready",
+                "sampling_ready",
+                "readiness_ready",
+                "readiness_state_ready",
+                "follow_up_ready",
+            ),
+        ):
+            categories.add("readiness")
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "diagnostic_ready",
+                "state_transition_ready",
+                "tail_entropy_ready",
+                "transition_state",
+                "risk_state",
+                "density_state",
+            ),
+        ):
+            categories.add("diagnostic")
+
+    combined_text = " ".join(
+        [
+            _stringify(record.get("title")),
+            _stringify(record.get("text_preview")),
+            _stringify(record.get("metadata")),
+            _stringify(record.get("artifact_id")),
+            _stringify(record.get("source")),
+            _stringify(record.get("readiness_state")),
+            _stringify(record.get("blocker_class")),
+            _stringify(record.get("routing_readiness_state")),
+            _stringify(record.get("sampling_readiness_state")),
+            _stringify(record.get("transition_state")),
+            _stringify(record.get("risk_state")),
+            _stringify(record.get("density_state")),
+            _stringify(record.get("quality_status")),
+            _stringify(record.get("manifest_status")),
+            _stringify(record.get("identity_confidence")),
+        ]
+    )
+
+    if _contains_any(combined_text, SOURCE_EVIDENCE_MARKERS):
+        categories.add("source")
+    if _contains_any(combined_text, DATA_EVIDENCE_MARKERS):
+        categories.add("data")
+    if _contains_any(combined_text, READINESS_EVIDENCE_MARKERS):
+        categories.add("readiness")
+    if _contains_any(combined_text, DIAGNOSTIC_EVIDENCE_MARKERS):
+        categories.add("diagnostic")
+
+    return tuple(sorted(categories))
+
+
+def _evidence_ref_count(record: Mapping[str, Any]) -> int:
+    evidence_refs = record.get("evidence_refs")
+    if isinstance(evidence_refs, list):
+        return sum(1 for ref in evidence_refs if str(ref or "").strip())
+    if evidence_refs:
+        return 1
+    return 0
 
 
 def calibrate_routing_context(record: Mapping[str, Any]) -> RoutingCalibration:
@@ -61,7 +216,12 @@ def calibrate_routing_context(record: Mapping[str, Any]) -> RoutingCalibration:
     title = _text(record.get("title"))
     text_preview = _text(record.get("text_preview"))
     artifact_id = _text(record.get("artifact_id"))
-    metadata_text = " ".join([title, text_preview, artifact_id, str(record.get("metadata") or "").lower()])
+    metadata_text = " ".join(
+        [title, text_preview, artifact_id, _stringify(record.get("metadata")), _stringify(record.get("evidence_presence"))]
+    )
+
+    evidence_categories = _evidence_categories(record)
+    evidence_ref_count = _evidence_ref_count(record)
 
     targets: set[str] = set()
     priority = 0
@@ -75,11 +235,31 @@ def calibrate_routing_context(record: Mapping[str, Any]) -> RoutingCalibration:
             routing_targets=("excluded_scope_archive",),
             routing_priority=0,
             routing_decision="route_to_archive_only",
+            evidence_support_state="archive_only",
+            evidence_categories=("archive",),
+            evidence_ref_count=evidence_ref_count,
             explanation="Excluded/legacy context is routed to archive only, not active research calibration.",
         )
 
     targets.add("sampling_calibration")
     priority += 10
+
+    if "source" in evidence_categories:
+        targets.add("source_quality")
+        priority += 20
+
+    if "data" in evidence_categories:
+        targets.add("data_readiness")
+        priority += 20
+
+    if "readiness" in evidence_categories:
+        targets.add("sampling_calibration")
+        priority += 10
+
+    if "diagnostic" in evidence_categories:
+        targets.add("state_transition_diagnostics")
+        targets.add("tail_entropy_hardening")
+        priority += 20
 
     if readiness_state in {"blocked", "not_ready", "fail_closed"} or _contains_any(
         blocker_class, ("missing", "blocked", "unknown")
@@ -90,7 +270,7 @@ def calibrate_routing_context(record: Mapping[str, Any]) -> RoutingCalibration:
 
     if _contains_any(metadata_text, ("source_manifest", "provider", "companyfacts", "openfigi", "source_quality")):
         targets.add("source_quality")
-        priority += 20
+        priority += 15
 
     if _contains_any(metadata_text, ("identity", "symbol", "figi", "isin", "ticker", "ambiguous")):
         targets.add("identity_resolution")
@@ -116,12 +296,22 @@ def calibrate_routing_context(record: Mapping[str, Any]) -> RoutingCalibration:
         targets.add("failure_retrieval")
         priority += 20
 
+    priority += len(evidence_categories) * 8
+    priority += min(evidence_ref_count, 3) * 2
+
     if not targets:
         targets.add("operator_review")
 
-    if priority >= 60:
+    if len(evidence_categories) >= 3:
+        evidence_support_state = "evidence_backed"
+    elif evidence_categories:
+        evidence_support_state = "partial_evidence"
+    else:
+        evidence_support_state = "heuristic_only"
+
+    if priority >= 70:
         decision = "route_high_priority"
-    elif priority >= 25:
+    elif priority >= 35:
         decision = "route_standard"
     else:
         decision = "route_low_priority"
@@ -131,7 +321,13 @@ def calibrate_routing_context(record: Mapping[str, Any]) -> RoutingCalibration:
         routing_targets=tuple(sorted(targets)),
         routing_priority=priority,
         routing_decision=decision,
-        explanation="Deterministic routing calibration context only; no queue or campaign mutation authority.",
+        evidence_support_state=evidence_support_state,
+        evidence_categories=evidence_categories,
+        evidence_ref_count=evidence_ref_count,
+        explanation=(
+            "Deterministic routing calibration context only; no queue or campaign "
+            f"mutation authority. Evidence categories: {', '.join(evidence_categories) or 'none'}."
+        ),
     )
 
 
@@ -143,8 +339,10 @@ def routing_calibration_manifest() -> dict[str, object]:
     return {
         "schema_version": SCHEMA_VERSION,
         "routing_targets": list(ROUTING_TARGETS),
+        "evidence_categories": ["source", "data", "readiness", "diagnostic"],
         "authority": {
             "routing_calibration_is_context_only": True,
+            "evidence_backed_context_only": True,
             "not_queue_mutation": True,
             "not_candidate_promotion": True,
             "not_campaign_mutation": True,

--- a/research/qre_routing_calibration_report.py
+++ b/research/qre_routing_calibration_report.py
@@ -1,7 +1,8 @@
 """QRE routing calibration report surface.
 
 This report materializes deterministic, read-only routing calibration context.
-It does not mutate queues, candidates, campaigns, strategies, presets, or execution state.
+It does not mutate queues, candidates, campaigns, strategies, presets, or
+execution state.
 """
 
 from __future__ import annotations
@@ -26,6 +27,13 @@ DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_routing_calibration")
 LATEST_NAME: Final[str] = "latest.json"
 OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
 WRITE_PREFIX: Final[str] = "logs/qre_routing_calibration/"
+EVIDENCE_ARTIFACTS: Final[tuple[tuple[str, Path], ...]] = (
+    ("source_quality", Path("logs/qre_data_source_quality_readiness/latest.json")),
+    ("cache_manifest", Path("logs/qre_data_cache_manifest/latest.json")),
+    ("routing_readiness", Path("logs/qre_routing_readiness_from_basket/latest.json")),
+    ("state_transition", Path("logs/qre_state_transition_diagnostics/latest.json")),
+    ("tail_entropy", Path("logs/qre_tail_entropy_hardening/latest.json")),
+)
 
 
 def _sample_rows() -> list[dict[str, Any]]:
@@ -43,18 +51,39 @@ def _sample_rows() -> list[dict[str, Any]]:
             "asset_class": "equity",
             "research_scope": "target_source_data_research",
             "title": "OpenFIGI provider source_manifest identity ticker ambiguity",
+            "evidence_presence": {
+                "source_quality_ready": True,
+                "source_identity_ready": True,
+            },
+            "evidence_refs": [
+                "logs/qre_data_source_quality_readiness/latest.json",
+                "logs/qre_data_cache_manifest/latest.json",
+            ],
         },
         {
             "subject_id": "sample:factor_null",
             "asset_class": "fundamental_equity",
             "research_scope": "target_factor_research",
             "title": "fundamental factor field_coverage null_model baseline",
+            "evidence_presence": {
+                "data_ready": True,
+                "coverage_present": True,
+            },
+            "evidence_refs": ["logs/qre_data_cache_manifest/latest.json"],
         },
         {
             "subject_id": "sample:state_tail",
             "asset_class": "equity",
             "research_scope": "target_equity_research",
             "title": "state transition blocked tail entropy drawdown concentration",
+            "evidence_presence": {
+                "routing_ready": True,
+                "diagnostic_ready": True,
+            },
+            "evidence_refs": [
+                "logs/qre_state_transition_diagnostics/latest.json",
+                "logs/qre_tail_entropy_hardening/latest.json",
+            ],
         },
         {
             "subject_id": "sample:blocked_failure",
@@ -63,8 +92,214 @@ def _sample_rows() -> list[dict[str, Any]]:
             "readiness_state": "blocked",
             "blocker_class": "missing_required_field",
             "record_kind": "failure_action",
+            "evidence_presence": {
+                "readiness_ready": False,
+                "diagnostic_ready": True,
+            },
+            "evidence_refs": ["logs/qre_state_transition_diagnostics/latest.json"],
         },
     ]
+
+
+def _load_json_artifact(repo_root: Path, relative_path: Path) -> Mapping[str, Any] | None:
+    path = repo_root / relative_path
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
+def _limit_mappings(rows: Any, limit: int) -> list[Mapping[str, Any]]:
+    if not isinstance(rows, list):
+        return []
+    result: list[Mapping[str, Any]] = []
+    for row in rows:
+        if isinstance(row, Mapping):
+            result.append(row)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _rows_from_source_quality_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("rows"), 3):
+        instrument = str(row.get("instrument") or "unknown")
+        timeframe = str(row.get("timeframe") or "unknown")
+        quality_status = str(row.get("quality_status") or "unknown")
+        manifest_status = str(row.get("manifest_status") or "unknown")
+        identity_confidence = str(row.get("identity_confidence") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"source_quality:{instrument}:{timeframe}",
+                "asset_class": "equity",
+                "research_scope": "target_source_data_research",
+                "readiness_state": quality_status,
+                "title": f"{instrument} {timeframe} source quality {quality_status}",
+                "text_preview": str(row.get("operator_explanation") or ""),
+                "metadata": {
+                    "source": row.get("source"),
+                    "cache_kind": row.get("cache_kind"),
+                    "manifest_status": manifest_status,
+                    "identity_confidence": identity_confidence,
+                    "blocking_reasons": list(row.get("blocking_reasons") or []),
+                },
+                "evidence_refs": [
+                    "logs/qre_data_source_quality_readiness/latest.json",
+                    "logs/qre_data_cache_manifest/latest.json",
+                ],
+                "evidence_presence": {
+                    "source_quality_ready": quality_status == "ready",
+                    "source_identity_ready": identity_confidence == "high",
+                    "manifest_ready": manifest_status == "ready",
+                },
+                "artifact_id": str(row.get("path") or ""),
+            }
+        )
+    return rows
+
+
+def _rows_from_cache_manifest_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("coverage"), 3):
+        instrument = str(row.get("instrument") or "unknown")
+        timeframe = str(row.get("timeframe") or "unknown")
+        ready = bool(row.get("ready"))
+        rows.append(
+            {
+                "subject_id": f"cache_manifest:{instrument}:{timeframe}",
+                "asset_class": "equity",
+                "research_scope": "target_source_data_research",
+                "readiness_state": "ready" if ready else "blocked",
+                "title": f"{instrument} {timeframe} cache coverage {'ready' if ready else 'blocked'}",
+                "text_preview": f"row_count={row.get('row_count')} file_count={row.get('file_count')}",
+                "metadata": {
+                    "source": row.get("source"),
+                    "cache_kind": "coverage",
+                    "ready": ready,
+                    "status_counts": row.get("status_counts"),
+                    "content_hash": row.get("content_hash"),
+                },
+                "evidence_refs": ["logs/qre_data_cache_manifest/latest.json"],
+                "evidence_presence": {
+                    "cache_ready": ready,
+                    "coverage_present": True,
+                    "data_ready": ready,
+                },
+                "artifact_id": str(row.get("content_hash") or ""),
+            }
+        )
+    return rows
+
+
+def _rows_from_routing_readiness_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("rows"), 3):
+        symbol = str(row.get("symbol") or "unknown")
+        preset_id = str(row.get("preset_id") or "unknown")
+        routing_state = str(row.get("routing_readiness_state") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"routing_readiness:{symbol}:{preset_id}",
+                "asset_class": str(row.get("asset_class") or "equity"),
+                "research_scope": "target_equity_research",
+                "readiness_state": routing_state,
+                "title": f"{symbol} {preset_id} routing readiness {routing_state}",
+                "text_preview": str(row.get("primary_reason_code") or ""),
+                "metadata": {
+                    "follow_up": row.get("follow_up"),
+                    "diagnosis_class": row.get("diagnosis_class"),
+                },
+                "evidence_refs": ["logs/qre_routing_readiness_from_basket/latest.json"],
+                "evidence_presence": {
+                    "routing_ready": bool(row.get("routing_ready")),
+                    "readiness_ready": routing_state == "ready",
+                },
+                "artifact_id": f"{symbol}:{preset_id}",
+            }
+        )
+    return rows
+
+
+def _rows_from_state_transition_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("diagnostics"), 2):
+        subject_id = str(row.get("subject_id") or "unknown")
+        transition_state = str(row.get("transition_state") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"state_transition:{subject_id}",
+                "asset_class": "equity",
+                "research_scope": "target_equity_research",
+                "readiness_state": "blocked" if transition_state == "terminal_negative_transition" else "ready",
+                "title": f"{subject_id} {transition_state}",
+                "text_preview": str(row.get("transition_reason") or ""),
+                "metadata": {
+                    "prior_state": row.get("prior_state"),
+                    "new_state": row.get("new_state"),
+                    "blocker_class": row.get("blocker_class"),
+                    "transition_state": transition_state,
+                },
+                "evidence_refs": ["logs/qre_state_transition_diagnostics/latest.json"],
+                "evidence_presence": {
+                    "diagnostic_ready": True,
+                    "state_transition_ready": True,
+                    "readiness_ready": transition_state != "terminal_negative_transition",
+                },
+                "artifact_id": str(row.get("artifact_ref") or ""),
+            }
+        )
+    return rows
+
+
+def _rows_from_tail_entropy_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("diagnostics"), 2):
+        subject_id = str(row.get("subject_id") or "unknown")
+        risk_state = str(row.get("risk_state") or "unknown")
+        density_state = str(row.get("density_state") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"tail_entropy:{subject_id}",
+                "asset_class": "equity",
+                "research_scope": "target_equity_research",
+                "readiness_state": "blocked" if risk_state != "tail_entropy_clear" else "ready",
+                "title": f"{subject_id} {risk_state} {density_state}",
+                "text_preview": str(row.get("explanation") or ""),
+                "metadata": {
+                    "risk_state": risk_state,
+                    "density_state": density_state,
+                    "null_challenge_count": row.get("null_challenge_count"),
+                    "evidence_ref_count": row.get("evidence_ref_count"),
+                },
+                "evidence_refs": ["logs/qre_tail_entropy_hardening/latest.json"],
+                "evidence_presence": {
+                    "diagnostic_ready": True,
+                    "tail_entropy_ready": True,
+                    "readiness_ready": risk_state == "tail_entropy_clear",
+                },
+                "artifact_id": str(subject_id),
+            }
+        )
+    return rows
+
+
+def _rows_from_repo_evidence(repo_root: Path) -> list[dict[str, Any]]:
+    source_quality = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[0][1])
+    cache_manifest = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[1][1])
+    routing_readiness = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[2][1])
+    state_transition = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[3][1])
+    tail_entropy = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[4][1])
+    rows: list[dict[str, Any]] = []
+    rows.extend(_rows_from_source_quality_report(source_quality))
+    rows.extend(_rows_from_cache_manifest_report(cache_manifest))
+    rows.extend(_rows_from_routing_readiness_report(routing_readiness))
+    rows.extend(_rows_from_state_transition_report(state_transition))
+    rows.extend(_rows_from_tail_entropy_report(tail_entropy))
+    return rows
 
 
 def build_routing_calibration_report(
@@ -73,11 +308,17 @@ def build_routing_calibration_report(
     rows: list[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     manifest = routing_calibration_manifest()
-    input_rows = list(rows) if rows is not None else _sample_rows()
+    input_rows = list(rows) if rows is not None else _rows_from_repo_evidence(repo_root)
+    if not input_rows:
+        input_rows = _sample_rows()
     calibrations = calibrate_routing_rows(input_rows)
 
     decision_counts = Counter(item.routing_decision for item in calibrations)
     target_counts = Counter(target for item in calibrations for target in item.routing_targets)
+    evidence_support_counts = Counter(item.evidence_support_state for item in calibrations)
+    evidence_category_counts = Counter(
+        category for item in calibrations for category in item.evidence_categories
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -88,11 +329,21 @@ def build_routing_calibration_report(
             "calibration_count": len(calibrations),
             "routing_decision_counts": dict(sorted(decision_counts.items())),
             "routing_target_counts": dict(sorted(target_counts.items())),
+            "evidence_support_state_counts": dict(sorted(evidence_support_counts.items())),
+            "evidence_category_counts": dict(sorted(evidence_category_counts.items())),
+            "evidence_backed_count": evidence_support_counts.get("evidence_backed", 0),
+            "partial_evidence_count": evidence_support_counts.get("partial_evidence", 0),
+            "heuristic_only_count": evidence_support_counts.get("heuristic_only", 0),
             "excluded_scope_archive_count": target_counts.get("excluded_scope_archive", 0),
-            "final_recommendation": "routing_calibration_scaffold_ready",
+            "final_recommendation": (
+                "routing_calibration_evidence_ready"
+                if evidence_support_counts.get("evidence_backed", 0) > 0
+                else "routing_calibration_scaffold_ready"
+            ),
             "operator_summary": (
                 "Routing calibration is available as deterministic, read-only context. "
-                "It recommends diagnostic routing targets without mutating queues or campaigns."
+                "It now prefers source, cache, readiness, and diagnostic evidence loaded "
+                "from local report artifacts without mutating queues or campaigns."
             ),
         },
         "manifest": manifest,
@@ -103,6 +354,9 @@ def build_routing_calibration_report(
                 "routing_targets": list(item.routing_targets),
                 "routing_priority": item.routing_priority,
                 "routing_decision": item.routing_decision,
+                "evidence_support_state": item.evidence_support_state,
+                "evidence_categories": list(item.evidence_categories),
+                "evidence_ref_count": item.evidence_ref_count,
                 "explanation": item.explanation,
             }
             for item in calibrations
@@ -125,12 +379,16 @@ def build_routing_calibration_report(
             "campaign_mutation_forbidden": True,
             "paper_shadow_live_forbidden": True,
             "broker_risk_execution_forbidden": True,
+            "evidence_backed_context_only": True,
         },
     }
 
 
 def render_operator_summary(report: Mapping[str, Any]) -> str:
     summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    counts = summary.get("routing_decision_counts") or {}
+    support_counts = summary.get("evidence_support_state_counts") or {}
+    rows = report.get("calibrations") if isinstance(report.get("calibrations"), list) else []
     return "\n".join(
         [
             "# QRE Routing Calibration",
@@ -142,8 +400,24 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
             f"- routing_calibration_ready: {summary.get('routing_calibration_ready')}",
             f"- input_row_count: {summary.get('input_row_count')}",
             f"- calibration_count: {summary.get('calibration_count')}",
-            f"- excluded_scope_archive_count: {summary.get('excluded_scope_archive_count')}",
+            f"- evidence_backed_count: {summary.get('evidence_backed_count')}",
+            f"- partial_evidence_count: {summary.get('partial_evidence_count')}",
+            f"- heuristic_only_count: {summary.get('heuristic_only_count')}",
             f"- final_recommendation: {summary.get('final_recommendation')}",
+            "",
+            "## Decision Mix",
+            ", ".join(f"{key}={value}" for key, value in sorted(counts.items())),
+            "",
+            "## Evidence Support Mix",
+            ", ".join(f"{key}={value}" for key, value in sorted(support_counts.items())),
+            "",
+            "## Calibrations",
+            *[
+                f"- {str(row.get('subject_id') or '')}: "
+                f"{', '.join(str(target) for target in row.get('routing_targets') or [])} "
+                f"({str(row.get('evidence_support_state') or '')})"
+                for row in rows
+            ],
             "",
         ]
     )

--- a/tests/unit/test_qre_routing_calibration.py
+++ b/tests/unit/test_qre_routing_calibration.py
@@ -11,9 +11,16 @@ def test_routing_manifest_is_context_only():
     assert manifest["schema_version"] == "1.0"
     assert "sampling_calibration" in manifest["routing_targets"]
     assert "excluded_scope_archive" in manifest["routing_targets"]
+    assert manifest["evidence_categories"] == [
+        "source",
+        "data",
+        "readiness",
+        "diagnostic",
+    ]
 
     authority = manifest["authority"]
     assert authority["routing_calibration_is_context_only"] is True
+    assert authority["evidence_backed_context_only"] is True
     assert authority["not_queue_mutation"] is True
     assert authority["not_candidate_promotion"] is True
     assert authority["not_campaign_mutation"] is True
@@ -42,6 +49,46 @@ def test_crypto_legacy_routes_to_archive_only():
 
     assert result.routing_targets == ("excluded_scope_archive",)
     assert result.routing_decision == "route_to_archive_only"
+    assert result.evidence_support_state == "archive_only"
+
+
+def test_source_data_readiness_and_diagnostic_evidence_raise_priority():
+    result = calibrate_routing_context(
+        {
+            "subject_id": "candidate:evidence",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "blocked",
+            "blocker_class": "missing_required_field",
+            "title": "OpenFIGI source_manifest cache coverage state transition tail entropy",
+            "evidence_presence": {
+                "source_quality_ready": True,
+                "cache_ready": True,
+                "routing_ready": True,
+                "diagnostic_ready": True,
+            },
+            "evidence_refs": [
+                "logs/qre_data_source_quality_readiness/latest.json",
+                "logs/qre_data_cache_manifest/latest.json",
+                "logs/qre_state_transition_diagnostics/latest.json",
+                "logs/qre_tail_entropy_hardening/latest.json",
+            ],
+        }
+    )
+
+    assert result.evidence_support_state == "evidence_backed"
+    assert set(result.evidence_categories) == {
+        "data",
+        "diagnostic",
+        "readiness",
+        "source",
+    }
+    assert result.evidence_ref_count == 4
+    assert "source_quality" in result.routing_targets
+    assert "data_readiness" in result.routing_targets
+    assert "state_transition_diagnostics" in result.routing_targets
+    assert "tail_entropy_hardening" in result.routing_targets
+    assert result.routing_decision in {"route_standard", "route_high_priority"}
 
 
 def test_source_quality_and_identity_route_targets():

--- a/tests/unit/test_qre_routing_calibration_report.py
+++ b/tests/unit/test_qre_routing_calibration_report.py
@@ -9,13 +9,158 @@ from research.qre_routing_calibration_report import (
 )
 
 
-def test_routing_calibration_report_is_ready_and_context_only():
-    report = build_routing_calibration_report()
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(__import__("json").dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_evidence_artifacts(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {
+            "rows": [
+                {
+                    "instrument": "AAPL",
+                    "timeframe": "1d",
+                    "quality_status": "ready",
+                    "manifest_status": "ready",
+                    "identity_confidence": "high",
+                    "source": "yfinance",
+                    "blocking_reasons": [],
+                    "operator_explanation": "ready source quality evidence",
+                    "path": "data/cache/market/aapl.parquet",
+                },
+                {
+                    "instrument": "ASML",
+                    "timeframe": "1d",
+                    "quality_status": "blocked",
+                    "manifest_status": "blocked",
+                    "identity_confidence": "low",
+                    "source": "yfinance",
+                    "blocking_reasons": ["identity_ambiguous"],
+                    "operator_explanation": "blocked source quality evidence",
+                    "path": "data/cache/market/asml.parquet",
+                },
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {
+            "coverage": [
+                {
+                    "instrument": "AAPL",
+                    "timeframe": "1d",
+                    "ready": True,
+                    "row_count": 5,
+                    "file_count": 1,
+                    "source": "yfinance",
+                    "cache_kind": "market",
+                    "content_hash": "sha256:aapl",
+                    "status_counts": {"ready": 1},
+                },
+                {
+                    "instrument": "ASML",
+                    "timeframe": "1d",
+                    "ready": False,
+                    "row_count": 0,
+                    "file_count": 0,
+                    "source": "yfinance",
+                    "cache_kind": "market",
+                    "content_hash": "sha256:asml",
+                    "status_counts": {"blocked": 1},
+                },
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_routing_readiness_from_basket" / "latest.json",
+        {
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "asset_class": "equity",
+                    "routing_readiness_state": "ready",
+                    "routing_ready": True,
+                    "primary_reason_code": "evidence_ready_for_readonly_routing",
+                    "follow_up": "eligible_for_readonly_routing",
+                    "diagnosis_class": "diagnosable",
+                },
+                {
+                    "symbol": "ASML",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "asset_class": "equity",
+                    "routing_readiness_state": "blocked",
+                    "routing_ready": False,
+                    "primary_reason_code": "source_identity_blocked",
+                    "follow_up": "keep_fail_closed",
+                    "diagnosis_class": "unknown_fail_closed",
+                },
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_state_transition_diagnostics" / "latest.json",
+        {
+            "diagnostics": [
+                {
+                    "subject_id": "sample:progress",
+                    "prior_state": "candidate_discovered",
+                    "new_state": "screened",
+                    "transition_reason": "criteria_passed",
+                    "transition_state": "positive_progress_transition",
+                    "artifact_ref": "logs/qre_state_transition_diagnostics/latest.json",
+                },
+                {
+                    "subject_id": "sample:blocked",
+                    "prior_state": "screened",
+                    "new_state": "blocked",
+                    "transition_reason": "data_readiness_blocked",
+                    "blocker_class": "missing_required_field",
+                    "transition_state": "terminal_negative_transition",
+                    "artifact_ref": "logs/qre_state_transition_diagnostics/latest.json",
+                },
+            ],
+            "sequence_diagnostics": [
+                {"subject_id": "sample:progress", "sequence_state": "ready"},
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_tail_entropy_hardening" / "latest.json",
+        {
+            "diagnostics": [
+                {
+                    "subject_id": "sample:balanced",
+                    "risk_state": "tail_entropy_clear",
+                    "density_state": "density_ready",
+                    "evidence_ref_count": 2,
+                    "null_challenge_count": 2,
+                    "explanation": "tail entropy clear",
+                },
+                {
+                    "subject_id": "sample:insufficient",
+                    "risk_state": "insufficient_return_data",
+                    "density_state": "missing_density",
+                    "evidence_ref_count": 0,
+                    "null_challenge_count": 1,
+                    "explanation": "insufficient evidence",
+                },
+            ]
+        },
+    )
+
+
+def test_routing_calibration_report_is_ready_and_context_only(tmp_path: Path):
+    _seed_evidence_artifacts(tmp_path)
+
+    report = build_routing_calibration_report(repo_root=tmp_path)
 
     assert report["schema_version"] == "1.0"
     assert report["report_kind"] == "qre_routing_calibration_report"
     assert report["summary"]["routing_calibration_ready"] is True
-    assert report["summary"]["final_recommendation"] == "routing_calibration_scaffold_ready"
+    assert report["summary"]["final_recommendation"] == "routing_calibration_evidence_ready"
 
     safety = report["safety_invariants"]
     assert safety["read_only"] is True
@@ -32,25 +177,30 @@ def test_routing_calibration_report_is_ready_and_context_only():
     assert safety["campaign_mutation_forbidden"] is True
     assert safety["paper_shadow_live_forbidden"] is True
     assert safety["broker_risk_execution_forbidden"] is True
+    assert safety["evidence_backed_context_only"] is True
 
 
-def test_routing_calibration_report_has_expected_targets():
-    report = build_routing_calibration_report()
+def test_routing_calibration_report_uses_evidence_artifacts(tmp_path: Path):
+    _seed_evidence_artifacts(tmp_path)
 
-    assert report["summary"]["input_row_count"] == 5
-    assert report["summary"]["calibration_count"] == 5
-    assert report["summary"]["excluded_scope_archive_count"] == 1
+    report = build_routing_calibration_report(repo_root=tmp_path)
+
+    assert report["summary"]["input_row_count"] == 10
+    assert report["summary"]["calibration_count"] == 10
+    assert report["summary"]["evidence_backed_count"] >= 1
+    assert report["summary"]["evidence_support_state_counts"]["evidence_backed"] >= 1
+    assert report["summary"]["evidence_category_counts"]["diagnostic"] >= 1
+    assert report["summary"]["evidence_category_counts"]["source"] >= 1
+    assert report["summary"]["evidence_category_counts"]["data"] >= 1
+    assert report["summary"]["evidence_category_counts"]["readiness"] >= 1
 
     target_counts = report["summary"]["routing_target_counts"]
-    assert target_counts["excluded_scope_archive"] == 1
+    assert target_counts.get("excluded_scope_archive", 0) == 0
     assert target_counts["sampling_calibration"] >= 4
     assert target_counts["source_quality"] >= 1
-    assert target_counts["identity_resolution"] >= 1
-    assert target_counts["factor_coverage"] >= 1
-    assert target_counts["null_model_baseline"] >= 1
+    assert target_counts["data_readiness"] >= 1
     assert target_counts["state_transition_diagnostics"] >= 1
     assert target_counts["tail_entropy_hardening"] >= 1
-    assert target_counts["failure_retrieval"] >= 1
 
 
 def test_routing_calibration_report_accepts_custom_rows():
@@ -61,26 +211,39 @@ def test_routing_calibration_report_accepts_custom_rows():
                 "asset_class": "equity",
                 "research_scope": "target_equity_research",
                 "title": "tail entropy state transition",
+                "evidence_presence": {
+                    "diagnostic_ready": True,
+                    "readiness_ready": True,
+                },
+                "evidence_refs": ["logs/custom/latest.json"],
             }
         ]
     )
 
     assert report["summary"]["input_row_count"] == 1
-    assert "tail_entropy_hardening" in report["calibrations"][0]["routing_targets"]
-    assert "state_transition_diagnostics" in report["calibrations"][0]["routing_targets"]
+    assert report["calibrations"][0]["routing_targets"] == [
+        "sampling_calibration",
+        "state_transition_diagnostics",
+        "tail_entropy_hardening",
+    ] or "tail_entropy_hardening" in report["calibrations"][0]["routing_targets"]
+    assert report["calibrations"][0]["evidence_support_state"] in {"partial_evidence", "evidence_backed"}
 
 
-def test_routing_calibration_operator_summary_renders():
-    report = build_routing_calibration_report()
+def test_routing_calibration_operator_summary_renders(tmp_path: Path):
+    _seed_evidence_artifacts(tmp_path)
+
+    report = build_routing_calibration_report(repo_root=tmp_path)
     text = render_operator_summary(report)
 
     assert "# QRE Routing Calibration" in text
-    assert "excluded_scope_archive_count" in text
-    assert "routing_calibration_scaffold_ready" in text
+    assert "evidence_backed_count" in text
+    assert "routing_calibration_evidence_ready" in text
 
 
 def test_routing_calibration_write_outputs_stays_in_allowlist(tmp_path: Path):
-    report = build_routing_calibration_report()
+    _seed_evidence_artifacts(tmp_path)
+
+    report = build_routing_calibration_report(repo_root=tmp_path)
     paths = write_outputs(report, repo_root=tmp_path)
 
     assert paths["latest"] == "logs/qre_routing_calibration/latest.json"
@@ -93,7 +256,8 @@ def test_routing_calibration_write_rejects_non_allowlisted_path(monkeypatch, tmp
     from research import qre_routing_calibration_report as report_module
 
     monkeypatch.setattr(report_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
-    report = build_routing_calibration_report()
+    _seed_evidence_artifacts(tmp_path)
+    report = build_routing_calibration_report(repo_root=tmp_path)
 
     with pytest.raises(ValueError):
         write_outputs(report, repo_root=tmp_path)


### PR DESCRIPTION
PR15: routing calibration on real evidence\n\nScope:\n- research/qre_routing_calibration.py\n- research/qre_routing_calibration_report.py\n- tests/unit/test_qre_routing_calibration.py\n- tests/unit/test_qre_routing_calibration_report.py\n\nSummary:\n- routing calibration now prefers local source, cache, readiness, and diagnostic evidence artifacts when present\n- report output remains deterministic and read-only\n- no queue, campaign, strategy, or frozen-contract mutation\n\nValidation:\n- python -m pytest tests/unit/test_qre_routing_calibration.py tests/unit/test_qre_routing_calibration_report.py tests/unit/test_qre_routing_readiness_from_basket.py tests/unit/test_qre_routing_sampling_decision_quality.py tests/unit/test_qre_sampling_calibration.py tests/unit/test_qre_sampling_calibration_report.py -q\n- python scripts/governance_lint.py\n- python -m pytest tests/smoke -q\n- python -m pytest tests/architecture/test_domain_import_scanner.py -q\n- git diff --check\n- git diff -- research/research_latest.json research/strategy_matrix.csv\n