### PR TITLE
feat: evidence-back trusted loop review packet

### DIFF
--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -17,6 +17,14 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Final
 
+from reporting import qre_trusted_loop_readiness as trusted_readiness
+from research import qre_evidence_complete_basket_closure as basket_closure
+from research import qre_failure_action_from_basket as failure_action
+from research import qre_reason_records_v1 as reason_records
+from research import qre_research_memory_current_artifacts as research_memory
+from research import qre_routing_calibration_report as routing_calibration
+from research import qre_sampling_calibration_report as sampling_calibration
+
 
 REPORT_KIND: Final[str] = "qre_trusted_loop_review_packet"
 SCHEMA_VERSION: Final[str] = "1.0"
@@ -115,32 +123,159 @@ def _path_state(repo_root: Path, relative_path: str) -> dict[str, Any]:
     }
 
 
+def _truthy(summary: Mapping[str, Any], key: str) -> bool:
+    return bool(summary.get(key))
+
+
+def _trusted_loop_level(
+    *,
+    readiness_state: str,
+    readiness_summary: Mapping[str, Any],
+    reason_summary: Mapping[str, Any],
+    failure_summary: Mapping[str, Any],
+    basket_summary: Mapping[str, Any],
+    routing_summary: Mapping[str, Any],
+    sampling_summary: Mapping[str, Any],
+    memory_summary: Mapping[str, Any],
+) -> tuple[str, str, list[str], str]:
+    blockers: list[str] = []
+    if readiness_state != "operator_trusted":
+        blockers.append(f"readiness_state:{readiness_state}")
+    if int(reason_summary.get("record_count") or 0) == 0:
+        blockers.append("reason_records_missing")
+    if int(basket_summary.get("evidence_complete_count") or 0) == 0:
+        blockers.append("evidence_complete_basket_missing")
+    if int(failure_summary.get("actionable_count") or 0) == 0:
+        blockers.append("failure_actionable_context_missing")
+    if str(routing_summary.get("final_recommendation") or "") != "routing_calibration_evidence_ready":
+        blockers.append("routing_calibration_not_evidence_ready")
+    if str(sampling_summary.get("final_recommendation") or "") != "sampling_calibration_evidence_ready":
+        blockers.append("sampling_calibration_not_evidence_ready")
+    if str(memory_summary.get("summary", {}).get("final_recommendation") or "") != "research_memory_current_artifacts_ready":
+        blockers.append("research_memory_not_ready")
+    if not _truthy(readiness_summary, "operator_report_available"):
+        blockers.append("operator_report_missing")
+    if str(readiness_summary.get("contradiction_visibility", {}).get("status") or "") != "visible":
+        blockers.append("contradiction_visibility_incomplete")
+    if str(readiness_summary.get("source_lineage", {}).get("status") or "") != "complete":
+        blockers.append("source_lineage_incomplete")
+    if str(readiness_summary.get("repeatability_status") or "") != "operator_approved_repeatability_evidence_present":
+        blockers.append("repeatability_or_operator_approval_missing")
+
+    if blockers:
+        if readiness_state == "operator_trusted_candidate":
+            level = "2"
+            verdict = "evidence_backed_operator_review_required"
+            exact_next_action = "refresh_missing_trusted_loop_evidence"
+        elif readiness_state == "working_capability":
+            level = "1"
+            verdict = "read_only_context_fail_closed"
+            exact_next_action = "restore_trusted_loop_readiness_evidence"
+        elif readiness_state == "scaffold":
+            level = "1"
+            verdict = "scaffold_fail_closed"
+            exact_next_action = "materialize_trusted_loop_evidence_chain"
+        else:
+            level = "2"
+            verdict = "operator_trust_review_required"
+            exact_next_action = "refresh_trusted_loop_evidence"
+        return level, verdict, blockers, exact_next_action
+
+    return "3", "operator_trusted", [], "maintain_operator_trusted_read_only_mode"
+
+
 def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    readiness_packet = trusted_readiness.collect_snapshot()
