### PR TITLE
feat: add evidence-backed sampling calibration

### DIFF
--- a/research/qre_sampling_calibration.py
+++ b/research/qre_sampling_calibration.py
@@ -1,8 +1,8 @@
 """Deterministic QRE sampling calibration scaffold.
 
-This module scores research sampling context using existing evidence metadata.
-It is read-only and cannot mutate candidates, campaigns, strategies, presets,
-or execution state.
+This module scores research sampling context using source, data, readiness,
+null-model, and regime evidence metadata. It is read-only and cannot mutate
+candidates, campaigns, strategies, presets, or execution state.
 """
 
 from __future__ import annotations
@@ -55,6 +55,73 @@ EXCLUDED_RESEARCH_SCOPES: tuple[str, ...] = (
 )
 
 
+SOURCE_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "source_quality",
+    "source_manifest",
+    "identity_confidence",
+    "provider_symbol",
+    "openfigi",
+    "companyfacts",
+)
+
+
+DATA_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "cache_ready",
+    "cache_manifest",
+    "coverage",
+    "row_count",
+    "file_count",
+    "parquet",
+    "duckdb",
+    "polars",
+)
+
+
+READINESS_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "readiness_state",
+    "routing_readiness",
+    "sampling_readiness",
+    "follow_up",
+    "ready",
+    "blocked",
+    "fail_closed",
+)
+
+
+DIAGNOSTIC_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "transition_state",
+    "state_transition",
+    "decision_quality",
+    "risk_state",
+    "density_state",
+    "tail_entropy",
+    "diagnostic",
+)
+
+
+NULL_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "null_model",
+    "baseline_type",
+    "baseline_metric",
+    "random_walk",
+    "shuffled_surrogate",
+    "martingale_like",
+    "candidate_above_baseline",
+    "candidate_below_baseline",
+    "candidate_equal_to_baseline",
+)
+
+
+REGIME_EVIDENCE_MARKERS: tuple[str, ...] = (
+    "regime_duration",
+    "dwell_state",
+    "sequence_state",
+    "longest_run",
+    "sequence_diagnostic",
+    "transition_reason",
+)
+
+
 @dataclass(frozen=True)
 class SamplingCalibration:
     subject_id: str
@@ -62,6 +129,9 @@ class SamplingCalibration:
     sampling_decision: str
     preferred_axes: tuple[str, ...]
     penalty_axes: tuple[str, ...]
+    evidence_support_state: str
+    evidence_categories: tuple[str, ...]
+    evidence_ref_count: int
     explanation: str
 
 
@@ -69,8 +139,131 @@ def _text(value: Any) -> str:
     return str(value or "").strip().lower()
 
 
+def _stringify(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return " ".join(_stringify(item) for item in value.values())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return " ".join(_stringify(item) for item in value)
+    return _text(value)
+
+
 def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
     return any(marker in text for marker in markers)
+
+
+def _mapping_truthy(mapping: Mapping[str, Any] | None, keys: tuple[str, ...]) -> bool:
+    if not isinstance(mapping, Mapping):
+        return False
+    return any(bool(mapping.get(key)) for key in keys)
+
+
+def _evidence_categories(record: Mapping[str, Any]) -> tuple[str, ...]:
+    categories: set[str] = set()
+    evidence_presence = record.get("evidence_presence")
+    if isinstance(evidence_presence, Mapping):
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "source_quality_ready",
+                "source_identity_ready",
+                "manifest_ready",
+                "identity_confidence",
+            ),
+        ):
+            categories.add("source")
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "cache_ready",
+                "coverage_present",
+                "data_ready",
+                "cache_coverage_ready",
+            ),
+        ):
+            categories.add("data")
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "sampling_ready",
+                "routing_ready",
+                "readiness_ready",
+            ),
+        ):
+            categories.add("readiness")
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "diagnostic_ready",
+                "tail_entropy_ready",
+                "state_transition_ready",
+            ),
+        ):
+            categories.add("diagnostic")
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "null_model_ready",
+                "baseline_ready",
+                "comparison_ready",
+            ),
+        ):
+            categories.add("null")
+        if _mapping_truthy(
+            evidence_presence,
+            (
+                "regime_ready",
+                "sequence_ready",
+                "dwell_ready",
+            ),
+        ):
+            categories.add("regime")
+
+    combined_text = " ".join(
+        [
+            _stringify(record.get("title")),
+            _stringify(record.get("text_preview")),
+            _stringify(record.get("metadata")),
+            _stringify(record.get("artifact_id")),
+            _stringify(record.get("source")),
+            _stringify(record.get("readiness_state")),
+            _stringify(record.get("blocker_class")),
+            _stringify(record.get("comparison_state")),
+            _stringify(record.get("baseline_type")),
+            _stringify(record.get("risk_state")),
+            _stringify(record.get("density_state")),
+            _stringify(record.get("transition_state")),
+            _stringify(record.get("sequence_state")),
+            _stringify(record.get("dwell_state")),
+            _stringify(record.get("regime_duration_steps")),
+            _stringify(record.get("quality_status")),
+            _stringify(record.get("manifest_status")),
+            _stringify(record.get("identity_confidence")),
+        ]
+    )
+
+    if _contains_any(combined_text, SOURCE_EVIDENCE_MARKERS):
+        categories.add("source")
+    if _contains_any(combined_text, DATA_EVIDENCE_MARKERS):
+        categories.add("data")
+    if _contains_any(combined_text, READINESS_EVIDENCE_MARKERS):
+        categories.add("readiness")
+    if _contains_any(combined_text, DIAGNOSTIC_EVIDENCE_MARKERS):
+        categories.add("diagnostic")
+    if _contains_any(combined_text, NULL_EVIDENCE_MARKERS):
+        categories.add("null")
+    if _contains_any(combined_text, REGIME_EVIDENCE_MARKERS):
+        categories.add("regime")
+
+    return tuple(sorted(categories))
+
+
+def _evidence_ref_count(record: Mapping[str, Any]) -> int:
+    evidence_refs = record.get("evidence_refs")
+    if isinstance(evidence_refs, list):
+        return sum(1 for ref in evidence_refs if str(ref or "").strip())
+    if evidence_refs:
+        return 1
+    return 0
 
 
 def _region_axis(metadata_text: str) -> str | None:
