### PR TITLE
feat: materialize basket evidence recovery queue

### DIFF
--- a/research/qre_basket_evidence_density_materialization.py
+++ b/research/qre_basket_evidence_density_materialization.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_grid_candidate_campaign_lineage_bridge as lineage_bridge
+from research import qre_real_basket_diagnosis as diagnosis
+
+
+REPORT_KIND: Final[str] = "qre_basket_evidence_density_materialization"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_basket_evidence_density_materialization")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_basket_evidence_density_materialization/"
+SCREENING_EVIDENCE_PATH: Final[Path] = Path("research/screening_evidence_latest.v1.json")
+
+_LINKED_SCREENING_STATUSES: Final[frozenset[str]] = frozenset(
+    {
+        "linked_exact_ids",
+        "linked_executable_hypothesis_bridge",
+        "linked_catalog_active_discovery",
+    }
+)
+_KNOWN_OOS_STATUSES: Final[frozenset[str]] = frozenset(
+    {
+        "sufficient_oos_evidence",
+        "insufficient_oos_evidence",
+        "no_oos_evidence",
+        "no_oos_trades",
+    }
+)
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _safe_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _bounded_ref(value: str, *, max_len: int = 180) -> str:
+    text = value.strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _screening_rows_by_symbol(payload: Mapping[str, Any] | None) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(payload, Mapping):
+        return {}
+    rows = payload.get("candidates")
+    if not isinstance(rows, list):
+        return {}
+    by_symbol: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        symbol = str(row.get("asset") or "").strip()
+        linkage_status = str(row.get("qre_validation_linkage_status") or "")
+        if not symbol or linkage_status not in _LINKED_SCREENING_STATUSES:
+            continue
+        by_symbol.setdefault(symbol, []).append(row)
+    return by_symbol
+
+
+def _screening_ref(row: Mapping[str, Any]) -> str:
+    candidate_id = str(row.get("candidate_id") or "").strip()
+    asset = str(row.get("asset") or "").strip()
+    row_id = candidate_id or asset or "unknown"
+    return f"{SCREENING_EVIDENCE_PATH.as_posix()}#{_bounded_ref(row_id)}"
+
+
+def _oos_status(screening_rows: Sequence[Mapping[str, Any]]) -> tuple[str, list[str]]:
+    statuses: list[str] = []
+    refs: list[str] = []
+    for row in screening_rows:
+        validation_evidence = row.get("validation_evidence")
+        status = None
+        if isinstance(validation_evidence, Mapping):
+            status = validation_evidence.get("status")
+        normalized = str(status or "unknown").strip().lower()
+        if normalized not in statuses:
+            statuses.append(normalized)
+        refs.append(_screening_ref(row))
+    if not statuses:
+        return ("oos_evidence_missing", refs)
+    if any(status in _KNOWN_OOS_STATUSES for status in statuses):
+        if any(status == "sufficient_oos_evidence" for status in statuses):
+            return ("sufficient_oos_evidence", refs)
+        if any(status == "insufficient_oos_evidence" for status in statuses):
+            return ("insufficient_oos_evidence", refs)
+        if any(status in {"no_oos_evidence", "no_oos_trades"} for status in statuses):
+            return ("no_oos_evidence", refs)
+    if all(status in {"unknown", "none", ""} for status in statuses):
+        return ("oos_evidence_unknown", refs)
+    return ("oos_evidence_unknown", refs)
+
+
+def _density_row(
+    *,
+    diagnosis_row: Mapping[str, Any],
+    bridge_row: Mapping[str, Any],
+    screening_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    evidence = diagnosis_row.get("current_evidence")
+    if not isinstance(evidence, Mapping):
+        evidence = {}
+    source_quality_rows = int(evidence.get("source_quality_rows") or 0)
+    cache_coverage_rows = int(evidence.get("cache_coverage_rows") or 0)
+    candidate_rows = int(evidence.get("candidate_rows") or 0)
+    campaign_rows = int(evidence.get("campaign_rows") or 0)
+    source_quality_refs = (
+        ["logs/qre_data_source_quality_readiness/latest.json"]
+        if source_quality_rows > 0
+        else []
+    )
+    cache_coverage_refs = (
+        ["logs/qre_data_cache_manifest/latest.json"] if cache_coverage_rows > 0 else []
+    )
+    screening_refs = [_screening_ref(row) for row in screening_rows]
+    oos_status, oos_refs = _oos_status(screening_rows)
+    candidate_lineage_status = str(bridge_row.get("candidate_lineage_status") or "missing")
+    campaign_lineage_status = (
+        "visible" if candidate_lineage_status == "visible" and campaign_rows > 0 else "missing"
+    )
+    candidate_lineage_refs = (
+        [
+            f"logs/qre_discovery_basket_grid_evidence_materialization/latest.json#"
+            f"{_bounded_ref(str(diagnosis_row.get('symbol') or ''))}|"
+            f"{_bounded_ref(str(diagnosis_row.get('preset_id') or ''))}"
+        ]
+        if candidate_rows > 0 or candidate_lineage_status != "missing"
+        else []
+    )
+    campaign_lineage_refs = (
+        [
+            f"logs/qre_grid_candidate_campaign_lineage_bridge/latest.json#"
+            f"{_bounded_ref(str(diagnosis_row.get('symbol') or ''))}|"
+            f"{_bounded_ref(str(diagnosis_row.get('preset_id') or ''))}"
+        ]
+        if campaign_rows > 0
+        else []
+    )
+    exact_blockers = list(diagnosis_row.get("missing_evidence_taxonomy") or [])
+    return {
+        "candidate_id": diagnosis_row.get("candidate_id"),
+        "symbol": diagnosis_row.get("symbol"),
+        "preset_id": diagnosis_row.get("preset_id"),
+        "hypothesis_id": diagnosis_row.get("hypothesis_id"),
+        "behavior_family": diagnosis_row.get("behavior_family"),
+        "region": diagnosis_row.get("region"),
+        "asset_class": diagnosis_row.get("asset_class"),
+        "timeframes": list(diagnosis_row.get("timeframes") or []),
+        "source_identity_status": diagnosis_row.get("source_identity_status"),
+        "source_identity_blocker": diagnosis_row.get("reason_code")
+        if str(diagnosis_row.get("reason_code") or "").startswith("source_identity")
+        else "",
+        "source_quality_rows": source_quality_rows,
+        "cache_coverage_rows": cache_coverage_rows,
+        "screening_evidence_rows": len(screening_rows),
+        "validation_evidence_statuses": [
+            str(
+                row.get("validation_evidence").get("status")  # type: ignore[union-attr]
+            )
+            if isinstance(row.get("validation_evidence"), Mapping)
+            else "unknown"
+            for row in screening_rows
+        ],
+        "oos_evidence_status": oos_status,
+        "campaign_lineage_rows": campaign_rows,
+        "candidate_lineage_rows": candidate_rows,
+        "campaign_lineage_status": campaign_lineage_status,
+        "candidate_lineage_status": candidate_lineage_status,
+        "source_quality_refs": source_quality_refs,
+        "cache_coverage_refs": cache_coverage_refs,
+        "screening_evidence_refs": screening_refs,
+        "oos_evidence_refs": oos_refs,
+        "candidate_lineage_refs": candidate_lineage_refs,
+        "campaign_lineage_refs": campaign_lineage_refs,
+        "expected_screening_evidence_ref": f"research/screening_evidence_latest.v1.json#{diagnosis_row.get('symbol')}",
+        "expected_oos_evidence_ref": f"research/screening_evidence_latest.v1.json#{diagnosis_row.get('symbol')}",
+        "expected_candidate_lineage_ref": f"logs/qre_discovery_basket_grid_evidence_materialization/latest.json#{diagnosis_row.get('symbol')}",
+        "expected_campaign_artifact_ref": f"logs/qre_grid_candidate_campaign_lineage_bridge/latest.json#{diagnosis_row.get('symbol')}",
+        "exact_blockers": exact_blockers,
+        "exact_next_action": bridge_row.get("exact_next_action")
+        or diagnosis_row.get("follow_up")
+        or "keep_fail_closed",
+    }
+
+
+def build_basket_evidence_density_materialization(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    diagnosis_report = diagnosis.build_real_basket_diagnosis(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    screening_payload = _read_json(repo_root / SCREENING_EVIDENCE_PATH)
+    screening_by_symbol = _screening_rows_by_symbol(screening_payload)
+    bridge_report = lineage_bridge.build_grid_candidate_campaign_lineage_bridge(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+
+    diagnosis_rows = diagnosis_report.get("rows")
+    if not isinstance(diagnosis_rows, list):
+        diagnosis_rows = []
+    bridge_rows = bridge_report.get("rows")
+    if not isinstance(bridge_rows, list):
+        bridge_rows = []
+    bridge_by_key = {
+        (str(row.get("asset") or ""), str(row.get("preset") or "")): row
+        for row in bridge_rows
+        if isinstance(row, Mapping)
+    }
+
+    rows: list[dict[str, Any]] = []
+    for row in diagnosis_rows:
+        if not isinstance(row, Mapping):
+            continue
+        symbol = str(row.get("symbol") or "")
+        preset_id = str(row.get("preset_id") or "")
+        bridge_row = bridge_by_key.get((symbol, preset_id), {})
+        rows.append(
+            _density_row(
+                diagnosis_row=row,
+                bridge_row=bridge_row,
+                screening_rows=screening_by_symbol.get(symbol, []),
+            )
+        )
+
+    rows.sort(key=lambda row: (str(row["symbol"]), str(row["preset_id"])))
+    screening_present = sum(1 for row in rows if int(row["screening_evidence_rows"]) > 0)
+    oos_known = sum(
+        1
+        for row in rows
+        if str(row["oos_evidence_status"]) in _KNOWN_OOS_STATUSES
+    )
+    candidate_lineage_visible = sum(
+        1
+        for row in rows
+        if int(row["candidate_lineage_rows"]) > 0
+        or str(row["candidate_lineage_status"]) != "missing"
+    )
+    campaign_lineage_visible = sum(
+        1 for row in rows if int(row["campaign_lineage_rows"]) > 0
+    )
+    identity_blocked = sum(
+        1
+        for row in rows
+        if str(row.get("source_identity_status") or "") == "candidate_alias_only"
+        or str(row.get("source_identity_blocker") or "").startswith("source_identity")
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "basket_count": len(rows),
+            "screening_evidence_present_count": screening_present,
+            "oos_evidence_known_count": oos_known,
+            "candidate_lineage_visible_count": candidate_lineage_visible,
+            "campaign_lineage_visible_count": campaign_lineage_visible,
+            "source_identity_blocked_count": identity_blocked,
+            "final_recommendation": (
+                "basket_evidence_density_materialized_read_only"
+                if rows
+                else "basket_evidence_density_missing"
+            ),
+            "operator_summary": (
+                "Read-only basket evidence density links the current bounded basket to local "
+                "screening, OOS, source/cache, and lineage artifacts while preserving explicit "
+                "gaps and identity blockers."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_campaigns": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["basket inventory", str(summary.get("basket_count") or 0)],
+            ["screening present", str(summary.get("screening_evidence_present_count") or 0)],
+            ["OOS known", str(summary.get("oos_evidence_known_count") or 0)],
+            ["candidate lineage visible", str(summary.get("candidate_lineage_visible_count") or 0)],
+            ["campaign lineage visible", str(summary.get("campaign_lineage_visible_count") or 0)],
+            ["identity blocked", str(summary.get("source_identity_blocked_count") or 0)],
+        ],
+    )
+    basket_table = _table(
+        [
+            "Symbol",
+            "Preset",
+            "Screening",
+            "OOS",
+            "Candidate lineage",
+            "Campaign lineage",
+            "Identity",
+            "Next action",
+        ],
+        [
+            [
+                str(row.get("symbol") or ""),
+                str(row.get("preset_id") or ""),
+                str(row.get("screening_evidence_rows") or 0),
+                str(row.get("oos_evidence_status") or ""),
+                str(row.get("candidate_lineage_status") or ""),
+                str(row.get("campaign_lineage_status") or ""),
+                str(row.get("source_identity_status") or ""),
+                str(row.get("exact_next_action") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Basket Evidence Density Materialization",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Evidence density counts",
+            count_table,
+            "",
+            "## 3. Basket evidence density",
+            basket_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            "qre_basket_evidence_density_materialization: refusing write outside allowlist: "
+            f"{path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_basket_evidence_density_materialization",
+        description="Build read-only basket evidence density materialization.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_basket_evidence_density_materialization(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_basket_evidence_recovery_plan.py
+++ b/research/qre_basket_evidence_recovery_plan.py
@@ -1,0 +1,626 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_basket_evidence_density_materialization as density
+from research import qre_discovery_source_identity_diagnostics as identity_diag
+from research import qre_evidence_complete_basket_closure as closure
+from research import qre_real_basket_evidence_coverage as coverage
+
+
+REPORT_KIND: Final[str] = "qre_basket_evidence_recovery_plan"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_basket_evidence_recovery_plan")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_basket_evidence_recovery_plan/"
+
+_BLOCKER_PRIORITY: Final[dict[str, int]] = {
+    "source_identity_blocked": 0,
+    "source_quality_rows_missing": 1,
+    "source_quality_not_ready": 1,
+    "cache_coverage_missing": 1,
+    "cache_coverage_not_ready": 1,
+    "campaign_lineage_missing": 2,
+    "candidate_lineage_missing": 2,
+    "screening_evidence_missing": 3,
+    "oos_evidence_missing": 4,
+    "oos_evidence_unknown": 4,
+    "no_oos_evidence": 4,
+    "insufficient_oos_evidence": 4,
+}
+
+_BLOCKER_FAMILY: Final[dict[str, str]] = {
+    "source_identity_blocked": "identity",
+    "source_quality_rows_missing": "source_cache",
+    "source_quality_not_ready": "source_cache",
+    "cache_coverage_missing": "source_cache",
+    "cache_coverage_not_ready": "source_cache",
+    "campaign_lineage_missing": "lineage",
+    "candidate_lineage_missing": "lineage",
+    "screening_evidence_missing": "screening",
+    "oos_evidence_missing": "oos",
+    "oos_evidence_unknown": "oos",
+    "no_oos_evidence": "oos",
+    "insufficient_oos_evidence": "oos",
+}
+
+_BLOCKER_ACTION: Final[dict[str, str]] = {
+    "source_identity_blocked": "require_identity_resolution",
+    "source_quality_rows_missing": "expand_basket_coverage",
+    "source_quality_not_ready": "expand_basket_coverage",
+    "cache_coverage_missing": "expand_basket_coverage",
+    "cache_coverage_not_ready": "expand_basket_coverage",
+    "campaign_lineage_missing": "materialize_lineage_from_existing_artifacts",
+    "candidate_lineage_missing": "materialize_lineage_from_existing_artifacts",
+    "screening_evidence_missing": "collect_screening_evidence",
+    "oos_evidence_missing": "collect_oos_evidence",
+    "oos_evidence_unknown": "collect_oos_evidence",
+    "no_oos_evidence": "collect_oos_evidence",
+    "insufficient_oos_evidence": "collect_oos_evidence",
+}
+
+_BLOCKER_ARTIFACTS: Final[dict[str, tuple[str, ...]]] = {
+    "source_identity_blocked": (
+        "research/production_discovery_catalog.py",
+        "logs/qre_discovery_source_identity_diagnostics/latest.json",
+    ),
+    "source_quality_rows_missing": (
+        "logs/qre_data_source_quality_readiness/latest.json",
+        "logs/qre_data_cache_manifest/latest.json",
+    ),
+    "source_quality_not_ready": (
+        "logs/qre_data_source_quality_readiness/latest.json",
+        "logs/qre_data_cache_manifest/latest.json",
+    ),
+    "cache_coverage_missing": (
+        "logs/qre_data_cache_manifest/latest.json",
+        "logs/qre_data_source_quality_readiness/latest.json",
+    ),
+    "cache_coverage_not_ready": (
+        "logs/qre_data_cache_manifest/latest.json",
+        "logs/qre_data_source_quality_readiness/latest.json",
+    ),
+    "campaign_lineage_missing": (
+        "logs/qre_discovery_basket_grid_evidence_materialization/latest.json",
+        "logs/qre_grid_candidate_campaign_lineage_bridge/latest.json",
+    ),
+    "candidate_lineage_missing": (
+        "logs/qre_discovery_basket_grid_evidence_materialization/latest.json",
+        "logs/qre_grid_candidate_campaign_lineage_bridge/latest.json",
+    ),
+    "screening_evidence_missing": (
+        "research/screening_evidence_latest.v1.json",
+        "logs/qre_real_basket_evidence_coverage/latest.json",
+    ),
+    "oos_evidence_missing": (
+        "research/screening_evidence_latest.v1.json",
+        "logs/qre_hypothesis_validation_results/latest.json",
+        "logs/qre_real_basket_evidence_coverage/latest.json",
+    ),
+    "oos_evidence_unknown": (
+        "research/screening_evidence_latest.v1.json",
+        "logs/qre_hypothesis_validation_results/latest.json",
+        "logs/qre_real_basket_evidence_coverage/latest.json",
+    ),
+    "no_oos_evidence": (
+        "research/screening_evidence_latest.v1.json",
+        "logs/qre_hypothesis_validation_results/latest.json",
+        "logs/qre_real_basket_evidence_coverage/latest.json",
+    ),
+    "insufficient_oos_evidence": (
+        "research/screening_evidence_latest.v1.json",
+        "logs/qre_hypothesis_validation_results/latest.json",
+        "logs/qre_real_basket_evidence_coverage/latest.json",
+    ),
+}
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _index_by_candidate(rows: Sequence[Mapping[str, Any]], *, key: str = "candidate_id") -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        subject_id = str(row.get(key) or "")
+        if subject_id and subject_id not in indexed:
+            indexed[subject_id] = dict(row)
+    return indexed
+
+
+def _dedupe_refs(*groups: Sequence[Any]) -> list[str]:
+    refs: list[str] = []
+    for group in groups:
+        if not isinstance(group, Sequence) or isinstance(group, str | bytes):
+            continue
+        for value in group:
+            text = str(value or "").strip()
+            if text and text not in refs:
+                refs.append(text)
+    return refs
+
+
+def _blocker_profile(
+    *,
+    blocker_code: str,
+    candidate_row: Mapping[str, Any],
+    coverage_row: Mapping[str, Any],
+    density_row: Mapping[str, Any],
+    identity_row: Mapping[str, Any],
+) -> dict[str, Any]:
+    family = _BLOCKER_FAMILY.get(blocker_code, "unknown")
+    exact_next_action = _BLOCKER_ACTION.get(blocker_code, "operator_review")
+    artifact_refs = list(_BLOCKER_ARTIFACTS.get(blocker_code, ("research/production_discovery_catalog.py",)))
+    if blocker_code in {"source_quality_rows_missing", "source_quality_not_ready"}:
+        artifact_refs = _dedupe_refs(
+            density_row.get("source_quality_refs") or artifact_refs,
+            artifact_refs,
+        )
+    elif blocker_code in {"cache_coverage_missing", "cache_coverage_not_ready"}:
+        artifact_refs = _dedupe_refs(
+            density_row.get("cache_coverage_refs") or artifact_refs,
+            artifact_refs,
+        )
+    elif blocker_code == "screening_evidence_missing":
+        artifact_refs = _dedupe_refs(
+            density_row.get("screening_evidence_refs") or artifact_refs,
+            artifact_refs,
+        )
+    elif blocker_code in {
+        "oos_evidence_missing",
+        "oos_evidence_unknown",
+        "no_oos_evidence",
+        "insufficient_oos_evidence",
+    }:
+        artifact_refs = _dedupe_refs(
+            density_row.get("oos_evidence_refs") or artifact_refs,
+            artifact_refs,
+        )
+    elif blocker_code in {"campaign_lineage_missing", "candidate_lineage_missing"}:
+        artifact_refs = _dedupe_refs(
+            density_row.get("candidate_lineage_refs") or [],
+            density_row.get("campaign_lineage_refs") or [],
+            artifact_refs,
+        )
+    elif blocker_code == "source_identity_blocked":
+        artifact_refs = _dedupe_refs(
+            artifact_refs,
+        )
+    recoverable = False
+    if blocker_code == "source_identity_blocked":
+        recoverable = bool(identity_row) and bool(identity_row.get("is_provider_symbol_verified"))
+    elif blocker_code in {"source_quality_rows_missing", "source_quality_not_ready"}:
+        recoverable = int(density_row.get("source_quality_rows") or 0) > 0 and int(
+            density_row.get("cache_coverage_rows") or 0
+        ) > 0
+    elif blocker_code in {"cache_coverage_missing", "cache_coverage_not_ready"}:
+        recoverable = int(density_row.get("cache_coverage_rows") or 0) > 0 and int(
+            density_row.get("source_quality_rows") or 0
+        ) > 0
+    elif blocker_code in {"campaign_lineage_missing", "candidate_lineage_missing"}:
+        recoverable = int(density_row.get("candidate_lineage_rows") or 0) > 0 and int(
+            density_row.get("campaign_lineage_rows") or 0
+        ) > 0
+    elif blocker_code == "screening_evidence_missing":
+        recoverable = int(density_row.get("screening_evidence_rows") or 0) > 0
+    elif blocker_code in {
+        "oos_evidence_missing",
+        "oos_evidence_unknown",
+        "no_oos_evidence",
+        "insufficient_oos_evidence",
+    }:
+        recoverable = str(density_row.get("oos_evidence_status") or "") in {
+            "sufficient_oos_evidence",
+            "insufficient_oos_evidence",
+        }
+    return {
+        "blocker_code": blocker_code,
+        "blocker_family": family,
+        "recovery_class": "reducible" if recoverable else "irreducible",
+        "exact_next_action": exact_next_action,
+        "required_artifact": "; ".join(artifact_refs),
+        "potential_clear_refs": artifact_refs,
+        "blocked_by_identity": family == "identity",
+        "blocked_by_source_cache": family == "source_cache",
+        "blocked_by_lineage": family == "lineage",
+        "blocked_by_screening": family == "screening",
+        "blocked_by_oos": family == "oos",
+        "current_status": str(coverage_row.get("evidence_completeness_status") or "missing"),
+        "allowed_to_auto_run": False,
+        "safe_action_type": "report_only",
+        "operator_explanation": (
+            f"{candidate_row.get('symbol')} remains blocked by {blocker_code}; "
+            f"the bounded next action is {exact_next_action}."
+        ),
+    }
+
+
+def _candidate_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("rows")
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, Mapping)]
+
+
+def build_basket_evidence_recovery_plan(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    density_report = density.build_basket_evidence_density_materialization(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    coverage_report = coverage.build_real_basket_evidence_coverage(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    closure_report = closure.build_evidence_complete_basket_closure(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    identity_report = identity_diag.build_source_identity_diagnostics(max_candidates=max_candidates)
+
+    density_rows = _index_by_candidate(_candidate_rows(density_report))
+    coverage_rows = _index_by_candidate(_candidate_rows(coverage_report))
+    closure_rows = _index_by_candidate(_candidate_rows(closure_report))
+    identity_rows = {
+        str(row.get("instrument_symbol") or ""): row
+        for row in _candidate_rows(identity_report)
+    }
+
+    candidate_ids = sorted(
+        {
+            *density_rows.keys(),
+            *coverage_rows.keys(),
+            *closure_rows.keys(),
+        }
+    )
+
+    rows: list[dict[str, Any]] = []
+    blocker_rows: list[dict[str, Any]] = []
+    blocker_counts: Counter[str] = Counter()
+    recovery_class_counts: Counter[str] = Counter()
+    action_counts: Counter[str] = Counter()
+
+    for candidate_id in candidate_ids:
+        density_row = density_rows.get(candidate_id, {})
+        coverage_row = coverage_rows.get(candidate_id, {})
+        closure_row = closure_rows.get(candidate_id, {})
+        symbol = str(
+            closure_row.get("symbol")
+            or coverage_row.get("symbol")
+            or density_row.get("symbol")
+            or ""
+        )
+        identity_row = identity_rows.get(symbol, {})
+        blocker_codes = list(closure_row.get("exact_blockers") or [])
+        if not blocker_codes:
+            blocker_codes = list(coverage_row.get("missing_evidence_taxonomy") or [])
+        blocker_codes = list(dict.fromkeys(blocker_codes))
+        blocker_records: list[dict[str, Any]] = []
+        reducible_count = 0
+        irreducible_count = 0
+        next_actions: list[str] = []
+        for blocker_code in blocker_codes:
+            record = _blocker_profile(
+                blocker_code=blocker_code,
+                candidate_row=closure_row or coverage_row or density_row,
+                coverage_row=coverage_row,
+                density_row=density_row,
+                identity_row=identity_row,
+            )
+            blocker_records.append(record)
+            blocker_rows.append(
+                {
+                    "candidate_id": candidate_id,
+                    "symbol": symbol,
+                    "preset_id": str(
+                        closure_row.get("preset_id")
+                        or coverage_row.get("preset_id")
+                        or density_row.get("preset_id")
+                        or ""
+                    ),
+                    "hypothesis_id": str(
+                        closure_row.get("hypothesis_id")
+                        or coverage_row.get("hypothesis_id")
+                        or density_row.get("hypothesis_id")
+                        or ""
+                    ),
+                    "behavior_family": str(
+                        closure_row.get("behavior_family")
+                        or coverage_row.get("behavior_family")
+                        or density_row.get("behavior_family")
+                        or ""
+                    ),
+                    "region": str(
+                        closure_row.get("region")
+                        or coverage_row.get("region")
+                        or density_row.get("region")
+                        or ""
+                    ),
+                    "asset_class": str(
+                        closure_row.get("asset_class")
+                        or coverage_row.get("asset_class")
+                        or density_row.get("asset_class")
+                        or ""
+                    ),
+                    "timeframes": list(
+                        closure_row.get("timeframes")
+                        or coverage_row.get("timeframes")
+                        or density_row.get("timeframes")
+                        or []
+                    ),
+                    **record,
+                    "reason_record_refs": {
+                        "record_ids": list(closure_row.get("reason_record_ids") or []),
+                        "record_families": list(closure_row.get("reason_record_families") or []),
+                        "evidence_refs": list(closure_row.get("reason_record_evidence_refs") or []),
+                    },
+                }
+            )
+            blocker_counts.update([blocker_code])
+            action_counts.update([record["exact_next_action"]])
+            recovery_class_counts.update([record["recovery_class"]])
+            if record["recovery_class"] == "reducible":
+                reducible_count += 1
+            else:
+                irreducible_count += 1
+            if record["exact_next_action"] not in next_actions:
+                next_actions.append(record["exact_next_action"])
+        rows.append(
+            {
+                "candidate_id": candidate_id,
+                "symbol": symbol,
+                "preset_id": str(
+                    closure_row.get("preset_id")
+                    or coverage_row.get("preset_id")
+                    or density_row.get("preset_id")
+                    or ""
+                ),
+                "hypothesis_id": str(
+                    closure_row.get("hypothesis_id")
+                    or coverage_row.get("hypothesis_id")
+                    or density_row.get("hypothesis_id")
+                    or ""
+                ),
+                "behavior_family": str(
+                    closure_row.get("behavior_family")
+                    or coverage_row.get("behavior_family")
+                    or density_row.get("behavior_family")
+                    or ""
+                ),
+                "region": str(
+                    closure_row.get("region")
+                    or coverage_row.get("region")
+                    or density_row.get("region")
+                    or ""
+                ),
+                "asset_class": str(
+                    closure_row.get("asset_class")
+                    or coverage_row.get("asset_class")
+                    or density_row.get("asset_class")
+                    or ""
+                ),
+                "timeframes": list(
+                    closure_row.get("timeframes")
+                    or coverage_row.get("timeframes")
+                    or density_row.get("timeframes")
+                    or []
+                ),
+                "closure_status": str(closure_row.get("closure_status") or "blocked_not_evidence_complete"),
+                "evidence_completeness_status": str(
+                    coverage_row.get("evidence_completeness_status") or "missing"
+                ),
+                "evidence_completeness_score_pct": int(
+                    coverage_row.get("evidence_completeness_score_pct") or 0
+                ),
+                "blocker_count": len(blocker_records),
+                "reducible_blocker_count": reducible_count,
+                "irreducible_blocker_count": irreducible_count,
+                "blockers": blocker_records,
+                "exact_next_actions": next_actions,
+                "reason_record_count": int(closure_row.get("reason_record_count") or 0),
+                "reason_record_ids": list(closure_row.get("reason_record_ids") or []),
+                "reason_record_evidence_refs": list(
+                    closure_row.get("reason_record_evidence_refs") or []
+                ),
+                "failure_action": dict(closure_row.get("failure_action") or {}),
+                "density_evidence_refs": {
+                    "source_quality": list(density_row.get("source_quality_refs") or []),
+                    "cache_coverage": list(density_row.get("cache_coverage_refs") or []),
+                    "screening": list(density_row.get("screening_evidence_refs") or []),
+                    "oos": list(density_row.get("oos_evidence_refs") or []),
+                    "candidate_lineage": list(density_row.get("candidate_lineage_refs") or []),
+                    "campaign_lineage": list(density_row.get("campaign_lineage_refs") or []),
+                },
+                "operator_explanation": (
+                    f"{symbol} remains blocked by {', '.join(blocker_codes) or 'no recorded blockers'}; "
+                    f"recoverable actions are {', '.join(next_actions) or 'none'}."
+                ),
+            }
+        )
+
+    rows.sort(key=lambda row: (str(row["symbol"]), str(row["preset_id"])))
+    blocker_rows.sort(
+        key=lambda row: (
+            _BLOCKER_PRIORITY.get(str(row.get("blocker_code") or ""), 99),
+            str(row.get("symbol") or ""),
+            str(row.get("preset_id") or ""),
+            str(row.get("blocker_code") or ""),
+        )
+    )
+    closure_summary = closure_report.get("summary") if isinstance(closure_report, Mapping) else {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "basket_count": len(rows),
+            "blocker_row_count": len(blocker_rows),
+            "blocker_counts": dict(sorted(blocker_counts.items())),
+            "reducible_blocker_count": sum(
+                1 for row in blocker_rows if str(row.get("recovery_class") or "") == "reducible"
+            ),
+            "irreducible_blocker_count": sum(
+                1 for row in blocker_rows if str(row.get("recovery_class") or "") != "reducible"
+            ),
+            "blocker_recovery_class_counts": dict(sorted(recovery_class_counts.items())),
+            "exact_next_action_counts": dict(sorted(action_counts.items())),
+            "evidence_complete_count": int(closure_summary.get("evidence_complete_count") or 0),
+            "final_recommendation": (
+                "basket_evidence_recovery_plan_ready" if rows else "basket_evidence_recovery_plan_missing"
+            ),
+            "operator_summary": (
+                "Read-only basket evidence recovery keeps missing evidence explicit, classifies "
+                "remaining blockers, and records the bounded next action for each unresolved blocker."
+            ),
+        },
+        "rows": rows,
+        "blocker_rows": blocker_rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_campaigns": False,
+            "mutates_queues": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    blocker_rows = report.get("blocker_rows") if isinstance(report.get("blocker_rows"), list) else []
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["basket count", str(summary.get("basket_count") or 0)],
+            ["blocker rows", str(summary.get("blocker_row_count") or 0)],
+            ["reducible blockers", str(summary.get("reducible_blocker_count") or 0)],
+            ["irreducible blockers", str(summary.get("irreducible_blocker_count") or 0)],
+            ["evidence complete baskets", str(summary.get("evidence_complete_count") or 0)],
+        ],
+    )
+    basket_table = _table(
+        [
+            "Symbol",
+            "Preset",
+            "Blockers",
+            "Actions",
+            "Reducible",
+            "Irreducible",
+        ],
+        [
+            [
+                str(row.get("symbol") or ""),
+                str(row.get("preset_id") or ""),
+                ", ".join(str(item.get("blocker_code") or "") for item in row.get("blockers") or []),
+                ", ".join(str(value) for value in row.get("exact_next_actions") or []),
+                str(row.get("reducible_blocker_count") or 0),
+                str(row.get("irreducible_blocker_count") or 0),
+            ]
+            for row in rows
+        ],
+    )
+    blocker_table = _table(
+        ["Symbol", "Blocker", "Recovery", "Next action", "Artifact"],
+        [
+            [
+                str(row.get("symbol") or ""),
+                str(row.get("blocker_code") or ""),
+                str(row.get("recovery_class") or ""),
+                str(row.get("exact_next_action") or ""),
+                str(row.get("required_artifact") or ""),
+            ]
+            for row in blocker_rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Basket Evidence Recovery Plan",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Blocker counts",
+            count_table,
+            "",
+            "## 3. Basket recovery matrix",
+            basket_table,
+            "",
+            "## 4. Blocker rows",
+            blocker_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_basket_evidence_recovery_plan: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_basket_evidence_recovery_plan",
+        description="Build a read-only basket evidence recovery plan.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_basket_evidence_recovery_plan(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_basket_next_action_queue.py
+++ b/research/qre_basket_next_action_queue.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_basket_evidence_recovery_plan as recovery_plan
+
+
+REPORT_KIND: Final[str] = "qre_basket_next_action_queue"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_basket_next_action_queue")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_basket_next_action_queue/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _candidate_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("rows")
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, Mapping)]
+
+
+def _blocker_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("blocker_rows")
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, Mapping)]
+
+
+def build_basket_next_action_queue(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    report = recovery_plan.build_basket_evidence_recovery_plan(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    blocker_rows = _blocker_rows(report)
+    queue_rows: list[dict[str, Any]] = []
+    for row in blocker_rows:
+        queue_rows.append(
+            {
+                "candidate_id": row.get("candidate_id"),
+                "symbol": row.get("symbol"),
+                "region": row.get("region"),
+                "asset_class": row.get("asset_class"),
+                "preset_id": row.get("preset_id"),
+                "hypothesis_id": row.get("hypothesis_id"),
+                "blocker_code": row.get("blocker_code"),
+                "blocker_family": row.get("blocker_family"),
+                "current_status": row.get("current_status"),
+                "exact_next_action": row.get("exact_next_action"),
+                "required_artifact": row.get("required_artifact"),
+                "safe_action_type": row.get("safe_action_type"),
+                "allowed_to_auto_run": False,
+                "blocked_by_identity": bool(row.get("blocked_by_identity")),
+                "blocked_by_source_cache": bool(row.get("blocked_by_source_cache")),
+                "blocked_by_lineage": bool(row.get("blocked_by_lineage")),
+                "blocked_by_screening": bool(row.get("blocked_by_screening")),
+                "blocked_by_oos": bool(row.get("blocked_by_oos")),
+                "evidence_refs": list(row.get("potential_clear_refs") or []),
+                "reason_record_refs": dict(row.get("reason_record_refs") or {}),
+                "operator_explanation": str(row.get("operator_explanation") or ""),
+            }
+        )
+    queue_rows.sort(
+        key=lambda row: (
+            str(row.get("symbol") or ""),
+            str(row.get("preset_id") or ""),
+            str(row.get("blocker_code") or ""),
+        )
+    )
+    action_counts = Counter(str(row["exact_next_action"]) for row in queue_rows)
+    blocker_counts = Counter(str(row["blocker_code"]) for row in queue_rows)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "row_count": len(queue_rows),
+            "blocker_counts": dict(sorted(blocker_counts.items())),
+            "exact_next_action_counts": dict(sorted(action_counts.items())),
+            "operator_summary": (
+                "Deterministic next-action queue enumerates every remaining basket blocker "
+                "as a read-only operator review item."
+            ),
+            "final_recommendation": "basket_next_action_queue_ready" if queue_rows else "basket_next_action_queue_missing",
+        },
+        "rows": queue_rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_campaigns": False,
+            "mutates_queues": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["rows", str(summary.get("row_count") or 0)],
+            ["collect_screening_evidence", str(summary.get("exact_next_action_counts", {}).get("collect_screening_evidence") or 0)],
+            ["collect_oos_evidence", str(summary.get("exact_next_action_counts", {}).get("collect_oos_evidence") or 0)],
+            ["expand_basket_coverage", str(summary.get("exact_next_action_counts", {}).get("expand_basket_coverage") or 0)],
+            ["materialize_lineage_from_existing_artifacts", str(summary.get("exact_next_action_counts", {}).get("materialize_lineage_from_existing_artifacts") or 0)],
+            ["require_identity_resolution", str(summary.get("exact_next_action_counts", {}).get("require_identity_resolution") or 0)],
+        ],
+    )
+    row_table = _table(
+        ["Symbol", "Blocker", "Action", "Artifact", "Auto-run"],
+        [
+            [
+                str(row.get("symbol") or ""),
+                str(row.get("blocker_code") or ""),
+                str(row.get("exact_next_action") or ""),
+                str(row.get("required_artifact") or ""),
+                str(bool(row.get("allowed_to_auto_run"))).lower(),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Basket Next-Action Queue",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Action counts",
+            count_table,
+            "",
+            "## 3. Queue rows",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_basket_next_action_queue: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_basket_next_action_queue",
+        description="Build the read-only basket next-action queue.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_basket_next_action_queue(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_real_basket_evidence_coverage.py
+++ b/research/qre_real_basket_evidence_coverage.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
 
+from research import qre_basket_evidence_density_materialization as density
 from research import qre_real_basket_diagnosis as diagnosis
 from research import qre_grid_evidence_readiness_bridge as grid_bridge
 
@@ -18,6 +19,7 @@ DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_real_basket_evidence_coverage")
 LATEST_NAME: Final[str] = "latest.json"
 OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
 _WRITE_PREFIX: Final[str] = "logs/qre_real_basket_evidence_coverage/"
+_DENSITY_PATH: Final[Path] = Path("logs/qre_basket_evidence_density_materialization/latest.json")
 _COMPLETENESS_FIELDS: Final[tuple[str, ...]] = (
     "source_identity_ready",
     "source_quality_ready",
@@ -34,6 +36,16 @@ def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
     divider = "| " + " | ".join(["---"] * len(headers)) + " |"
     body = ["| " + " | ".join(row) + " |" for row in rows]
     return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 def _validation_statuses(screening_rows: Sequence[Mapping[str, Any]]) -> list[str]:
@@ -161,6 +173,22 @@ def _source_cache_artifact_status(
     }
 
 
+def _density_by_candidate(payload: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not isinstance(payload, Mapping):
+        return {}
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        return {}
+    indexed: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        candidate_id = str(row.get("candidate_id") or "")
+        if candidate_id and candidate_id not in indexed:
+            indexed[candidate_id] = dict(row)
+    return indexed
+
+
 def build_real_basket_evidence_coverage(
     *,
     repo_root: Path = Path("."),
@@ -175,12 +203,19 @@ def build_real_basket_evidence_coverage(
         repo_root=repo_root,
         max_candidates=max_candidates,
     )
+    density_report = _read_json(repo_root / _DENSITY_PATH)
+    if density_report is None:
+        density_report = density.build_basket_evidence_density_materialization(
+            repo_root=repo_root,
+            max_candidates=max_candidates,
+        )
     rows = base.get("rows")
     if not isinstance(rows, list):
         rows = []
     bridge_rows = bridge_report.get("rows")
     if not isinstance(bridge_rows, list):
         bridge_rows = []
+    density_rows = _density_by_candidate(density_report)
     bridge_by_candidate = {
         str(row.get("basket_id") or ""): row
         for row in bridge_rows
@@ -201,15 +236,28 @@ def build_real_basket_evidence_coverage(
             evidence = {}
         candidate_id = str(row.get("candidate_id") or "")
         bridge_row = bridge_by_candidate.get(candidate_id, {})
+        density_row = density_rows.get(candidate_id, {})
         screening_rows = diagnosis._matching_screening_rows(  # type: ignore[attr-defined]
             supporting_artifacts.get("screening_evidence"),
             symbol=str(row.get("symbol") or ""),
             hypothesis_id=str(row.get("hypothesis_id") or ""),
         )
+        if int(density_row.get("screening_evidence_rows") or 0) > 0:
+            screening_rows = screening_rows[:]
+        density_screening_rows = int(density_row.get("screening_evidence_rows") or 0)
+        density_validation_statuses = list(density_row.get("validation_evidence_statuses") or [])
         validation_statuses = _validation_statuses(screening_rows)
+        if density_validation_statuses:
+            validation_statuses = density_validation_statuses
         bridge_screening_visible = bool(bridge_row.get("readiness_screening_evidence_visible"))
         bridge_oos_visible = bool(bridge_row.get("readiness_oos_evidence_visible"))
         bridge_sufficient_visible = bool(bridge_row.get("readiness_sufficient_oos_visible"))
+        density_screening_visible = density_screening_rows > 0
+        density_oos_known = str(density_row.get("oos_evidence_status") or "") in {
+            "sufficient_oos_evidence",
+            "insufficient_oos_evidence",
+            "no_oos_evidence",
+        }
         if bridge_screening_visible and not validation_statuses:
             if bridge_sufficient_visible:
                 validation_statuses = ["sufficient_oos_evidence"]
@@ -217,10 +265,16 @@ def build_real_basket_evidence_coverage(
                 validation_statuses = ["grid_oos_evidence_present"]
             else:
                 validation_statuses = ["grid_screening_evidence_present"]
+        if density_screening_visible and not validation_statuses:
+            validation_statuses = ["screening_evidence_present"]
         flags = _completeness_flags(row=row, validation_statuses=validation_statuses)
         if bridge_screening_visible:
             flags["screening_evidence_present"] = True
         if bridge_oos_visible or bridge_sufficient_visible:
+            flags["oos_evidence_known"] = True
+        if density_screening_visible:
+            flags["screening_evidence_present"] = True
+        if density_oos_known:
             flags["oos_evidence_known"] = True
         score = round(100 * sum(flags.values()) / len(_COMPLETENESS_FIELDS))
         status = _completeness_status(score)
@@ -228,23 +282,42 @@ def build_real_basket_evidence_coverage(
             diagnosis_class=str(row.get("diagnosis_class") or "unknown_fail_closed"),
             reason_code=str(row.get("reason_code") or "unknown"),
             provider_symbol_status=str(row.get("provider_symbol_status") or "unknown"),
-            source_quality_rows=int(evidence.get("source_quality_rows") or 0),
+            source_quality_rows=max(
+                int(evidence.get("source_quality_rows") or 0),
+                int(density_row.get("source_quality_rows") or 0),
+            ),
             source_quality_ready=flags["source_quality_ready"],
-            cache_rows=int(evidence.get("cache_coverage_rows") or 0),
+            cache_rows=max(
+                int(evidence.get("cache_coverage_rows") or 0),
+                int(density_row.get("cache_coverage_rows") or 0),
+            ),
             cache_ready=flags["cache_ready"],
             screening_rows=max(
                 int(evidence.get("screening_rows") or 0),
+                density_screening_rows,
                 1 if bridge_screening_visible else 0,
             ),
             validation_statuses=validation_statuses,
-            campaign_rows=int(evidence.get("campaign_rows") or 0),
-            candidate_rows=int(evidence.get("candidate_rows") or 0),
+            campaign_rows=max(
+                int(evidence.get("campaign_rows") or 0),
+                int(density_row.get("campaign_lineage_rows") or 0),
+            ),
+            candidate_rows=max(
+                int(evidence.get("candidate_rows") or 0),
+                int(density_row.get("candidate_lineage_rows") or 0),
+            ),
         )
         if bridge_screening_visible and "screening_evidence_missing" in missing:
+            missing.remove("screening_evidence_missing")
+        if density_screening_visible and "screening_evidence_missing" in missing:
             missing.remove("screening_evidence_missing")
         if (bridge_oos_visible or bridge_sufficient_visible) and "oos_evidence_missing" in missing:
             missing.remove("oos_evidence_missing")
         if (bridge_oos_visible or bridge_sufficient_visible) and "oos_evidence_unknown" in missing:
+            missing.remove("oos_evidence_unknown")
+        if density_oos_known and "oos_evidence_missing" in missing:
+            missing.remove("oos_evidence_missing")
+        if density_oos_known and "oos_evidence_unknown" in missing:
             missing.remove("oos_evidence_unknown")
         if flags["screening_evidence_present"] or flags["oos_evidence_known"]:
             evidence_backed_zero = False
@@ -266,20 +339,35 @@ def build_real_basket_evidence_coverage(
                 "source_identity_status": row.get("source_identity_status"),
                 "provider_symbol_status": row.get("provider_symbol_status"),
                 "evidence_counts": {
-                    "campaign_lineage_rows": int(evidence.get("campaign_rows") or 0),
-                    "candidate_lineage_rows": int(evidence.get("candidate_rows") or 0),
+                    "campaign_lineage_rows": max(
+                        int(evidence.get("campaign_rows") or 0),
+                        int(density_row.get("campaign_lineage_rows") or 0),
+                    ),
+                    "candidate_lineage_rows": max(
+                        int(evidence.get("candidate_rows") or 0),
+                        int(density_row.get("candidate_lineage_rows") or 0),
+                    ),
                     "screening_rows": max(
                         int(evidence.get("screening_rows") or 0),
+                        density_screening_rows,
                         1 if bridge_screening_visible else 0,
                     ),
-                    "source_quality_rows": int(evidence.get("source_quality_rows") or 0),
-                    "cache_coverage_rows": int(evidence.get("cache_coverage_rows") or 0),
+                    "source_quality_rows": max(
+                        int(evidence.get("source_quality_rows") or 0),
+                        int(density_row.get("source_quality_rows") or 0),
+                    ),
+                    "cache_coverage_rows": max(
+                        int(evidence.get("cache_coverage_rows") or 0),
+                        int(density_row.get("cache_coverage_rows") or 0),
+                    ),
                     "cache_ready_rows": int(evidence.get("cache_ready_count") or 0),
                     "oos_trade_count_max": _oos_trade_count(screening_rows),
                     "grid_matched_rows": int(bridge_row.get("matched_grid_rows_count") or 0),
                     "grid_screening_visible_rows": 1 if bridge_screening_visible else 0,
                     "grid_oos_visible_rows": 1 if bridge_oos_visible else 0,
                     "grid_sufficient_oos_visible_rows": 1 if bridge_sufficient_visible else 0,
+                    "density_screening_rows": density_screening_rows,
+                    "density_oos_known": 1 if density_oos_known else 0,
                 },
                 "screening_stage_result_counts": dict(
                     evidence.get("screening_stage_result_counts") or {}

--- a/tests/unit/test_qre_basket_evidence_density_materialization.py
+++ b/tests/unit/test_qre_basket_evidence_density_materialization.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research import qre_basket_evidence_density_materialization as density
+from research import qre_real_basket_evidence_coverage as coverage
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_read_only_inputs(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {
+            "coverage": [
+                {"instrument": "AAPL", "timeframe": "1d", "ready": True},
+                {"instrument": "ASML", "timeframe": "1d", "ready": True},
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {
+            "rows": [
+                {"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"},
+                {"instrument": "ASML", "timeframe": "1d", "quality_status": "ready"},
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "screening_evidence_latest.v1.json",
+        {
+            "candidates": [
+                {
+                    "candidate_id": "candidate-aapl",
+                    "asset": "AAPL",
+                    "hypothesis_id": "trend_pullback_v1",
+                    "qre_validation_linkage_status": "linked_catalog_active_discovery",
+                    "validation_evidence": {
+                        "status": "no_oos_trades",
+                        "oos_trade_count": 0,
+                    },
+                },
+                {
+                    "candidate_id": "candidate-asml",
+                    "asset": "ASML",
+                    "hypothesis_id": "trend_pullback_v1",
+                    "qre_validation_linkage_status": "linked_catalog_active_discovery",
+                    "validation_evidence": {
+                        "status": None,
+                        "oos_trade_count": None,
+                    },
+                },
+            ]
+        },
+    )
+    _write_json(tmp_path / "research" / "campaign_registry_latest.v1.json", {"campaigns": {}})
+    _write_json(tmp_path / "research" / "candidate_registry_latest.v1.json", {"candidates": []})
+
+
+def test_density_materialization_links_local_screening_and_oos_rows(tmp_path: Path) -> None:
+    _seed_read_only_inputs(tmp_path)
+
+    report = density.build_basket_evidence_density_materialization(repo_root=tmp_path, max_candidates=2)
+    paths = density.write_outputs(report, repo_root=tmp_path)
+    coverage_report = coverage.build_real_basket_evidence_coverage(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    assert report["report_kind"] == "qre_basket_evidence_density_materialization"
+    assert report["summary"]["screening_evidence_present_count"] == 2
+    assert report["summary"]["oos_evidence_known_count"] == 1
+    assert paths["latest"] == "logs/qre_basket_evidence_density_materialization/latest.json"
+    assert paths["operator_summary"] == "logs/qre_basket_evidence_density_materialization/operator_summary.md"
+
+    rows = {row["symbol"]: row for row in coverage_report["rows"]}
+    aapl = rows["AAPL"]
+    asml = rows["ASML"]
+    assert aapl["evidence_counts"]["screening_rows"] == 1
+    assert "screening_evidence_missing" not in aapl["missing_evidence_taxonomy"]
+    assert "oos_evidence_missing" not in aapl["missing_evidence_taxonomy"]
+    assert aapl["validation_evidence_status_counts"] == {"no_oos_trades": 1}
+    assert asml["evidence_counts"]["screening_rows"] == 1
+    assert "screening_evidence_missing" not in asml["missing_evidence_taxonomy"]
+    assert "oos_evidence_missing" not in asml["missing_evidence_taxonomy"]
+    assert coverage_report["summary"]["screening_evidence_rows_total"] == 2
+    assert coverage_report["summary"]["evidence_backed_zero_screening"] is False
+
+
+def test_density_materialization_preserves_asmi_identity_blocker(tmp_path: Path) -> None:
+    _write_json(tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json", {"coverage": []})
+    _write_json(tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json", {"rows": []})
+    _write_json(tmp_path / "research" / "screening_evidence_latest.v1.json", {"candidates": []})
+    _write_json(tmp_path / "research" / "campaign_registry_latest.v1.json", {"campaigns": {}})
+    _write_json(tmp_path / "research" / "candidate_registry_latest.v1.json", {"candidates": []})
+
+    report = density.build_basket_evidence_density_materialization(repo_root=tmp_path, max_candidates=5)
+    rows = {row["symbol"]: row for row in report["rows"]}
+
+    assert rows["ASMI"]["source_identity_status"] == "candidate_alias_only"
+    assert rows["ASMI"]["source_identity_blocker"] == "source_identity_candidate_alias_unverified"
+    assert rows["ASMI"]["screening_evidence_rows"] == 0
+    assert rows["ASMI"]["oos_evidence_status"] == "oos_evidence_missing"
+    assert report["summary"]["source_identity_blocked_count"] == 1
+
+
+def test_density_write_outputs_writes_only_allowlisted_paths(tmp_path: Path) -> None:
+    _seed_read_only_inputs(tmp_path)
+    report = density.build_basket_evidence_density_materialization(repo_root=tmp_path, max_candidates=2)
+    paths = density.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_basket_evidence_density_materialization/latest.json"
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()
+    with pytest.raises(ValueError):
+        density.write_outputs(report, repo_root=tmp_path, output_dir=Path("outside"))

--- a/tests/unit/test_qre_basket_evidence_recovery_plan.py
+++ b/tests/unit/test_qre_basket_evidence_recovery_plan.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_basket_evidence_recovery_plan as recovery
+from research import qre_basket_next_action_queue as queue
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_basket_evidence_recovery_plan_preserves_blockers_and_actions(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        recovery.density,
+        "build_basket_evidence_density_materialization",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "preset_id": "preset-a",
+                    "hypothesis_id": "hyp-a",
+                    "behavior_family": "trend_pullback",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "timeframes": ["4h"],
+                    "screening_evidence_rows": 1,
+                    "screening_evidence_refs": ["research/screening_evidence_latest.v1.json#cand-a"],
+                    "oos_evidence_status": "no_oos_evidence",
+                    "oos_evidence_refs": ["research/screening_evidence_latest.v1.json#cand-a"],
+                    "source_quality_rows": 1,
+                    "source_quality_refs": ["logs/qre_data_source_quality_readiness/latest.json"],
+                    "cache_coverage_rows": 1,
+                    "cache_coverage_refs": ["logs/qre_data_cache_manifest/latest.json"],
+                    "candidate_lineage_rows": 1,
+                    "candidate_lineage_refs": ["logs/qre_discovery_basket_grid_evidence_materialization/latest.json"],
+                    "campaign_lineage_rows": 0,
+                    "campaign_lineage_refs": [],
+                    "source_identity_status": "provider_symbol_verified",
+                    "source_identity_blocker": "",
+                },
+                {
+                    "candidate_id": "cand-b",
+                    "symbol": "ASMI",
+                    "preset_id": "preset-b",
+                    "hypothesis_id": "hyp-b",
+                    "behavior_family": "trend_pullback",
+                    "region": "NL/EU",
+                    "asset_class": "equity",
+                    "timeframes": ["1d"],
+                    "screening_evidence_rows": 0,
+                    "screening_evidence_refs": [],
+                    "oos_evidence_status": "oos_evidence_missing",
+                    "oos_evidence_refs": [],
+                    "source_quality_rows": 0,
+                    "source_quality_refs": [],
+                    "cache_coverage_rows": 0,
+                    "cache_coverage_refs": [],
+                    "candidate_lineage_rows": 0,
+                    "candidate_lineage_refs": [],
+                    "campaign_lineage_rows": 0,
+                    "campaign_lineage_refs": [],
+                    "source_identity_status": "candidate_alias_only",
+                    "source_identity_blocker": "source_identity_blocked",
+                },
+            ],
+            "summary": {
+                "basket_count": 2,
+                "screening_evidence_present_count": 1,
+                "oos_evidence_known_count": 1,
+                "candidate_lineage_visible_count": 1,
+                "campaign_lineage_visible_count": 0,
+                "source_identity_blocked_count": 1,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        recovery.coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "preset_id": "preset-a",
+                    "hypothesis_id": "hyp-a",
+                    "behavior_family": "trend_pullback",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "timeframes": ["4h"],
+                    "evidence_completeness_status": "partial",
+                    "evidence_completeness_score_pct": 50,
+                    "exact_blockers": ["screening_evidence_missing", "no_oos_evidence"],
+                    "reason_record_ids": ["rr-a"],
+                    "reason_record_evidence_refs": ["logs/qre_reason_records/latest.json#rr-a"],
+                    "failure_action": {"recommended_action": "collect_more_evidence"},
+                },
+                {
+                    "candidate_id": "cand-b",
+                    "symbol": "ASMI",
+                    "preset_id": "preset-b",
+                    "hypothesis_id": "hyp-b",
+                    "behavior_family": "trend_pullback",
+                    "region": "NL/EU",
+                    "asset_class": "equity",
+                    "timeframes": ["1d"],
+                    "evidence_completeness_status": "missing",
+                    "evidence_completeness_score_pct": 0,
+                    "exact_blockers": ["source_identity_blocked", "campaign_lineage_missing"],
+                    "reason_record_ids": ["rr-b"],
+                    "reason_record_evidence_refs": ["logs/qre_reason_records/latest.json#rr-b"],
+                    "failure_action": {"recommended_action": "require_identity_resolution"},
+                },
+            ],
+            "summary": {"evidence_complete_count": 0},
+        },
+    )
+    monkeypatch.setattr(
+        recovery.closure,
+        "build_evidence_complete_basket_closure",
+        lambda **_: {
+            "summary": {"evidence_complete_count": 0},
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "preset_id": "preset-a",
+                    "hypothesis_id": "hyp-a",
+                    "behavior_family": "trend_pullback",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "timeframes": ["4h"],
+                    "closure_status": "blocked_not_evidence_complete",
+                    "evidence_completeness_status": "partial",
+                    "evidence_completeness_score_pct": 50,
+                    "exact_blockers": ["screening_evidence_missing", "no_oos_evidence"],
+                    "unknown_blockers": [],
+                    "reason_record_count": 1,
+                    "reason_record_ids": ["rr-a"],
+                    "reason_record_families": ["basket_diagnosis"],
+                    "reason_record_evidence_refs": ["logs/qre_reason_records/latest.json#rr-a"],
+                    "failure_action": {"recommended_action": "collect_more_evidence"},
+                },
+                {
+                    "candidate_id": "cand-b",
+                    "symbol": "ASMI",
+                    "preset_id": "preset-b",
+                    "hypothesis_id": "hyp-b",
+                    "behavior_family": "trend_pullback",
+                    "region": "NL/EU",
+                    "asset_class": "equity",
+                    "timeframes": ["1d"],
+                    "closure_status": "blocked_not_evidence_complete",
+                    "evidence_completeness_status": "missing",
+                    "evidence_completeness_score_pct": 0,
+                    "exact_blockers": ["source_identity_blocked", "campaign_lineage_missing"],
+                    "unknown_blockers": [],
+                    "reason_record_count": 1,
+                    "reason_record_ids": ["rr-b"],
+                    "reason_record_families": ["basket_diagnosis"],
+                    "reason_record_evidence_refs": ["logs/qre_reason_records/latest.json#rr-b"],
+                    "failure_action": {"recommended_action": "require_identity_resolution"},
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        recovery.identity_diag,
+        "build_source_identity_diagnostics",
+        lambda **_: {
+            "rows": [
+                {
+                    "instrument_symbol": "ASMI",
+                    "candidate_aliases": ["ASM.AS", "ASMI.AS"],
+                    "source_identity_status": "candidate_alias_only",
+                    "next_action": "require_alias_verification",
+                }
+            ]
+        },
+    )
+
+    report = recovery.build_basket_evidence_recovery_plan(repo_root=tmp_path, max_candidates=2)
+
+    assert report["report_kind"] == "qre_basket_evidence_recovery_plan"
+    assert report["summary"]["basket_count"] == 2
+    assert report["summary"]["blocker_row_count"] == 4
+    assert report["summary"]["reducible_blocker_count"] == 1
+    assert report["summary"]["irreducible_blocker_count"] == 3
+    rows = {row["symbol"]: row for row in report["rows"]}
+    aapl = rows["AAPL"]
+    assert aapl["blocker_count"] == 2
+    assert aapl["exact_next_actions"] == ["collect_screening_evidence", "collect_oos_evidence"]
+    assert aapl["reducible_blocker_count"] == 1
+    asmi = rows["ASMI"]
+    assert asmi["blockers"][0]["exact_next_action"] == "require_identity_resolution"
+    assert asmi["blockers"][0]["blocked_by_identity"] is True
+    assert asmi["blockers"][1]["exact_next_action"] == "materialize_lineage_from_existing_artifacts"
+    assert "research/production_discovery_catalog.py" in asmi["blockers"][0]["potential_clear_refs"]
+    assert report["summary"]["exact_next_action_counts"]["require_identity_resolution"] == 1
+
+
+def test_build_basket_next_action_queue_flattens_blockers_deterministically(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        queue.recovery_plan,
+        "build_basket_evidence_recovery_plan",
+        lambda **_: {
+            "blocker_rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "preset_id": "preset-a",
+                    "hypothesis_id": "hyp-a",
+                    "blocker_code": "screening_evidence_missing",
+                    "blocker_family": "screening",
+                    "current_status": "partial",
+                    "exact_next_action": "collect_screening_evidence",
+                    "required_artifact": "research/screening_evidence_latest.v1.json",
+                    "safe_action_type": "report_only",
+                    "blocked_by_identity": False,
+                    "blocked_by_source_cache": False,
+                    "blocked_by_lineage": False,
+                    "blocked_by_screening": True,
+                    "blocked_by_oos": False,
+                    "potential_clear_refs": ["research/screening_evidence_latest.v1.json"],
+                    "reason_record_refs": {"record_ids": ["rr-a"]},
+                    "operator_explanation": "AAPL remains blocked by screening_evidence_missing; the bounded next action is collect_screening_evidence.",
+                },
+                {
+                    "candidate_id": "cand-b",
+                    "symbol": "ASMI",
+                    "region": "NL/EU",
+                    "asset_class": "equity",
+                    "preset_id": "preset-b",
+                    "hypothesis_id": "hyp-b",
+                    "blocker_code": "source_identity_blocked",
+                    "blocker_family": "identity",
+                    "current_status": "missing",
+                    "exact_next_action": "require_identity_resolution",
+                    "required_artifact": "research/production_discovery_catalog.py",
+                    "safe_action_type": "report_only",
+                    "blocked_by_identity": True,
+                    "blocked_by_source_cache": False,
+                    "blocked_by_lineage": False,
+                    "blocked_by_screening": False,
+                    "blocked_by_oos": False,
+                    "potential_clear_refs": ["research/production_discovery_catalog.py"],
+                    "reason_record_refs": {"record_ids": ["rr-b"]},
+                    "operator_explanation": "ASMI remains blocked by source_identity_blocked; the bounded next action is require_identity_resolution.",
+                },
+            ],
+            "rows": [
+                {"symbol": "AAPL", "preset_id": "preset-a"},
+                {"symbol": "ASMI", "preset_id": "preset-b"},
+            ],
+            "summary": {"evidence_complete_count": 0},
+        },
+    )
+
+    report = queue.build_basket_next_action_queue(repo_root=tmp_path, max_candidates=2)
+
+    assert report["report_kind"] == "qre_basket_next_action_queue"
+    assert report["summary"]["row_count"] == 2
+    assert report["summary"]["exact_next_action_counts"] == {
+        "collect_screening_evidence": 1,
+        "require_identity_resolution": 1,
+    }
+    rows = {row["symbol"]: row for row in report["rows"]}
+    assert rows["AAPL"]["allowed_to_auto_run"] is False
+    assert rows["ASMI"]["blocked_by_identity"] is True
+    assert rows["ASMI"]["required_artifact"] == "research/production_discovery_catalog.py"
+
+
+def test_write_outputs_use_only_allowlisted_log_paths(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        recovery.density,
+        "build_basket_evidence_density_materialization",
+        lambda **_: {"rows": [], "summary": {"basket_count": 0}},
+    )
+    monkeypatch.setattr(
+        recovery.coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {"rows": [], "summary": {"evidence_complete_count": 0}},
+    )
+    monkeypatch.setattr(
+        recovery.closure,
+        "build_evidence_complete_basket_closure",
+        lambda **_: {"rows": [], "summary": {"evidence_complete_count": 0}},
+    )
+    monkeypatch.setattr(
+        recovery.identity_diag,
+        "build_source_identity_diagnostics",
+        lambda **_: {"rows": []},
+    )
+
+    report = recovery.build_basket_evidence_recovery_plan(repo_root=tmp_path, max_candidates=1)
+    paths = recovery.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_basket_evidence_recovery_plan/latest.json"
+    assert paths["operator_summary"] == "logs/qre_basket_evidence_recovery_plan/operator_summary.md"
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()


### PR DESCRIPTION
Adds read-only basket evidence density, recovery diagnosis, and next-action queue reports. Preserves all unresolved blockers explicitly, keeps ASMI identity fail-closed, and does not mutate campaigns, queues, frozen contracts, or execution paths.

Validation:
- python -m pytest tests/unit/test_qre_basket_evidence_recovery_plan.py tests/unit/test_qre_basket_evidence_density_materialization.py tests/unit/test_qre_real_basket_evidence_coverage.py tests/unit/test_qre_evidence_complete_basket_closure.py tests/unit/test_qre_trusted_loop_review_packet.py tests/unit/test_qre_reason_records_v1.py tests/unit/test_qre_failure_action_from_basket.py tests/unit/test_qre_routing_calibration_report.py tests/unit/test_qre_sampling_calibration_report.py -q
- python scripts/governance_lint.py
- python -m pytest tests/smoke -q
- git diff --check
- frozen contract diff remained empty

Safety:
- read-only/report-only only
- no strategy synthesis
- no campaign mutation
- no candidate promotion
- no paper/shadow/live
- no broker/risk/execution
- no frozen contract mutation