+    reason_snapshot = reason_records.build_reason_records_snapshot(repo_root=repo_root)
+    failure_packet = failure_action.build_failure_action_from_basket(repo_root=repo_root)
+    closure_packet = basket_closure.build_evidence_complete_basket_closure(repo_root=repo_root)
+    routing_packet = routing_calibration.build_routing_calibration_report(repo_root=repo_root)
+    sampling_packet = sampling_calibration.build_sampling_calibration_report(repo_root=repo_root)
+    memory_packet = research_memory.build_research_memory_current_artifacts(repo_root=repo_root)
+
     protected_artifacts = [
         _path_state(repo_root, "research/research_latest.json"),
         _path_state(repo_root, "research/strategy_matrix.csv"),
     ]
 
     implemented_count = sum(1 for row in CAPABILITY_ROWS if str(row.get("status", "")).startswith("implemented"))
+    readiness_summary = readiness_packet if isinstance(readiness_packet, Mapping) else {}
+    reason_summary = reason_snapshot.get("meta") if isinstance(reason_snapshot.get("meta"), Mapping) else {}
+    failure_summary = failure_packet.get("summary") if isinstance(failure_packet.get("summary"), Mapping) else {}
+    basket_summary = closure_packet.get("summary") if isinstance(closure_packet.get("summary"), Mapping) else {}
+    routing_summary = routing_packet.get("summary") if isinstance(routing_packet.get("summary"), Mapping) else {}
+    sampling_summary = sampling_packet.get("summary") if isinstance(sampling_packet.get("summary"), Mapping) else {}
+    memory_summary = memory_packet if isinstance(memory_packet, Mapping) else {}
+    trust_level, trust_verdict, trust_blockers, exact_next_action = _trusted_loop_level(
+        readiness_state=str(readiness_summary.get("readiness_state") or "scaffold"),
+        readiness_summary=readiness_summary,
+        reason_summary=reason_summary,
+        failure_summary=failure_summary,
+        basket_summary=basket_summary,
+        routing_summary=routing_summary,
+        sampling_summary=sampling_summary,
+        memory_summary=memory_summary,
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
         "summary": {
-            "trusted_loop_review_ready": True,
+            "trusted_loop_review_ready": trust_verdict == "operator_trusted",
+            "trust_level": trust_level,
+            "trust_verdict": trust_verdict,
+            "trust_blocker_count": len(trust_blockers),
+            "trust_blockers": trust_blockers,
+            "exact_next_action": exact_next_action,
+            "readiness_state": str(readiness_summary.get("readiness_state") or "scaffold"),
+            "reason_record_count": int(reason_summary.get("record_count") or 0),
+            "failure_actionable_count": int(failure_summary.get("actionable_count") or 0),
+            "evidence_complete_basket_count": int(basket_summary.get("evidence_complete_count") or 0),
+            "routing_evidence_ready": str(routing_summary.get("final_recommendation") or "")
+            == "routing_calibration_evidence_ready",
+            "sampling_evidence_ready": str(sampling_summary.get("final_recommendation") or "")
+            == "sampling_calibration_evidence_ready",
+            "research_memory_ready": str(
+                (memory_summary.get("summary") or {}).get("final_recommendation") or ""
+            )
+            == "research_memory_current_artifacts_ready",
+            "contradiction_visibility": (
+                readiness_summary.get("contradiction_visibility")
+                if isinstance(readiness_summary.get("contradiction_visibility"), Mapping)
+                else {}
+            ),
+            "source_lineage": (
+                readiness_summary.get("source_lineage")
+                if isinstance(readiness_summary.get("source_lineage"), Mapping)
+                else {}
+            ),
+            "repeatability_status": str(readiness_summary.get("repeatability_status") or "unknown"),
             "capability_count": len(CAPABILITY_ROWS),
             "implemented_capability_count": implemented_count,
             "report_surface_count": len(REPORT_SURFACES),
-            "final_recommendation": "trusted_loop_ready_for_operator_review_not_execution",
+            "final_recommendation": (
+                "trusted_loop_operator_trusted"
+                if trust_verdict == "operator_trusted"
+                else "trusted_loop_operator_review_required"
+            ),
             "operator_summary": (
-                "Roadmap A-E trusted-loop scaffolds and report surfaces are present as "
-                "deterministic, read-only/context-only diagnostics. The system is ready "
-                "for operator review of research-loop evidence, not for paper/shadow/live "
-                "or broker/risk/execution activation."
+                "Roadmap A-F trusted-loop scaffolds and report surfaces are present as "
+                "deterministic, read-only/context-only diagnostics. The packet now requires "
+                "durable reason records, closure evidence, calibrated routing/sampling, and "
+                "trusted-loop readiness before it will report operator trust."
             ),
         },
         "capabilities": list(CAPABILITY_ROWS),
         "report_surfaces": list(REPORT_SURFACES),
+        "evidence_inputs": {
+            "trusted_loop_readiness": readiness_packet,
+            "reason_records": reason_snapshot,
+            "failure_action": failure_packet,
+            "basket_closure": closure_packet,
+            "routing_calibration": routing_packet,
+            "sampling_calibration": sampling_packet,
+            "research_memory": memory_packet,
+        },
         "protected_artifacts": protected_artifacts,
         "current_scope_policy": {
             "crypto_legacy": "excluded_from_current_research_scope_and_archive_only",
@@ -209,15 +344,30 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
 
 def render_operator_summary(packet: Mapping[str, Any]) -> str:
     summary = packet.get("summary") if isinstance(packet.get("summary"), Mapping) else {}
+    trust_blockers = summary.get("trust_blockers") if isinstance(summary.get("trust_blockers"), list) else []
     return "\n".join(
         [
             "# QRE Trusted Loop Review Packet",
             "",
             f"- {summary.get('operator_summary') or ''}",
             "",
+            "## Trust Verdict",
+            "",
+            f"- trust_level: {summary.get('trust_level')}",
+            f"- trust_verdict: {summary.get('trust_verdict')}",
+            f"- exact_next_action: {summary.get('exact_next_action')}",
+            f"- trusted_loop_review_ready: {summary.get('trusted_loop_review_ready')}",
+            f"- readiness_state: {summary.get('readiness_state')}",
+            f"- reason_record_count: {summary.get('reason_record_count')}",
+            f"- failure_actionable_count: {summary.get('failure_actionable_count')}",
+            f"- evidence_complete_basket_count: {summary.get('evidence_complete_basket_count')}",
+            f"- routing_evidence_ready: {summary.get('routing_evidence_ready')}",
+            f"- sampling_evidence_ready: {summary.get('sampling_evidence_ready')}",
+            f"- research_memory_ready: {summary.get('research_memory_ready')}",
+            f"- trust_blockers: {', '.join(str(item) for item in trust_blockers) or 'none'}",
+            "",
             "## Current Status",
             "",
-            f"- trusted_loop_review_ready: {summary.get('trusted_loop_review_ready')}",
             f"- capability_count: {summary.get('capability_count')}",
             f"- implemented_capability_count: {summary.get('implemented_capability_count')}",
             f"- report_surface_count: {summary.get('report_surface_count')}",

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -1,95 +1,186 @@
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 import pytest
 
-from research.qre_trusted_loop_review_packet import (
-    build_trusted_loop_review_packet,
-    render_operator_summary,
-    write_outputs,
-)
+from research import qre_trusted_loop_review_packet as packet_module
 
 
-def test_trusted_loop_review_packet_is_ready_and_context_only():
-    packet = build_trusted_loop_review_packet()
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
-    assert packet["schema_version"] == "1.0"
-    assert packet["report_kind"] == "qre_trusted_loop_review_packet"
+
+def _seed_repo_files(tmp_path: Path) -> None:
+    _write_json(tmp_path / "research" / "research_latest.json", {"report_kind": "seed"})
+    (tmp_path / "research" / "strategy_matrix.csv").write_text("seed\n", encoding="utf-8")
+
+
+def _ready_snapshots() -> dict[str, dict]:
+    return {
+        "readiness": {
+            "readiness_state": "operator_trusted",
+            "operator_report_available": True,
+            "contradiction_visibility": {"status": "visible"},
+            "source_lineage": {"status": "complete"},
+            "repeatability_status": "operator_approved_repeatability_evidence_present",
+            "blockers": [],
+            "final_recommendation": "trusted_loop_ready_for_operator_use",
+        },
+        "reason_records": {
+            "meta": {"record_count": 3},
+        },
+        "failure_action": {
+            "summary": {"actionable_count": 3, "non_actionable_count": 0},
+        },
+        "basket_closure": {
+            "summary": {"evidence_complete_count": 1},
+        },
+        "routing": {
+            "summary": {"final_recommendation": "routing_calibration_evidence_ready"},
+        },
+        "sampling": {
+            "summary": {"final_recommendation": "sampling_calibration_evidence_ready"},
+        },
+        "research_memory": {
+            "summary": {"final_recommendation": "research_memory_current_artifacts_ready"},
+        },
+    }
+
+
+def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain_is_complete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_repo_files(tmp_path)
+    snapshots = _ready_snapshots()
+    monkeypatch.setattr(packet_module.trusted_readiness, "collect_snapshot", lambda **_: snapshots["readiness"])
+    monkeypatch.setattr(
+        packet_module.reason_records,
+        "build_reason_records_snapshot",
+        lambda **_: snapshots["reason_records"],
+    )
+    monkeypatch.setattr(
+        packet_module.failure_action,
+        "build_failure_action_from_basket",
+        lambda **_: snapshots["failure_action"],
+    )
+    monkeypatch.setattr(
+        packet_module.basket_closure,
+        "build_evidence_complete_basket_closure",
+        lambda **_: snapshots["basket_closure"],
+    )
+    monkeypatch.setattr(
+        packet_module.routing_calibration,
+        "build_routing_calibration_report",
+        lambda **_: snapshots["routing"],
+    )
+    monkeypatch.setattr(
+        packet_module.sampling_calibration,
+        "build_sampling_calibration_report",
+        lambda **_: snapshots["sampling"],
+    )
+    monkeypatch.setattr(
+        packet_module.research_memory,
+        "build_research_memory_current_artifacts",
+        lambda **_: snapshots["research_memory"],
+    )
+
+    packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
+
     assert packet["summary"]["trusted_loop_review_ready"] is True
-    assert packet["summary"]["final_recommendation"] == "trusted_loop_ready_for_operator_review_not_execution"
-
-    boundaries = packet["authority_boundaries"]
-    assert boundaries["review_packet_is_context_only"] is True
-    assert boundaries["not_alpha_authority"] is True
-    assert boundaries["not_queue_mutation"] is True
-    assert boundaries["not_candidate_promotion"] is True
-    assert boundaries["not_campaign_mutation"] is True
-    assert boundaries["not_strategy_registration"] is True
-    assert boundaries["not_preset_mutation"] is True
-    assert boundaries["not_trade_signal_generation"] is True
-    assert boundaries["not_provider_activation"] is True
-    assert boundaries["not_data_fetching"] is True
-    assert boundaries["not_paper_shadow_live"] is True
-    assert boundaries["not_broker_execution"] is True
-    assert boundaries["not_risk_authority"] is True
-    assert boundaries["does_not_mutate_frozen_contracts"] is True
-    assert boundaries["does_not_mutate_research_latest"] is True
-    assert boundaries["does_not_mutate_strategy_matrix"] is True
+    assert packet["summary"]["trust_level"] == "3"
+    assert packet["summary"]["trust_verdict"] == "operator_trusted"
+    assert packet["summary"]["exact_next_action"] == "maintain_operator_trusted_read_only_mode"
+    assert packet["summary"]["final_recommendation"] == "trusted_loop_operator_trusted"
+    assert packet["summary"]["reason_record_count"] == 3
+    assert packet["summary"]["evidence_complete_basket_count"] == 1
+    assert packet["summary"]["routing_evidence_ready"] is True
+    assert packet["summary"]["sampling_evidence_ready"] is True
+    assert packet["summary"]["research_memory_ready"] is True
+    assert packet["summary"]["trust_blocker_count"] == 0
+    assert packet["protected_artifacts"][0]["exists"] is True
+    assert packet["protected_artifacts"][1]["exists"] is True
+    assert packet["evidence_inputs"]["trusted_loop_readiness"]["readiness_state"] == "operator_trusted"
 
 
-def test_trusted_loop_review_packet_lists_all_capability_stages():
-    packet = build_trusted_loop_review_packet()
+def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomplete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_repo_files(tmp_path)
+    monkeypatch.setattr(
+        packet_module.trusted_readiness,
+        "collect_snapshot",
+        lambda **_: {
+            "readiness_state": "working_capability",
+            "operator_report_available": True,
+            "contradiction_visibility": {"status": "visible"},
+            "source_lineage": {"status": "complete"},
+            "repeatability_status": "no_repeatability_evidence",
+            "blockers": ["validation_results_or_evidence_updates_absent"],
+            "final_recommendation": "operator_review_required_before_trusted_loop_use",
+        },
+    )
+    monkeypatch.setattr(packet_module.reason_records, "build_reason_records_snapshot", lambda **_: {"meta": {"record_count": 0}})
+    monkeypatch.setattr(packet_module.failure_action, "build_failure_action_from_basket", lambda **_: {"summary": {"actionable_count": 0, "non_actionable_count": 1}})
+    monkeypatch.setattr(packet_module.basket_closure, "build_evidence_complete_basket_closure", lambda **_: {"summary": {"evidence_complete_count": 0}})
+    monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: {"summary": {"final_recommendation": "routing_calibration_scaffold_ready"}})
+    monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: {"summary": {"final_recommendation": "sampling_calibration_scaffold_ready"}})
+    monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: {"summary": {"final_recommendation": "research_memory_current_artifacts_partial"}})
 
-    capability_ids = {row["capability_id"] for row in packet["capabilities"]}
-    assert capability_ids == {"A", "B", "C", "D", "E", "F"}
-    assert packet["summary"]["capability_count"] == 6
-    assert packet["summary"]["implemented_capability_count"] == 6
+    packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
 
-
-def test_trusted_loop_review_packet_lists_expected_report_surfaces():
-    packet = build_trusted_loop_review_packet()
-
-    report_kinds = {row["report_kind"] for row in packet["report_surfaces"]}
-
-    assert "qre_null_model_baseline_report" in report_kinds
-    assert "qre_state_transition_diagnostics_report" in report_kinds
-    assert "qre_tail_entropy_hardening_report" in report_kinds
-    assert "qre_sampling_calibration_report" in report_kinds
-    assert "qre_routing_calibration_report" in report_kinds
-    assert "qre_trusted_loop_review_packet" in report_kinds
-
-
-def test_trusted_loop_review_packet_scope_policy_excludes_crypto_and_prefers_equity():
-    packet = build_trusted_loop_review_packet()
-    policy = packet["current_scope_policy"]
-
-    assert policy["crypto_legacy"] == "excluded_from_current_research_scope_and_archive_only"
-    assert "fundamental_equity" in policy["preferred_sampling_axes"]
-    assert "netherlands" in policy["preferred_sampling_axes"]
-    assert "united_states" in policy["preferred_sampling_axes"]
-    assert "asia" in policy["preferred_sampling_axes"]
-    assert "excluded_scope_archive" in policy["routing_context_targets"]
-
-
-def test_trusted_loop_review_packet_tracks_protected_artifacts():
-    packet = build_trusted_loop_review_packet()
-
-    paths = {row["path"] for row in packet["protected_artifacts"]}
-    assert "research/research_latest.json" in paths
-    assert "research/strategy_matrix.csv" in paths
+    assert packet["summary"]["trusted_loop_review_ready"] is False
+    assert packet["summary"]["trust_level"] == "1"
+    assert packet["summary"]["trust_verdict"] == "read_only_context_fail_closed"
+    assert packet["summary"]["exact_next_action"] == "restore_trusted_loop_readiness_evidence"
+    assert "readiness_state:working_capability" in packet["summary"]["trust_blockers"]
+    assert "reason_records_missing" in packet["summary"]["trust_blockers"]
+    assert packet["summary"]["final_recommendation"] == "trusted_loop_operator_review_required"
 
 
-def test_trusted_loop_review_packet_operator_summary_renders():
-    packet = build_trusted_loop_review_packet()
-    text = render_operator_summary(packet)
+def test_trusted_loop_review_packet_operator_summary_renders(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_repo_files(tmp_path)
+    snapshots = _ready_snapshots()
+    monkeypatch.setattr(packet_module.trusted_readiness, "collect_snapshot", lambda **_: snapshots["readiness"])
+    monkeypatch.setattr(packet_module.reason_records, "build_reason_records_snapshot", lambda **_: snapshots["reason_records"])
+    monkeypatch.setattr(packet_module.failure_action, "build_failure_action_from_basket", lambda **_: snapshots["failure_action"])
+    monkeypatch.setattr(packet_module.basket_closure, "build_evidence_complete_basket_closure", lambda **_: snapshots["basket_closure"])
+    monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: snapshots["routing"])
+    monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: snapshots["sampling"])
+    monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: snapshots["research_memory"])
+
+    packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
+    text = packet_module.render_operator_summary(packet)
 
     assert "# QRE Trusted Loop Review Packet" in text