@@ -98,10 +291,16 @@ def calibrate_sampling_context(record: Mapping[str, Any]) -> SamplingCalibration
     asset_class = _text(record.get("asset_class") or ontology.get("asset_class"))
     research_scope = _text(record.get("research_scope") or ontology.get("research_scope"))
     readiness_state = _text(record.get("readiness_state") or ontology.get("readiness_state"))
+    comparison_state = _text(record.get("comparison_state") or ontology.get("comparison_state"))
     title = _text(record.get("title"))
     text_preview = _text(record.get("text_preview"))
     artifact_id = _text(record.get("artifact_id"))
-    metadata_text = " ".join([title, text_preview, artifact_id, str(record.get("metadata") or "").lower()])
+    metadata_text = " ".join(
+        [title, text_preview, artifact_id, _stringify(record.get("metadata")), _stringify(record.get("evidence_presence"))]
+    )
+
+    evidence_categories = _evidence_categories(record)
+    evidence_ref_count = _evidence_ref_count(record)
 
     score = 0
     preferred_axes: list[str] = []
@@ -115,6 +314,9 @@ def calibrate_sampling_context(record: Mapping[str, Any]) -> SamplingCalibration
             sampling_decision="exclude_sampling",
             preferred_axes=tuple(preferred_axes),
             penalty_axes=tuple(penalty_axes),
+            evidence_support_state="archive_only",
+            evidence_categories=("archive",),
+            evidence_ref_count=evidence_ref_count,
             explanation="Crypto legacy/non-target asset class is excluded from current sampling scope.",
         )
 
@@ -126,6 +328,9 @@ def calibrate_sampling_context(record: Mapping[str, Any]) -> SamplingCalibration
             sampling_decision="exclude_sampling",
             preferred_axes=tuple(preferred_axes),
             penalty_axes=tuple(penalty_axes),
+            evidence_support_state="archive_only",
+            evidence_categories=("archive",),
+            evidence_ref_count=evidence_ref_count,
             explanation="Research scope is excluded from current sampling scope.",
         )
 
@@ -146,6 +351,40 @@ def calibrate_sampling_context(record: Mapping[str, Any]) -> SamplingCalibration
         score += 15
         preferred_axes.append(region)
 
+    if "source" in evidence_categories:
+        score += 15
+        preferred_axes.append("evidence:source_ready")
+
+    if "data" in evidence_categories:
+        score += 15
+        preferred_axes.append("evidence:data_ready")
+
+    if "readiness" in evidence_categories:
+        score += 10
+        preferred_axes.append("evidence:readiness_ready")
+
+    if "diagnostic" in evidence_categories:
+        score += 10
+        preferred_axes.append("evidence:diagnostic_ready")
+
+    if "null" in evidence_categories:
+        score += 15
+        preferred_axes.append("evidence:null_model_ready")
+
+    if "regime" in evidence_categories:
+        score += 10
+        preferred_axes.append("evidence:regime_ready")
+
+    if comparison_state == "candidate_above_baseline":
+        score += 10
+        preferred_axes.append("comparison_state:above_baseline")
+    elif comparison_state == "candidate_equal_to_baseline":
+        score += 5
+        preferred_axes.append("comparison_state:equal_to_baseline")
+    elif comparison_state == "candidate_below_baseline":
+        score -= 15
+        penalty_axes.append("comparison_state:below_baseline")
+
     if readiness_state in {"blocked", "fail_closed", "not_ready"}:
         score -= 40
         penalty_axes.append(f"readiness_state:{readiness_state}")
@@ -160,6 +399,13 @@ def calibrate_sampling_context(record: Mapping[str, Any]) -> SamplingCalibration
         score -= 80
         penalty_axes.append("content:crypto_marker")
 
+    if len(evidence_categories) >= 3:
+        evidence_support_state = "evidence_backed"
+    elif evidence_categories:
+        evidence_support_state = "partial_evidence"
+    else:
+        evidence_support_state = "heuristic_only"
+
     if score >= 60:
         decision = "prefer_sampling"
     elif score >= 20:
@@ -169,13 +415,22 @@ def calibrate_sampling_context(record: Mapping[str, Any]) -> SamplingCalibration
     else:
         decision = "exclude_sampling"
 
+    if readiness_state in {"blocked", "fail_closed", "not_ready"} and decision == "prefer_sampling":
+        decision = "allow_sampling" if score >= 20 else "deprioritize_sampling"
+
     return SamplingCalibration(
         subject_id=subject_id,
         sampling_score=score,
         sampling_decision=decision,
         preferred_axes=tuple(sorted(set(preferred_axes))),
         penalty_axes=tuple(sorted(set(penalty_axes))),
-        explanation="Deterministic sampling calibration context only; no campaign mutation authority.",
+        evidence_support_state=evidence_support_state,
+        evidence_categories=evidence_categories,
+        evidence_ref_count=evidence_ref_count,
+        explanation=(
+            "Deterministic sampling calibration context only; no campaign mutation "
+            f"authority. Evidence categories: {', '.join(evidence_categories) or 'none'}."
+        ),
     )
 
 
@@ -192,8 +447,17 @@ def sampling_calibration_manifest() -> dict[str, object]:
         "excluded_asset_classes": list(EXCLUDED_ASSET_CLASSES),
         "preferred_research_scopes": list(PREFERRED_RESEARCH_SCOPES),
         "excluded_research_scopes": list(EXCLUDED_RESEARCH_SCOPES),
+        "evidence_categories": [
+            "source",
+            "data",
+            "readiness",
+            "diagnostic",
+            "null",
+            "regime",
+        ],
         "authority": {
             "sampling_calibration_is_context_only": True,
+            "evidence_backed_context_only": True,
             "not_alpha_authority": True,
             "not_candidate_promotion": True,
             "not_campaign_mutation": True,

--- a/research/qre_sampling_calibration_report.py
+++ b/research/qre_sampling_calibration_report.py
@@ -26,6 +26,13 @@ DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_sampling_calibration")
 LATEST_NAME: Final[str] = "latest.json"
 OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
 WRITE_PREFIX: Final[str] = "logs/qre_sampling_calibration/"
+EVIDENCE_ARTIFACTS: Final[tuple[tuple[str, Path], ...]] = (
+    ("source_quality", Path("logs/qre_data_source_quality_readiness/latest.json")),
+    ("cache_manifest", Path("logs/qre_data_cache_manifest/latest.json")),
+    ("null_model", Path("logs/qre_null_model_baseline/latest.json")),
+    ("state_transition", Path("logs/qre_state_transition_diagnostics/latest.json")),
+    ("tail_entropy", Path("logs/qre_tail_entropy_hardening/latest.json")),
+)
 
 
 def _sample_rows() -> list[dict[str, Any]]:
@@ -71,20 +78,292 @@ def _sample_rows() -> list[dict[str, Any]]:
     ]
 
 
+def _load_json_artifact(repo_root: Path, relative_path: Path) -> Mapping[str, Any] | None:
+    path = repo_root / relative_path
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
+def _limit_mappings(rows: Any, limit: int) -> list[Mapping[str, Any]]:
+    if not isinstance(rows, list):
+        return []
+    result: list[Mapping[str, Any]] = []
+    for row in rows:
+        if isinstance(row, Mapping):
+            result.append(row)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _rows_from_source_quality_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("rows"), 2):
+        instrument = str(row.get("instrument") or "unknown")
+        timeframe = str(row.get("timeframe") or "unknown")
+        quality_status = str(row.get("quality_status") or "unknown")
+        manifest_status = str(row.get("manifest_status") or "unknown")
+        identity_confidence = str(row.get("identity_confidence") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"source_quality:{instrument}:{timeframe}",
+                "asset_class": "equity",
+                "research_scope": "target_source_data_research",
+                "readiness_state": quality_status,
+                "title": f"{instrument} {timeframe} source quality {quality_status}",
+                "text_preview": str(row.get("operator_explanation") or ""),
+                "metadata": {
+                    "source": row.get("source"),
+                    "cache_kind": row.get("cache_kind"),
+                    "manifest_status": manifest_status,
+                    "identity_confidence": identity_confidence,
+                    "blocking_reasons": list(row.get("blocking_reasons") or []),
+                },
+                "evidence_refs": [
+                    "logs/qre_data_source_quality_readiness/latest.json",
+                    "logs/qre_data_cache_manifest/latest.json",
+                ],
+                "evidence_presence": {
+                    "source_quality_ready": quality_status == "ready",
+                    "source_identity_ready": identity_confidence == "high",
+                    "manifest_ready": manifest_status == "ready",
+                },
+                "artifact_id": str(row.get("path") or ""),
+            }
+        )
+    return rows
+
+
+def _rows_from_cache_manifest_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("coverage"), 2):
+        instrument = str(row.get("instrument") or "unknown")
+        timeframe = str(row.get("timeframe") or "unknown")
+        ready = bool(row.get("ready"))
+        rows.append(
+            {
+                "subject_id": f"cache_manifest:{instrument}:{timeframe}",
+                "asset_class": "equity",
+                "research_scope": "target_source_data_research",
+                "readiness_state": "ready" if ready else "blocked",
+                "title": f"{instrument} {timeframe} cache coverage {'ready' if ready else 'blocked'}",
+                "text_preview": f"row_count={row.get('row_count')} file_count={row.get('file_count')}",
+                "metadata": {
+                    "source": row.get("source"),
+                    "cache_kind": "coverage",
+                    "ready": ready,
+                    "status_counts": row.get("status_counts"),
+                    "content_hash": row.get("content_hash"),
+                },
+                "evidence_refs": ["logs/qre_data_cache_manifest/latest.json"],
+                "evidence_presence": {
+                    "cache_ready": ready,
+                    "coverage_present": True,
+                    "data_ready": ready,
+                },
+                "artifact_id": str(row.get("content_hash") or ""),
+            }
+        )
+    return rows
+
+
+def _rows_from_null_model_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    sample_comparisons = _limit_mappings((report or {}).get("sample_comparisons"), 2)
+    suite_comparisons = _limit_mappings((report or {}).get("suite_comparisons"), 2)
+
+    for row in sample_comparisons:
+        comparison_state = str(row.get("comparison_state") or "unknown")
+        candidate_id = str(row.get("candidate_id") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"null_model_sample:{candidate_id}",
+                "asset_class": "fundamental_equity",
+                "research_scope": "target_factor_research",
+                "readiness_state": (
+                    "ready" if comparison_state in {"candidate_above_baseline", "candidate_equal_to_baseline"} else "blocked"
+                ),
+                "comparison_state": comparison_state,
+                "baseline_type": str(row.get("baseline_type") or "median_candidate"),
+                "title": f"{candidate_id} {comparison_state}",
+                "text_preview": str(row.get("explanation") or ""),
+                "metadata": {
+                    "baseline_metric": row.get("baseline_metric"),
+                    "candidate_metric": row.get("candidate_metric"),
+                    "delta_vs_baseline": row.get("delta_vs_baseline"),
+                },
+                "evidence_refs": ["logs/qre_null_model_baseline/latest.json"],
+                "evidence_presence": {
+                    "null_model_ready": True,
+                    "baseline_ready": True,
+                    "comparison_ready": True,
+                },
+                "artifact_id": f"{candidate_id}:{comparison_state}",
+            }
+        )
+
+    for row in suite_comparisons:
+        comparison_state = str(row.get("comparison_state") or "unknown")
+        candidate_id = str(row.get("candidate_id") or "unknown")
+        family = str(row.get("family") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"null_model_suite:{family}:{candidate_id}",
+                "asset_class": "fundamental_equity",
+                "research_scope": "target_factor_research",
+                "readiness_state": (
+                    "ready" if comparison_state in {"candidate_above_baseline", "candidate_equal_to_baseline"} else "blocked"
+                ),
+                "comparison_state": comparison_state,
+                "baseline_type": family,
+                "title": f"{family} {candidate_id} {comparison_state}",
+                "text_preview": str(row.get("explanation") or ""),
+                "metadata": {
+                    "baseline_metric": row.get("baseline_metric"),
+                    "candidate_metric": row.get("candidate_metric"),
+                    "delta_vs_baseline": row.get("delta_vs_baseline"),
+                    "family": family,
+                },
+                "evidence_refs": ["logs/qre_null_model_baseline/latest.json"],
+                "evidence_presence": {
+                    "null_model_ready": True,
+                    "baseline_ready": True,
+                    "comparison_ready": True,
+                },
+                "artifact_id": f"{family}:{candidate_id}:{comparison_state}",
+            }
+        )
+    return rows
+
+
+def _rows_from_state_transition_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("diagnostics"), 2):
+        subject_id = str(row.get("subject_id") or "unknown")
+        transition_state = str(row.get("transition_state") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"state_transition:{subject_id}",
+                "asset_class": "equity",
+                "research_scope": "target_equity_research",
+                "readiness_state": "blocked" if transition_state == "terminal_negative_transition" else "ready",
+                "title": f"{subject_id} {transition_state}",
+                "text_preview": str(row.get("transition_reason") or ""),
+                "metadata": {
+                    "prior_state": row.get("prior_state"),
+                    "new_state": row.get("new_state"),
+                    "blocker_class": row.get("blocker_class"),
+                    "transition_state": transition_state,
+                },
+                "evidence_refs": ["logs/qre_state_transition_diagnostics/latest.json"],
+                "evidence_presence": {
+                    "diagnostic_ready": True,
+                    "state_transition_ready": True,
+                    "regime_ready": True,
+                },
+                "artifact_id": str(row.get("artifact_ref") or ""),
+            }
+        )
+
+    for row in _limit_mappings((report or {}).get("sequence_diagnostics"), 2):
+        subject_id = str(row.get("subject_id") or "unknown")
+        sparse_data = bool(row.get("sparse_data"))
+        rows.append(
+            {
+                "subject_id": f"regime:{subject_id}",
+                "asset_class": "equity",
+                "research_scope": "target_equity_research",
+                "readiness_state": "blocked" if sparse_data else "ready",
+                "title": f"{subject_id} regime duration {row.get('regime_duration_steps')}",
+                "text_preview": str(row.get("explanation") or ""),
+                "metadata": {
+                    "sequence_state": row.get("sequence_state"),
+                    "dwell_state": row.get("dwell_state"),
+                    "dwell_steps": row.get("dwell_steps"),
+                    "regime_duration_steps": row.get("regime_duration_steps"),
+                },
+                "evidence_refs": ["logs/qre_state_transition_diagnostics/latest.json"],
+                "evidence_presence": {
+                    "diagnostic_ready": True,
+                    "sequence_ready": True,
+                    "regime_ready": True,
+                },
+                "artifact_id": str(row.get("subject_id") or ""),
+            }
+        )
+    return rows
+
+
+def _rows_from_tail_entropy_report(report: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in _limit_mappings((report or {}).get("diagnostics"), 2):
+        subject_id = str(row.get("subject_id") or "unknown")
+        risk_state = str(row.get("risk_state") or "unknown")
+        density_state = str(row.get("density_state") or "unknown")
+        rows.append(
+            {
+                "subject_id": f"tail_entropy:{subject_id}",
+                "asset_class": "equity",
+                "research_scope": "target_equity_research",
+                "readiness_state": "blocked" if risk_state != "tail_entropy_clear" else "ready",
+                "title": f"{subject_id} {risk_state} {density_state}",
+                "text_preview": str(row.get("explanation") or ""),
+                "metadata": {
+                    "risk_state": risk_state,
+                    "density_state": density_state,
+                    "null_challenge_count": row.get("null_challenge_count"),
+                    "evidence_ref_count": row.get("evidence_ref_count"),
+                },
+                "evidence_refs": ["logs/qre_tail_entropy_hardening/latest.json"],
+                "evidence_presence": {
+                    "diagnostic_ready": True,
+                    "tail_entropy_ready": True,
+                    "regime_ready": True,
+                },
+                "artifact_id": str(subject_id),
+            }
+        )
+    return rows
+
+
+def _rows_from_repo_evidence(repo_root: Path) -> list[dict[str, Any]]:
+    source_quality = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[0][1])
+    cache_manifest = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[1][1])
+    null_model = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[2][1])
+    state_transition = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[3][1])
+    tail_entropy = _load_json_artifact(repo_root, EVIDENCE_ARTIFACTS[4][1])
+    rows: list[dict[str, Any]] = []
+    rows.extend(_rows_from_source_quality_report(source_quality))
+    rows.extend(_rows_from_cache_manifest_report(cache_manifest))
+    rows.extend(_rows_from_null_model_report(null_model))
+    rows.extend(_rows_from_state_transition_report(state_transition))
+    rows.extend(_rows_from_tail_entropy_report(tail_entropy))
+    return rows
+
+
 def build_sampling_calibration_report(
     *,
     repo_root: Path = Path("."),
     rows: list[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     manifest = sampling_calibration_manifest()
-    input_rows = list(rows) if rows is not None else _sample_rows()
+    input_rows = list(rows) if rows is not None else _rows_from_repo_evidence(repo_root)
+    if not input_rows:
+        input_rows = _sample_rows()
     calibrations = calibrate_sampling_rows(input_rows)
 
     decision_counts = Counter(item.sampling_decision for item in calibrations)
-    preferred_axis_counts = Counter(
-        axis for item in calibrations for axis in item.preferred_axes
-    )
+    preferred_axis_counts = Counter(axis for item in calibrations for axis in item.preferred_axes)
     penalty_axis_counts = Counter(axis for item in calibrations for axis in item.penalty_axes)
+    evidence_support_counts = Counter(item.evidence_support_state for item in calibrations)
+    evidence_category_counts = Counter(
+        category for item in calibrations for category in item.evidence_categories
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -96,12 +375,21 @@ def build_sampling_calibration_report(
             "sampling_decision_counts": dict(sorted(decision_counts.items())),
             "preferred_axis_counts": dict(sorted(preferred_axis_counts.items())),
             "penalty_axis_counts": dict(sorted(penalty_axis_counts.items())),
+            "evidence_support_state_counts": dict(sorted(evidence_support_counts.items())),
+            "evidence_category_counts": dict(sorted(evidence_category_counts.items())),
+            "null_model_backed_count": evidence_support_counts.get("evidence_backed", 0),
+            "partial_evidence_count": evidence_support_counts.get("partial_evidence", 0),
+            "heuristic_only_count": evidence_support_counts.get("heuristic_only", 0),
             "crypto_legacy_excluded_count": penalty_axis_counts.get("asset_class:crypto_legacy", 0),
-            "final_recommendation": "sampling_calibration_scaffold_ready",
+            "final_recommendation": (
+                "sampling_calibration_evidence_ready"
+                if evidence_support_counts.get("evidence_backed", 0) > 0
+                else "sampling_calibration_scaffold_ready"
+            ),
             "operator_summary": (
                 "Sampling calibration is available as deterministic, read-only context. "
-                "Crypto legacy is excluded, while equity/fundamental/source/factor and "
-                "regional diversity axes are preferred."
+                "It now prefers source, cache, null-model, readiness, and regime evidence "
+                "loaded from local report artifacts without mutating candidates or campaigns."
             ),
         },
         "manifest": manifest,
@@ -113,6 +401,9 @@ def build_sampling_calibration_report(
                 "sampling_decision": item.sampling_decision,
                 "preferred_axes": list(item.preferred_axes),
                 "penalty_axes": list(item.penalty_axes),
+                "evidence_support_state": item.evidence_support_state,
+                "evidence_categories": list(item.evidence_categories),
+                "evidence_ref_count": item.evidence_ref_count,
                 "explanation": item.explanation,
             }
             for item in calibrations
@@ -133,12 +424,16 @@ def build_sampling_calibration_report(
             "campaign_mutation_forbidden": True,
             "paper_shadow_live_forbidden": True,
             "broker_risk_execution_forbidden": True,
+            "evidence_backed_context_only": True,
         },
     }
 
 
 def render_operator_summary(report: Mapping[str, Any]) -> str:
     summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    counts = summary.get("sampling_decision_counts") or {}
+    support_counts = summary.get("evidence_support_state_counts") or {}
+    rows = report.get("calibrations") if isinstance(report.get("calibrations"), list) else []
     return "\n".join(
         [
             "# QRE Sampling Calibration",
@@ -150,8 +445,24 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
             f"- sampling_calibration_ready: {summary.get('sampling_calibration_ready')}",
             f"- input_row_count: {summary.get('input_row_count')}",
             f"- calibration_count: {summary.get('calibration_count')}",
-            f"- crypto_legacy_excluded_count: {summary.get('crypto_legacy_excluded_count')}",
+            f"- null_model_backed_count: {summary.get('null_model_backed_count')}",
+            f"- partial_evidence_count: {summary.get('partial_evidence_count')}",
+            f"- heuristic_only_count: {summary.get('heuristic_only_count')}",
             f"- final_recommendation: {summary.get('final_recommendation')}",
+            "",
+            "## Decision Mix",
+            ", ".join(f"{key}={value}" for key, value in sorted(counts.items())),
+            "",
+            "## Evidence Support Mix",
+            ", ".join(f"{key}={value}" for key, value in sorted(support_counts.items())),
+            "",
+            "## Calibrations",
+            *[
+                f"- {str(row.get('subject_id') or '')}: "
+                f"{', '.join(str(axis) for axis in row.get('preferred_axes') or [])} "
+                f"({str(row.get('evidence_support_state') or '')})"
+                for row in rows
+            ],
             "",
         ]
     )

--- a/tests/unit/test_qre_sampling_calibration.py
+++ b/tests/unit/test_qre_sampling_calibration.py
@@ -12,9 +12,18 @@ def test_sampling_manifest_is_context_only():
     assert "prefer_sampling" in manifest["sampling_decisions"]
     assert "crypto_legacy" in manifest["excluded_asset_classes"]
     assert "target_equity_research" in manifest["preferred_research_scopes"]
+    assert manifest["evidence_categories"] == [
+        "source",
+        "data",
+        "readiness",
+        "diagnostic",
+        "null",
+        "regime",
+    ]
 
     authority = manifest["authority"]
     assert authority["sampling_calibration_is_context_only"] is True
+    assert authority["evidence_backed_context_only"] is True
     assert authority["not_candidate_promotion"] is True
     assert authority["not_campaign_mutation"] is True
     assert authority["not_strategy_registration"] is True
@@ -41,6 +50,51 @@ def test_crypto_legacy_is_excluded():
     assert result.sampling_decision == "exclude_sampling"
     assert result.sampling_score == -100
     assert "asset_class:crypto_legacy" in result.penalty_axes
+    assert result.evidence_support_state == "archive_only"
+
+
+def test_source_data_null_and_regime_evidence_raise_priority():
+    result = calibrate_sampling_context(
+        {
+            "subject_id": "candidate:evidence",
+            "asset_class": "fundamental_equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "ready",
+            "comparison_state": "candidate_above_baseline",
+            "title": "OpenFIGI source_manifest cache coverage null_model regime sequence tail entropy",
+            "evidence_presence": {
+                "source_quality_ready": True,
+                "cache_ready": True,
+                "readiness_ready": True,
+                "diagnostic_ready": True,
+                "null_model_ready": True,
+                "regime_ready": True,
+            },
+            "evidence_refs": [
+                "logs/qre_data_source_quality_readiness/latest.json",
+                "logs/qre_data_cache_manifest/latest.json",
+                "logs/qre_null_model_baseline/latest.json",
+                "logs/qre_state_transition_diagnostics/latest.json",
+                "logs/qre_tail_entropy_hardening/latest.json",
+            ],
+        }
+    )
+
+    assert result.evidence_support_state == "evidence_backed"
+    assert set(result.evidence_categories) == {
+        "data",
+        "diagnostic",
+        "null",
+        "readiness",
+        "regime",
+        "source",
+    }
+    assert result.evidence_ref_count == 5
+    assert "evidence:source_ready" in result.preferred_axes
+    assert "evidence:data_ready" in result.preferred_axes
+    assert "evidence:null_model_ready" in result.preferred_axes
+    assert "evidence:regime_ready" in result.preferred_axes
+    assert result.sampling_decision in {"prefer_sampling", "allow_sampling"}
 
 
 def test_excluded_research_scope_is_excluded():

--- a/tests/unit/test_qre_sampling_calibration_report.py
+++ b/tests/unit/test_qre_sampling_calibration_report.py
@@ -9,13 +9,193 @@ from research.qre_sampling_calibration_report import (
 )
 
 
-def test_sampling_calibration_report_is_ready_and_context_only():
-    report = build_sampling_calibration_report()
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(__import__("json").dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_evidence_artifacts(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {
+            "rows": [
+                {
+                    "instrument": "AAPL",
+                    "timeframe": "1d",
+                    "quality_status": "ready",
+                    "manifest_status": "ready",
+                    "identity_confidence": "high",
+                    "source": "yfinance",
+                    "blocking_reasons": [],
+                    "operator_explanation": "ready source quality evidence",
+                    "path": "data/cache/market/aapl.parquet",
+                },
+                {
+                    "instrument": "ASML",
+                    "timeframe": "1d",
+                    "quality_status": "blocked",
+                    "manifest_status": "blocked",
+                    "identity_confidence": "low",
+                    "source": "yfinance",
+                    "blocking_reasons": ["identity_ambiguous"],
+                    "operator_explanation": "blocked source quality evidence",
+                    "path": "data/cache/market/asml.parquet",
+                },
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {
+            "coverage": [
+                {
+                    "instrument": "AAPL",
+                    "timeframe": "1d",
+                    "ready": True,
+                    "row_count": 5,
+                    "file_count": 1,
+                    "source": "yfinance",
+                    "cache_kind": "market",
+                    "content_hash": "sha256:aapl",
+                    "status_counts": {"ready": 1},
+                },
+                {
+                    "instrument": "ASML",
+                    "timeframe": "1d",
+                    "ready": False,
+                    "row_count": 0,
+                    "file_count": 0,
+                    "source": "yfinance",
+                    "cache_kind": "market",
+                    "content_hash": "sha256:asml",
+                    "status_counts": {"blocked": 1},
+                },
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_null_model_baseline" / "latest.json",
+        {
+            "sample_comparisons": [
+                {
+                    "candidate_id": "sample:below",
+                    "baseline_type": "median_candidate",
+                    "candidate_metric": -0.01,
+                    "baseline_metric": 0.0,
+                    "delta_vs_baseline": -0.01,
+                    "comparison_state": "candidate_below_baseline",
+                    "explanation": "Deterministic metric-vs-baseline comparison; context only, not authority.",
+                },
+                {
+                    "candidate_id": "sample:above",
+                    "baseline_type": "median_candidate",
+                    "candidate_metric": 0.02,
+                    "baseline_metric": 0.0,
+                    "delta_vs_baseline": 0.02,
+                    "comparison_state": "candidate_above_baseline",
+                    "explanation": "Deterministic metric-vs-baseline comparison; context only, not authority.",
+                },
+            ],
+            "suite_comparisons": [
+                {
+                    "candidate_id": "sample:below",
+                    "family": "random_walk",
+                    "candidate_metric": -0.01,
+                    "baseline_metric": -0.005,
+                    "delta_vs_baseline": -0.005,
+                    "comparison_state": "candidate_below_baseline",
+                    "explanation": "Deterministic metric-vs-baseline comparison; context only, not authority.",
+                },
+                {
+                    "candidate_id": "sample:above",
+                    "family": "random_walk",
+                    "candidate_metric": 0.02,
+                    "baseline_metric": -0.03,
+                    "delta_vs_baseline": 0.05,
+                    "comparison_state": "candidate_above_baseline",
+                    "explanation": "Deterministic metric-vs-baseline comparison; context only, not authority.",
+                },
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_state_transition_diagnostics" / "latest.json",
+        {
+            "diagnostics": [
+                {
+                    "subject_id": "sample:progress",
+                    "prior_state": "candidate_discovered",
+                    "new_state": "screened",
+                    "transition_reason": "criteria_passed",
+                    "transition_state": "positive_progress_transition",
+                    "artifact_ref": "logs/qre_state_transition_diagnostics/latest.json",
+                },
+                {
+                    "subject_id": "sample:blocked",
+                    "prior_state": "screened",
+                    "new_state": "blocked",
+                    "transition_reason": "data_readiness_blocked",
+                    "blocker_class": "missing_required_field",
+                    "transition_state": "terminal_negative_transition",
+                    "artifact_ref": "logs/qre_state_transition_diagnostics/latest.json",
+                },
+            ],
+            "sequence_diagnostics": [
+                {
+                    "subject_id": "sample:progress",
+                    "sequence_state": "ready",
+                    "dwell_state": "validated",
+                    "dwell_steps": 1,
+                    "regime_duration_steps": 4,
+                    "sparse_data": False,
+                    "explanation": "sequence ready",
+                },
+                {
+                    "subject_id": "sample:blocked",
+                    "sequence_state": "blocked",
+                    "dwell_state": "fail_closed",
+                    "dwell_steps": 1,
+                    "regime_duration_steps": 3,
+                    "sparse_data": False,
+                    "explanation": "sequence blocked",
+                },
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_tail_entropy_hardening" / "latest.json",
+        {
+            "diagnostics": [
+                {
+                    "subject_id": "sample:balanced",
+                    "risk_state": "tail_entropy_clear",
+                    "density_state": "density_ready",
+                    "evidence_ref_count": 2,
+                    "null_challenge_count": 2,
+                    "explanation": "tail entropy clear",
+                },
+                {
+                    "subject_id": "sample:insufficient",
+                    "risk_state": "insufficient_return_data",
+                    "density_state": "missing_density",
+                    "evidence_ref_count": 0,
+                    "null_challenge_count": 1,
+                    "explanation": "insufficient evidence",
+                },
+            ]
+        },
+    )
+
+
+def test_sampling_calibration_report_is_ready_and_context_only(tmp_path: Path):
+    _seed_evidence_artifacts(tmp_path)
+
+    report = build_sampling_calibration_report(repo_root=tmp_path)
 
     assert report["schema_version"] == "1.0"
     assert report["report_kind"] == "qre_sampling_calibration_report"
     assert report["summary"]["sampling_calibration_ready"] is True
-    assert report["summary"]["final_recommendation"] == "sampling_calibration_scaffold_ready"
+    assert report["summary"]["final_recommendation"] == "sampling_calibration_evidence_ready"
 
     safety = report["safety_invariants"]
     assert safety["read_only"] is True
@@ -30,22 +210,26 @@ def test_sampling_calibration_report_is_ready_and_context_only():
     assert safety["campaign_mutation_forbidden"] is True
     assert safety["paper_shadow_live_forbidden"] is True
     assert safety["broker_risk_execution_forbidden"] is True
+    assert safety["evidence_backed_context_only"] is True
 
 
-def test_sampling_calibration_report_excludes_crypto_and_prefers_equity_axes():
-    report = build_sampling_calibration_report()
+def test_sampling_calibration_report_uses_evidence_artifacts(tmp_path: Path):
+    _seed_evidence_artifacts(tmp_path)
 
-    assert report["summary"]["input_row_count"] == 5
-    assert report["summary"]["calibration_count"] == 5
-    assert report["summary"]["crypto_legacy_excluded_count"] == 1
+    report = build_sampling_calibration_report(repo_root=tmp_path)
+
+    assert report["summary"]["input_row_count"] == 14
+    assert report["summary"]["calibration_count"] == 14
+    assert report["summary"]["null_model_backed_count"] >= 1
+    assert report["summary"]["evidence_support_state_counts"]["evidence_backed"] >= 1
+    assert report["summary"]["evidence_category_counts"]["null"] >= 1
+    assert report["summary"]["evidence_category_counts"]["regime"] >= 1
+    assert report["summary"]["evidence_category_counts"]["source"] >= 1
+    assert report["summary"]["evidence_category_counts"]["data"] >= 1
 
     decision_counts = report["summary"]["sampling_decision_counts"]
-    assert decision_counts["exclude_sampling"] >= 1
     assert decision_counts["prefer_sampling"] >= 1
-
-    preferred_axes = report["summary"]["preferred_axis_counts"]
-    assert preferred_axes["asset_class:fundamental_equity"] >= 1
-    assert preferred_axes["region:netherlands"] >= 1
+    assert "allow_sampling" in decision_counts or "deprioritize_sampling" in decision_counts
 
 
 def test_sampling_calibration_report_accepts_custom_rows():
@@ -56,26 +240,38 @@ def test_sampling_calibration_report_accepts_custom_rows():
                 "asset_class": "fundamental_equity",
                 "research_scope": "target_equity_research",
                 "readiness_state": "ready",
-                "title": "Europe factor source_manifest",
+                "comparison_state": "candidate_above_baseline",
+                "title": "Europe factor source_manifest null_model regime",
+                "evidence_presence": {
+                    "source_quality_ready": True,
+                    "null_model_ready": True,
+                    "regime_ready": True,
+                },
+                "evidence_refs": ["logs/custom/latest.json"],
             }
         ]
     )
 
     assert report["summary"]["input_row_count"] == 1
-    assert report["calibrations"][0]["sampling_decision"] == "prefer_sampling"
+    assert report["calibrations"][0]["sampling_decision"] in {"prefer_sampling", "allow_sampling"}
+    assert report["calibrations"][0]["evidence_support_state"] in {"partial_evidence", "evidence_backed"}
 
 
-def test_sampling_calibration_operator_summary_renders():
-    report = build_sampling_calibration_report()
+def test_sampling_calibration_operator_summary_renders(tmp_path: Path):
+    _seed_evidence_artifacts(tmp_path)
+
+    report = build_sampling_calibration_report(repo_root=tmp_path)
     text = render_operator_summary(report)
 
     assert "# QRE Sampling Calibration" in text
-    assert "crypto_legacy_excluded_count" in text
-    assert "sampling_calibration_scaffold_ready" in text
+    assert "null_model_backed_count" in text
+    assert "sampling_calibration_evidence_ready" in text
 
 
 def test_sampling_calibration_write_outputs_stays_in_allowlist(tmp_path: Path):
-    report = build_sampling_calibration_report()
+    _seed_evidence_artifacts(tmp_path)
+
+    report = build_sampling_calibration_report(repo_root=tmp_path)
     paths = write_outputs(report, repo_root=tmp_path)
 
     assert paths["latest"] == "logs/qre_sampling_calibration/latest.json"
@@ -88,7 +284,8 @@ def test_sampling_calibration_write_rejects_non_allowlisted_path(monkeypatch, tm
     from research import qre_sampling_calibration_report as report_module
 
     monkeypatch.setattr(report_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
-    report = build_sampling_calibration_report()
+    _seed_evidence_artifacts(tmp_path)
+    report = build_sampling_calibration_report(repo_root=tmp_path)
 
     with pytest.raises(ValueError):
         write_outputs(report, repo_root=tmp_path)


### PR DESCRIPTION
PR16: sampling calibration on real evidence\n\nScope:\n- research/qre_sampling_calibration.py\n- research/qre_sampling_calibration_report.py\n- tests/unit/test_qre_sampling_calibration.py\n- tests/unit/test_qre_sampling_calibration_report.py\n\nSummary:\n- sampling calibration now prefers local source/cache/null-model/readiness/regime evidence artifacts when present\n- report output remains deterministic and read-only\n- no queue, campaign, strategy, or frozen-contract mutation\n\nValidation:\n- python -m pytest tests/unit/test_qre_sampling_calibration.py tests/unit/test_qre_sampling_calibration_report.py -q\n- python -m pytest tests/unit/test_qre_routing_sampling_decision_quality.py -q\n- python scripts/governance_lint.py\n- python -m pytest tests/smoke -q\n- python -m pytest tests/architecture/test_domain_import_scanner.py -q\n- git diff --check\n- git diff -- research/research_latest.json research/strategy_matrix.csv\n