-    assert "trusted_loop_ready_for_operator_review_not_execution" in text
+    assert "trust_level: 3" in text
+    assert "maintain_operator_trusted_read_only_mode" in text
     assert "Authority Boundary" in text
 
 
-def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(tmp_path: Path):
-    packet = build_trusted_loop_review_packet(repo_root=tmp_path)
-    paths = write_outputs(packet, repo_root=tmp_path)
+def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_repo_files(tmp_path)
+    snapshots = _ready_snapshots()
+    monkeypatch.setattr(packet_module.trusted_readiness, "collect_snapshot", lambda **_: snapshots["readiness"])
+    monkeypatch.setattr(packet_module.reason_records, "build_reason_records_snapshot", lambda **_: snapshots["reason_records"])
+    monkeypatch.setattr(packet_module.failure_action, "build_failure_action_from_basket", lambda **_: snapshots["failure_action"])
+    monkeypatch.setattr(packet_module.basket_closure, "build_evidence_complete_basket_closure", lambda **_: snapshots["basket_closure"])
+    monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: snapshots["routing"])
+    monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: snapshots["sampling"])
+    monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: snapshots["research_memory"])
+
+    packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
+    paths = packet_module.write_outputs(packet, repo_root=tmp_path)
 
     assert paths["latest"] == "logs/qre_trusted_loop_review/latest.json"
     assert paths["operator_summary"] == "logs/qre_trusted_loop_review/operator_summary.md"
@@ -97,11 +188,12 @@ def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(tmp_path: P
     assert (tmp_path / paths["operator_summary"]).exists()
 
 
-def test_trusted_loop_review_packet_write_rejects_non_allowlisted_path(monkeypatch, tmp_path: Path):
-    from research import qre_trusted_loop_review_packet as packet_module
-
+def test_trusted_loop_review_packet_write_rejects_non_allowlisted_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.setattr(packet_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
-    packet = build_trusted_loop_review_packet(repo_root=tmp_path)
+    packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
 
     with pytest.raises(ValueError):
-        write_outputs(packet, repo_root=tmp_path)
+        packet_module.write_outputs(packet, repo_root=tmp_path)


### PR DESCRIPTION
PR18 of the QRE Audit Gap Closure Roadmap.

Scope:
- convert the trusted-loop review packet into an evidence-backed verdict over existing read-only QRE reports
- require reason records, basket closure, routing/sampling calibration, research memory, and trusted-loop readiness evidence
- fail closed with an exact next action when the evidence chain is incomplete

Validation:
- python -m pytest tests/unit/test_qre_trusted_loop_review_packet.py tests/unit/test_qre_trusted_loop_readiness.py tests/unit/test_qre_reason_records_v1.py tests/unit/test_qre_failure_action_from_basket.py tests/unit/test_qre_evidence_complete_basket_closure.py tests/unit/test_qre_routing_calibration_report.py tests/unit/test_qre_sampling_calibration_report.py -q
- python -m pytest tests/unit/test_qre_research_memory_current_artifacts.py -q
- python scripts/governance_lint.py
- python -m pytest tests/smoke -q
- python -m pytest tests/architecture/test_domain_import_scanner.py -q
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv
