### PR TITLE
fix: normalize OOS blockers and prioritize lineage recovery

### DIFF
--- a/research/qre_basket_evidence_recovery_plan.py
+++ b/research/qre_basket_evidence_recovery_plan.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from research import qre_basket_evidence_density_materialization as density
+from research import qre_basket_lineage_recovery_diagnostics as lineage_diag
 from research import qre_discovery_source_identity_diagnostics as identity_diag
 from research import qre_evidence_complete_basket_closure as closure
 from research import qre_real_basket_evidence_coverage as coverage
@@ -166,6 +167,7 @@ def _blocker_profile(
     candidate_row: Mapping[str, Any],
     coverage_row: Mapping[str, Any],
     density_row: Mapping[str, Any],
+    lineage_row: Mapping[str, Any],
     identity_row: Mapping[str, Any],
 ) -> dict[str, Any]:
     family = _BLOCKER_FAMILY.get(blocker_code, "unknown")
@@ -200,6 +202,7 @@ def _blocker_profile(
         artifact_refs = _dedupe_refs(
             density_row.get("candidate_lineage_refs") or [],
             density_row.get("campaign_lineage_refs") or [],
+            lineage_row.get("proof_source_refs", {}).get("density") if isinstance(lineage_row.get("proof_source_refs"), Mapping) else [],
             artifact_refs,
         )
     elif blocker_code == "source_identity_blocked":
@@ -218,9 +221,11 @@ def _blocker_profile(
             density_row.get("source_quality_rows") or 0
         ) > 0
     elif blocker_code in {"campaign_lineage_missing", "candidate_lineage_missing"}:
-        recoverable = int(density_row.get("candidate_lineage_rows") or 0) > 0 and int(
-            density_row.get("campaign_lineage_rows") or 0
-        ) > 0
+        recoverable = str(lineage_row.get("candidate_lineage_proof_status") or "") in {
+            "lineage_visible",
+            "candidate_proven_campaign_missing",
+        }
+        recoverable = recoverable or str(lineage_row.get("campaign_lineage_proof_status") or "") == "proven"
     elif blocker_code == "screening_evidence_missing":
         recoverable = int(density_row.get("screening_evidence_rows") or 0) > 0
     elif blocker_code in {
@@ -245,6 +250,9 @@ def _blocker_profile(
         "blocked_by_lineage": family == "lineage",
         "blocked_by_screening": family == "screening",
         "blocked_by_oos": family == "oos",
+        "lineage_proof_status": str(lineage_row.get("candidate_lineage_proof_status") or "gap"),
+        "campaign_lineage_proof_status": str(lineage_row.get("campaign_lineage_proof_status") or "gap"),
+        "lineage_recovery_reason": str(lineage_row.get("lineage_recovery_reason") or ""),
         "current_status": str(coverage_row.get("evidence_completeness_status") or "missing"),
         "allowed_to_auto_run": False,
         "safe_action_type": "report_only",
@@ -271,6 +279,10 @@ def build_basket_evidence_recovery_plan(
         repo_root=repo_root,
         max_candidates=max_candidates,
     )
+    lineage_report = lineage_diag.build_basket_lineage_recovery_diagnostics(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
     coverage_report = coverage.build_real_basket_evidence_coverage(
         repo_root=repo_root,
         max_candidates=max_candidates,
@@ -282,6 +294,7 @@ def build_basket_evidence_recovery_plan(
     identity_report = identity_diag.build_source_identity_diagnostics(max_candidates=max_candidates)
 
     density_rows = _index_by_candidate(_candidate_rows(density_report))
+    lineage_rows = _index_by_candidate(_candidate_rows(lineage_report))
     coverage_rows = _index_by_candidate(_candidate_rows(coverage_report))
     closure_rows = _index_by_candidate(_candidate_rows(closure_report))
     identity_rows = {
@@ -305,6 +318,7 @@ def build_basket_evidence_recovery_plan(
 
     for candidate_id in candidate_ids:
         density_row = density_rows.get(candidate_id, {})
+        lineage_row = lineage_rows.get(candidate_id, {})
         coverage_row = coverage_rows.get(candidate_id, {})
         closure_row = closure_rows.get(candidate_id, {})
         symbol = str(
@@ -328,6 +342,7 @@ def build_basket_evidence_recovery_plan(
                 candidate_row=closure_row or coverage_row or density_row,
                 coverage_row=coverage_row,
                 density_row=density_row,
+                lineage_row=lineage_row,
                 identity_row=identity_row,
             )
             blocker_records.append(record)
@@ -454,6 +469,7 @@ def build_basket_evidence_recovery_plan(
                     "candidate_lineage": list(density_row.get("candidate_lineage_refs") or []),
                     "campaign_lineage": list(density_row.get("campaign_lineage_refs") or []),
                 },
+                "lineage_diagnostic": dict(lineage_row),
                 "operator_explanation": (
                     f"{symbol} remains blocked by {', '.join(blocker_codes) or 'no recorded blockers'}; "
                     f"recoverable actions are {', '.join(next_actions) or 'none'}."
@@ -487,6 +503,20 @@ def build_basket_evidence_recovery_plan(
             "blocker_recovery_class_counts": dict(sorted(recovery_class_counts.items())),
             "exact_next_action_counts": dict(sorted(action_counts.items())),
             "evidence_complete_count": int(closure_summary.get("evidence_complete_count") or 0),
+            "lineage_diagnostic_row_count": len(lineage_rows),
+            "lineage_proven_candidate_count": sum(
+                1
+                for row in lineage_rows.values()
+                if str(row.get("candidate_lineage_proof_status") or "") in {
+                    "lineage_visible",
+                    "candidate_proven_campaign_missing",
+                }
+            ),
+            "lineage_proven_campaign_count": sum(
+                1
+                for row in lineage_rows.values()
+                if str(row.get("campaign_lineage_proof_status") or "") == "proven"
+            ),
             "final_recommendation": (
                 "basket_evidence_recovery_plan_ready" if rows else "basket_evidence_recovery_plan_missing"
             ),

--- a/research/qre_basket_lineage_recovery_diagnostics.py
+++ b/research/qre_basket_lineage_recovery_diagnostics.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_basket_evidence_density_materialization as density
+from research import qre_grid_candidate_campaign_lineage_bridge as lineage_bridge
+
+
+REPORT_KIND: Final[str] = "qre_basket_lineage_recovery_diagnostics"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_basket_lineage_recovery_diagnostics")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_basket_lineage_recovery_diagnostics/"
+GRID_MATERIALIZATION_PATH: Final[Path] = Path(
+    "logs/qre_discovery_basket_grid_evidence_materialization/latest.json"
+)
+LINEAGE_BRIDGE_PATH: Final[Path] = Path("logs/qre_grid_candidate_campaign_lineage_bridge/latest.json")
+_PROOF_FIELDS: Final[tuple[str, ...]] = (
+    "candidate_id",
+    "symbol",
+    "preset_id",
+    "hypothesis_id",
+    "behavior_family",
+    "region",
+    "asset_class",
+    "timeframes",
+)
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _index_by_candidate(rows: Sequence[Mapping[str, Any]], *, key: str = "candidate_id") -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        subject_id = str(row.get(key) or "")
+        if subject_id and subject_id not in indexed:
+            indexed[subject_id] = dict(row)
+    return indexed
+
+
+def _row_state(
+    *,
+    density_row: Mapping[str, Any],
+    bridge_row: Mapping[str, Any],
+    density_state: str,
+    grid_state: str,
+    bridge_state: str,
+) -> dict[str, Any]:
+    candidate_refs = list(density_row.get("candidate_lineage_refs") or [])
+    campaign_refs = list(density_row.get("campaign_lineage_refs") or [])
+    candidate_rows = int(density_row.get("candidate_lineage_rows") or 0)
+    campaign_rows = int(density_row.get("campaign_lineage_rows") or 0)
+    candidate_proven = candidate_rows > 0 or bool(candidate_refs)
+    campaign_proven = campaign_rows > 0 or bool(campaign_refs)
+    candidate_lineage_status = str(density_row.get("candidate_lineage_status") or "missing")
+    campaign_lineage_status = str(density_row.get("campaign_lineage_status") or "missing")
+    bridge_lineage_status = str(bridge_row.get("lineage_bridge_status") or "blocked_no_grid_match")
+    if candidate_proven and campaign_proven:
+        proof_status = "lineage_visible"
+        next_action = "keep_fail_closed"
+        reason = "candidate_and_campaign_lineage_proven_from_local_artifacts"
+    elif candidate_proven:
+        proof_status = "candidate_proven_campaign_missing"
+        next_action = "materialize_campaign_lineage"
+        reason = "candidate_lineage_proven_campaign_lineage_missing"
+    elif campaign_proven:
+        proof_status = "campaign_proven_candidate_missing"
+        next_action = "materialize_candidate_lineage"
+        reason = "campaign_lineage_proven_candidate_lineage_missing"
+    elif density_state == "missing" or grid_state == "missing" or bridge_state == "missing":
+        proof_status = "artifact_missing"
+        next_action = "restore_or_run_grid_artifacts"
+        reason = "required_lineage_artifacts_are_missing"
+    elif bridge_lineage_status == "blocked_no_grid_match":
+        proof_status = "lineage_gap"
+        next_action = str(bridge_row.get("exact_next_action") or "restore_or_run_grid_artifacts")
+        reason = "no_local_grid_match_is_available"
+    else:
+        proof_status = "lineage_gap"
+        next_action = str(bridge_row.get("exact_next_action") or "materialize_candidate_lineage")
+        reason = "lineage_is_not_proven_by_current_local_artifacts"
+    return {
+        "candidate_id": density_row.get("candidate_id"),
+        "symbol": density_row.get("symbol"),
+        "preset_id": density_row.get("preset_id"),
+        "hypothesis_id": density_row.get("hypothesis_id"),
+        "behavior_family": density_row.get("behavior_family"),
+        "region": density_row.get("region"),
+        "asset_class": density_row.get("asset_class"),
+        "timeframes": list(density_row.get("timeframes") or []),
+        "density_artifact_state": density_state,
+        "grid_materialization_state": grid_state,
+        "bridge_artifact_state": bridge_state,
+        "candidate_lineage_rows": candidate_rows,
+        "campaign_lineage_rows": campaign_rows,
+        "candidate_lineage_refs": candidate_refs,
+        "campaign_lineage_refs": campaign_refs,
+        "candidate_lineage_status": candidate_lineage_status,
+        "campaign_lineage_status": campaign_lineage_status,
+        "candidate_lineage_proof_status": proof_status,
+        "campaign_lineage_proof_status": "proven" if campaign_proven else "gap",
+        "lineage_recovery_reason": reason,
+        "exact_next_action": next_action,
+        "proof_fields": {field: density_row.get(field) for field in _PROOF_FIELDS},
+        "proof_source_refs": {
+            "density": [f"logs/qre_basket_evidence_density_materialization/latest.json#{density_row.get('candidate_id') or density_row.get('symbol') or ''}"],
+            "grid_materialization": [
+                f"logs/qre_discovery_basket_grid_evidence_materialization/latest.json#{density_row.get('symbol') or ''}|{density_row.get('preset_id') or ''}"
+            ],
+            "lineage_bridge": [
+                f"logs/qre_grid_candidate_campaign_lineage_bridge/latest.json#{density_row.get('symbol') or ''}|{density_row.get('preset_id') or ''}"
+            ],
+        },
+    }
+
+
+def build_basket_lineage_recovery_diagnostics(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    density_report = _read_json(repo_root / Path("logs/qre_basket_evidence_density_materialization/latest.json"))
+    if density_report is None:
+        density_report = density.build_basket_evidence_density_materialization(
+            repo_root=repo_root,
+            max_candidates=max_candidates,
+        )
+    bridge_report = _read_json(repo_root / LINEAGE_BRIDGE_PATH)
+    if bridge_report is None:
+        bridge_report = lineage_bridge.build_grid_candidate_campaign_lineage_bridge(
+            repo_root=repo_root,
+            max_candidates=max_candidates,
+        )
+    grid_report = _read_json(repo_root / GRID_MATERIALIZATION_PATH)
+
+    density_rows = density_report.get("rows") if isinstance(density_report.get("rows"), list) else []
+    bridge_rows = bridge_report.get("rows") if isinstance(bridge_report.get("rows"), list) else []
+    grid_rows = grid_report.get("rows") if isinstance(grid_report, Mapping) and isinstance(grid_report.get("rows"), list) else []
+
+    density_by_candidate = _index_by_candidate(density_rows)
+    bridge_by_key = {
+        (str(row.get("asset") or ""), str(row.get("preset") or "")): dict(row)
+        for row in bridge_rows
+        if isinstance(row, Mapping)
+    }
+    grid_by_key = {
+        (str(row.get("asset") or ""), str(row.get("preset") or "")): dict(row)
+        for row in grid_rows
+        if isinstance(row, Mapping)
+    }
+    candidate_ids = sorted(density_by_candidate.keys())
+    density_state = "present" if density_report else "missing"
+    grid_state = "present" if grid_report else "missing"
+    bridge_state = "present" if bridge_report else "missing"
+
+    rows: list[dict[str, Any]] = []
+    proof_counts: Counter[str] = Counter()
+    gap_counts: Counter[str] = Counter()
+
+    for candidate_id in candidate_ids:
+        density_row = density_by_candidate.get(candidate_id, {})
+        symbol = str(density_row.get("symbol") or "")
+        preset_id = str(density_row.get("preset_id") or "")
+        bridge_row = bridge_by_key.get((symbol, preset_id), {})
+        grid_row = grid_by_key.get((symbol, preset_id), {})
+        row = _row_state(
+            density_row=density_row,
+            bridge_row={**bridge_row, **grid_row},
+            density_state=density_state,
+            grid_state=grid_state,
+            bridge_state=bridge_state,
+        )
+        rows.append(row)
+        proof_counts.update([str(row["candidate_lineage_proof_status"])])
+        if str(row["candidate_lineage_proof_status"]) != "lineage_visible":
+            gap_counts.update([str(row["lineage_recovery_reason"])])
+
+    rows.sort(key=lambda row: (str(row["symbol"]), str(row["preset_id"])))
+    candidate_proven_count = sum(1 for row in rows if str(row["candidate_lineage_proof_status"]) in {"lineage_visible", "candidate_proven_campaign_missing"})
+    campaign_proven_count = sum(1 for row in rows if str(row["campaign_lineage_proof_status"]) == "proven")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "basket_count": len(rows),
+            "density_artifact_state": density_state,
+            "grid_materialization_state": grid_state,
+            "bridge_artifact_state": bridge_state,
+            "candidate_lineage_proven_count": candidate_proven_count,
+            "campaign_lineage_proven_count": campaign_proven_count,
+            "candidate_lineage_gap_count": sum(
+                1 for row in rows if str(row["candidate_lineage_proof_status"]) != "lineage_visible"
+            ),
+            "campaign_lineage_gap_count": sum(
+                1 for row in rows if str(row["campaign_lineage_proof_status"]) != "proven"
+            ),
+            "candidate_lineage_proof_counts": dict(sorted(proof_counts.items())),
+            "lineage_gap_reason_counts": dict(sorted(gap_counts.items())),
+            "final_recommendation": (
+                "basket_lineage_recovery_diagnostics_ready" if rows else "basket_lineage_recovery_diagnostics_missing"
+            ),
+            "operator_summary": (
+                "Read-only lineage diagnostics distinguish proven candidate lineage from campaign lineage gaps "
+                "and keep explicit recovery reasons visible for operator review."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_campaigns": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["basket count", str(summary.get("basket_count") or 0)],
+            ["candidate lineage proven", str(summary.get("candidate_lineage_proven_count") or 0)],
+            ["campaign lineage proven", str(summary.get("campaign_lineage_proven_count") or 0)],
+            ["candidate lineage gap", str(summary.get("candidate_lineage_gap_count") or 0)],
+            ["campaign lineage gap", str(summary.get("campaign_lineage_gap_count") or 0)],
+        ],
+    )
+    row_table = _table(
+        ["Symbol", "Candidate lineage", "Campaign lineage", "Reason", "Next action"],
+        [
+            [
+                str(row.get("symbol") or ""),
+                str(row.get("candidate_lineage_proof_status") or ""),
+                str(row.get("campaign_lineage_proof_status") or ""),
+                str(row.get("lineage_recovery_reason") or ""),
+                str(row.get("exact_next_action") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Basket Lineage Recovery Diagnostics",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Lineage counts",
+            count_table,
+            "",
+            "## 3. Lineage rows",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_basket_lineage_recovery_diagnostics: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_basket_lineage_recovery_diagnostics",
+        description="Build read-only basket lineage recovery diagnostics.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_basket_lineage_recovery_diagnostics(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_basket_next_action_queue.py
+++ b/research/qre_basket_next_action_queue.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from research import qre_basket_evidence_recovery_plan as recovery_plan
+from research import qre_basket_lineage_recovery_diagnostics as lineage_diag
 
 
 REPORT_KIND: Final[str] = "qre_basket_next_action_queue"
@@ -40,6 +41,61 @@ def _blocker_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
     return [dict(row) for row in rows if isinstance(row, Mapping)]
 
 
+def _priority_bucket(row: Mapping[str, Any]) -> str:
+    if bool(row.get("blocked_by_identity")):
+        return "identity_first"
+    if bool(row.get("blocked_by_lineage")) and int(row.get("candidate_score") or 0) >= 80:
+        return "lineage_first"
+    if bool(row.get("blocked_by_source_cache")):
+        return "source_cache_first"
+    if bool(row.get("blocked_by_screening")):
+        return "screening_second"
+    if bool(row.get("blocked_by_oos")):
+        return "oos_second"
+    if bool(row.get("blocked_by_lineage")):
+        return "lineage_followup"
+    return "operator_review"
+
+
+def _priority_rank(row: Mapping[str, Any]) -> int:
+    bucket = _priority_bucket(row)
+    return {
+        "identity_first": 0,
+        "lineage_first": 1,
+        "source_cache_first": 2,
+        "screening_second": 3,
+        "oos_second": 4,
+        "lineage_followup": 5,
+        "operator_review": 6,
+    }.get(bucket, 99)
+
+
+def _recommended_batch(row: Mapping[str, Any]) -> str:
+    if bool(row.get("blocked_by_identity")):
+        return "batch_identity_review"
+    if bool(row.get("blocked_by_lineage")) and int(row.get("candidate_score") or 0) >= 80:
+        return "batch_lineage_oos"
+    if bool(row.get("blocked_by_source_cache")):
+        return "batch_source_cache_expansion"
+    if bool(row.get("blocked_by_screening")) or bool(row.get("blocked_by_oos")):
+        return "batch_screening_oos_collection"
+    if bool(row.get("blocked_by_lineage")):
+        return "batch_lineage_repair"
+    return "batch_operator_review"
+
+
+def _safe_command_template(row: Mapping[str, Any]) -> str:
+    if bool(row.get("blocked_by_identity")):
+        return "python -m research.qre_discovery_source_identity_diagnostics --write"
+    if bool(row.get("blocked_by_lineage")):
+        return "python -m research.qre_basket_lineage_recovery_diagnostics --write"
+    if bool(row.get("blocked_by_source_cache")):
+        return "python -m research.qre_basket_evidence_density_materialization --write"
+    if bool(row.get("blocked_by_screening")) or bool(row.get("blocked_by_oos")):
+        return "python -m research.qre_evidence_complete_basket_closure --write"
+    return "python -m research.qre_basket_next_action_queue --write"
+
+
 def build_basket_next_action_queue(
     *,
     repo_root: Path = Path("."),
@@ -49,9 +105,29 @@ def build_basket_next_action_queue(
         repo_root=repo_root,
         max_candidates=max_candidates,
     )
+    lineage_report = lineage_diag.build_basket_lineage_recovery_diagnostics(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    candidate_rows = {
+        str(row.get("candidate_id") or ""): dict(row)
+        for row in _candidate_rows(report)
+    }
     blocker_rows = _blocker_rows(report)
+    lineage_rows = {
+        str(row.get("candidate_id") or ""): dict(row)
+        for row in _candidate_rows(lineage_report)
+    }
     queue_rows: list[dict[str, Any]] = []
     for row in blocker_rows:
+        lineage_row = lineage_rows.get(str(row.get("candidate_id") or ""), {})
+        candidate_score = int(
+            candidate_rows.get(str(row.get("candidate_id") or ""), {}).get(
+                "evidence_completeness_score_pct",
+                row.get("evidence_completeness_score_pct") or 0,
+            )
+            or 0
+        )
         queue_rows.append(
             {
                 "candidate_id": row.get("candidate_id"),
@@ -72,6 +148,38 @@ def build_basket_next_action_queue(
                 "blocked_by_lineage": bool(row.get("blocked_by_lineage")),
                 "blocked_by_screening": bool(row.get("blocked_by_screening")),
                 "blocked_by_oos": bool(row.get("blocked_by_oos")),
+                "candidate_score": candidate_score,
+                "lineage_proof_status": str(lineage_row.get("candidate_lineage_proof_status") or ""),
+                "campaign_lineage_proof_status": str(lineage_row.get("campaign_lineage_proof_status") or ""),
+                "priority_bucket": _priority_bucket({**row, "candidate_score": candidate_score}),
+                "priority_rank": _priority_rank({**row, "candidate_score": candidate_score}),
+                "dependency_order": (
+                    0
+                    if bool(row.get("blocked_by_identity"))
+                    else 1
+                    if bool(row.get("blocked_by_lineage")) and candidate_score >= 80
+                    else 2
+                    if bool(row.get("blocked_by_source_cache"))
+                    else 3
+                    if bool(row.get("blocked_by_screening"))
+                    else 4
+                    if bool(row.get("blocked_by_oos"))
+                    else 5
+                ),
+                "is_top_candidate": str(row.get("symbol") or "") in {"AAPL", "NVDA"},
+                "blocks_evidence_complete": True,
+                "recommended_batch": _recommended_batch({**row, "candidate_score": candidate_score}),
+                "rationale": (
+                    "identity before all else"
+                    if bool(row.get("blocked_by_identity"))
+                    else "lineage is the closest recoverable evidence chain"
+                    if bool(row.get("blocked_by_lineage")) and candidate_score >= 80
+                    else "source/cache coverage should precede deeper evidence collection"
+                    if bool(row.get("blocked_by_source_cache"))
+                    else "screening and OOS remain explicit evidence gaps"
+                ),
+                "allowed_command_template": _safe_command_template({**row, "candidate_score": candidate_score}),
+                "requires_operator_review": True,
                 "evidence_refs": list(row.get("potential_clear_refs") or []),
                 "reason_record_refs": dict(row.get("reason_record_refs") or {}),
                 "operator_explanation": str(row.get("operator_explanation") or ""),
@@ -79,6 +187,9 @@ def build_basket_next_action_queue(
         )
     queue_rows.sort(
         key=lambda row: (
+            int(row.get("priority_rank") or 99),
+            -int(row.get("candidate_score") or 0),
+            int(row.get("dependency_order") or 99),
             str(row.get("symbol") or ""),
             str(row.get("preset_id") or ""),
             str(row.get("blocker_code") or ""),
@@ -86,6 +197,7 @@ def build_basket_next_action_queue(
     )
     action_counts = Counter(str(row["exact_next_action"]) for row in queue_rows)
     blocker_counts = Counter(str(row["blocker_code"]) for row in queue_rows)
+    priority_counts = Counter(str(row["priority_bucket"]) for row in queue_rows)
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
@@ -93,9 +205,17 @@ def build_basket_next_action_queue(
             "row_count": len(queue_rows),
             "blocker_counts": dict(sorted(blocker_counts.items())),
             "exact_next_action_counts": dict(sorted(action_counts.items())),
+            "priority_bucket_counts": dict(sorted(priority_counts.items())),
+            "top_candidate_symbols": list(
+                dict.fromkeys(
+                    str(row.get("symbol") or "")
+                    for row in queue_rows
+                    if bool(row.get("is_top_candidate"))
+                )
+            ),
             "operator_summary": (
                 "Deterministic next-action queue enumerates every remaining basket blocker "
-                "as a read-only operator review item."
+                "as a read-only operator review item with lineage-first priority ordering."
             ),
             "final_recommendation": "basket_next_action_queue_ready" if queue_rows else "basket_next_action_queue_missing",
         },
@@ -127,11 +247,13 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
         ],
     )
     row_table = _table(
-        ["Symbol", "Blocker", "Action", "Artifact", "Auto-run"],
+        ["Symbol", "Blocker", "Priority", "Batch", "Action", "Artifact", "Auto-run"],
         [
             [
                 str(row.get("symbol") or ""),
                 str(row.get("blocker_code") or ""),
+                str(row.get("priority_bucket") or ""),
+                str(row.get("recommended_batch") or ""),
                 str(row.get("exact_next_action") or ""),
                 str(row.get("required_artifact") or ""),
                 str(bool(row.get("allowed_to_auto_run"))).lower(),

--- a/research/qre_basket_operator_action_plan.py
+++ b/research/qre_basket_operator_action_plan.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_basket_lineage_recovery_diagnostics as lineage_diag
+from research import qre_basket_next_action_queue as next_action_queue
+
+
+REPORT_KIND: Final[str] = "qre_basket_operator_action_plan"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_basket_operator_action_plan")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_basket_operator_action_plan/"
+
+SAFE_COMMANDS: Final[tuple[str, ...]] = (
+    "python -m research.qre_basket_evidence_density_materialization --write",
+    "python -m research.qre_basket_lineage_recovery_diagnostics --write",
+    "python -m research.qre_basket_evidence_recovery_plan --write",
+    "python -m research.qre_basket_next_action_queue --write",
+    "python -m research.qre_evidence_complete_basket_closure --write",
+    "python -m research.qre_trusted_loop_review_packet --write",
+)
+NOT_ALLOWED_COMMANDS: Final[tuple[str, ...]] = (
+    "any campaign mutation command",
+    "any paper/shadow/live activation command",
+    "any broker/risk/execution command",
+    "any strategy synthesis or registration command",
+)
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _candidate_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("rows")
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, Mapping)]
+
+
+def build_basket_operator_action_plan(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    queue_report = next_action_queue.build_basket_next_action_queue(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    lineage_report = lineage_diag.build_basket_lineage_recovery_diagnostics(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    queue_rows = _candidate_rows(queue_report)
+    lineage_rows = {
+        str(row.get("candidate_id") or ""): dict(row)
+        for row in _candidate_rows(lineage_report)
+    }
+
+    top_candidates = [
+        row
+        for row in queue_rows
+        if str(row.get("symbol") or "") in {"AAPL", "NVDA"}
+    ]
+    top_candidates.sort(
+        key=lambda row: (
+            int(row.get("priority_rank") or 99),
+            -int(row.get("candidate_score") or 0),
+            str(row.get("blocker_code") or ""),
+        )
+    )
+    first_batch_rows = top_candidates[:4] if top_candidates else queue_rows[:4]
+    first_batch_symbols = list(dict.fromkeys(str(row.get("symbol") or "") for row in first_batch_rows))
+    targeted_blockers = Counter(str(row.get("blocker_code") or "") for row in first_batch_rows)
+    top_actions = list(dict.fromkeys(str(row.get("exact_next_action") or "") for row in first_batch_rows))
+    expected_blocker_impact = {
+        blocker: count
+        for blocker, count in sorted(targeted_blockers.items())
+    }
+    blocked_by_identity = any(bool(row.get("blocked_by_identity")) for row in first_batch_rows)
+    blocked_by_source_cache = any(bool(row.get("blocked_by_source_cache")) for row in first_batch_rows)
+    blocked_by_lineage = any(bool(row.get("blocked_by_lineage")) for row in first_batch_rows)
+    blocked_by_screening = any(bool(row.get("blocked_by_screening")) for row in first_batch_rows)
+    blocked_by_oos = any(bool(row.get("blocked_by_oos")) for row in first_batch_rows)
+    if blocked_by_identity:
+        first_batch_name = "identity_review"
+    elif blocked_by_lineage and not blocked_by_source_cache:
+        first_batch_name = "lineage_repair"
+    elif blocked_by_source_cache:
+        first_batch_name = "source_cache_repair"
+    elif blocked_by_screening or blocked_by_oos:
+        first_batch_name = "evidence_collection"
+    else:
+        first_batch_name = "operator_review"
+
+    report_rows = [
+        {
+            "candidate_id": row.get("candidate_id"),
+            "symbol": row.get("symbol"),
+            "region": row.get("region"),
+            "asset_class": row.get("asset_class"),
+            "preset_id": row.get("preset_id"),
+            "hypothesis_id": row.get("hypothesis_id"),
+            "priority_rank": row.get("priority_rank"),
+            "priority_bucket": row.get("priority_bucket"),
+            "exact_next_action": row.get("exact_next_action"),
+            "recommended_batch": row.get("recommended_batch"),
+            "candidate_score": row.get("candidate_score"),
+            "lineage_proof_status": row.get("lineage_proof_status"),
+            "campaign_lineage_proof_status": row.get("campaign_lineage_proof_status"),
+            "allowed_command_template": row.get("allowed_command_template"),
+            "requires_operator_review": True,
+            "safe_action_type": row.get("safe_action_type"),
+            "exact_blocker": row.get("blocker_code"),
+            "blocker_family": row.get("blocker_family"),
+            "operator_explanation": row.get("operator_explanation"),
+            "lineage_diagnostic": lineage_rows.get(str(row.get("candidate_id") or ""), {}),
+        }
+        for row in first_batch_rows
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "recommended_first_batch": first_batch_name,
+            "first_batch_candidate_symbols": first_batch_symbols,
+            "top_candidates": first_batch_symbols,
+            "top_actions": top_actions,
+            "blockers_targeted": dict(expected_blocker_impact),
+            "safe_command_count": len(SAFE_COMMANDS),
+            "commands_not_allowed_count": len(NOT_ALLOWED_COMMANDS),
+            "final_recommendation": "basket_operator_action_plan_ready" if queue_rows else "basket_operator_action_plan_missing",
+            "operator_summary": (
+                "Read-only operator action plan groups the closest evidence recovery steps into a bounded first batch "
+                "without granting any execution authority."
+            ),
+        },
+        "first_batch": report_rows,
+        "safe_commands_to_run_manually": list(SAFE_COMMANDS),
+        "commands_not_allowed": list(NOT_ALLOWED_COMMANDS),
+        "stop_conditions": [
+            "Do not run any command that mutates campaigns, queues, or strategy registration.",
+            "Do not use paper/shadow/live, broker, risk, or execution paths.",
+            "Do not claim evidence completeness unless the closure packet proves it from local artifacts.",
+            "Do not clear ASMI identity blocking without deterministic local proof.",
+        ],
+        "required_follow_up_reports": [
+            "python -m research.qre_basket_evidence_density_materialization --write",
+            "python -m research.qre_basket_lineage_recovery_diagnostics --write",
+            "python -m research.qre_basket_evidence_recovery_plan --write",
+            "python -m research.qre_basket_next_action_queue --write",
+            "python -m research.qre_evidence_complete_basket_closure --write",
+            "python -m research.qre_trusted_loop_review_packet --write",
+        ],
+        "expected_rerun_sequence": [
+            "materialize_density",
+            "diagnose_lineage",
+            "refresh_recovery_plan",
+            "refresh_next_action_queue",
+            "refresh_closure",
+            "refresh_trusted_loop",
+        ],
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_campaigns": False,
+            "mutates_queues": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("first_batch") if isinstance(report.get("first_batch"), list) else []
+    batch_table = _table(
+        ["Symbol", "Priority", "Batch", "Action", "Allowed command"],
+        [
+            [
+                str(row.get("symbol") or ""),
+                str(row.get("priority_bucket") or ""),
+                str(row.get("recommended_batch") or ""),
+                str(row.get("exact_next_action") or ""),
+                str(row.get("allowed_command_template") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Basket Operator Action Plan",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Recommended first batch",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["recommended_first_batch", str(summary.get("recommended_first_batch") or "")],
+                    ["top_candidates", ", ".join(str(item) for item in summary.get("top_candidates") or []) or "none"],
+                    ["top_actions", ", ".join(str(item) for item in summary.get("top_actions") or []) or "none"],
+                ],
+            ),
+            "",
+            "## 3. First batch rows",
+            batch_table,
+            "",
+            "## 4. Safe commands",
+            "\n".join(f"- `{item}`" for item in report.get("safe_commands_to_run_manually") or []),
+            "",
+            "## 5. Commands not allowed",
+            "\n".join(f"- {item}" for item in report.get("commands_not_allowed") or []),
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_basket_operator_action_plan: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_basket_operator_action_plan",
+        description="Build the read-only basket operator action plan.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_basket_operator_action_plan(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_evidence_complete_basket_closure.py
+++ b/research/qre_evidence_complete_basket_closure.py
@@ -31,6 +31,15 @@ CHECKLIST_ORDER: Final[tuple[tuple[str, str], ...]] = (
     ("candidate_lineage_present", "candidate_lineage_present"),
 )
 
+KNOWN_OOS_GAP_BLOCKERS: Final[frozenset[str]] = frozenset(
+    {
+        "oos_evidence_missing",
+        "oos_evidence_unknown",
+        "no_oos_evidence",
+        "insufficient_oos_evidence",
+    }
+)
+
 
 def _index_by_candidate(rows: Sequence[Mapping[str, Any]], *, key: str = "candidate_id") -> dict[str, dict[str, Any]]:
     indexed: dict[str, dict[str, Any]] = {}
@@ -96,7 +105,11 @@ def _row_closure(row: Mapping[str, Any]) -> dict[str, Any]:
         "reason_records_present": reason_record_present,
         "failure_action_present": bool(failure_action),
     }
-    unknown_like = [value for value in missing_taxonomy if "unknown" in str(value)]
+    unknown_like = [
+        value
+        for value in missing_taxonomy
+        if "unknown" in str(value) and str(value) not in KNOWN_OOS_GAP_BLOCKERS
+    ]
     if all(closure_criteria.values()):
         closure_status = "evidence_complete"
         exact_next_action = "keep_fail_closed"

--- a/research/qre_real_basket_evidence_coverage.py
+++ b/research/qre_real_basket_evidence_coverage.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from research import qre_basket_evidence_density_materialization as density
+from research import qre_basket_lineage_recovery_diagnostics as lineage_diag
 from research import qre_real_basket_diagnosis as diagnosis
 from research import qre_grid_evidence_readiness_bridge as grid_bridge
 
@@ -209,6 +210,10 @@ def build_real_basket_evidence_coverage(
             repo_root=repo_root,
             max_candidates=max_candidates,
         )
+    lineage_report = lineage_diag.build_basket_lineage_recovery_diagnostics(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
     rows = base.get("rows")
     if not isinstance(rows, list):
         rows = []
@@ -216,6 +221,7 @@ def build_real_basket_evidence_coverage(
     if not isinstance(bridge_rows, list):
         bridge_rows = []
     density_rows = _density_by_candidate(density_report)
+    lineage_rows = _density_by_candidate(lineage_report)
     bridge_by_candidate = {
         str(row.get("basket_id") or ""): row
         for row in bridge_rows
@@ -237,6 +243,7 @@ def build_real_basket_evidence_coverage(
         candidate_id = str(row.get("candidate_id") or "")
         bridge_row = bridge_by_candidate.get(candidate_id, {})
         density_row = density_rows.get(candidate_id, {})
+        lineage_row = lineage_rows.get(candidate_id, {})
         screening_rows = diagnosis._matching_screening_rows(  # type: ignore[attr-defined]
             supporting_artifacts.get("screening_evidence"),
             symbol=str(row.get("symbol") or ""),
@@ -268,6 +275,15 @@ def build_real_basket_evidence_coverage(
         if density_screening_visible and not validation_statuses:
             validation_statuses = ["screening_evidence_present"]
         flags = _completeness_flags(row=row, validation_statuses=validation_statuses)
+        candidate_lineage_proof_status = str(lineage_row.get("candidate_lineage_proof_status") or "")
+        campaign_lineage_proof_status = str(lineage_row.get("campaign_lineage_proof_status") or "")
+        if candidate_lineage_proof_status in {
+            "lineage_visible",
+            "candidate_proven_campaign_missing",
+        }:
+            flags["candidate_lineage_present"] = True
+        if campaign_lineage_proof_status == "proven":
+            flags["campaign_lineage_present"] = True
         if bridge_screening_visible:
             flags["screening_evidence_present"] = True
         if bridge_oos_visible or bridge_sufficient_visible:
@@ -319,6 +335,13 @@ def build_real_basket_evidence_coverage(
             missing.remove("oos_evidence_missing")
         if density_oos_known and "oos_evidence_unknown" in missing:
             missing.remove("oos_evidence_unknown")
+        if candidate_lineage_proof_status in {
+            "lineage_visible",
+            "candidate_proven_campaign_missing",
+        } and "candidate_lineage_missing" in missing:
+            missing.remove("candidate_lineage_missing")
+        if campaign_lineage_proof_status == "proven" and "campaign_lineage_missing" in missing:
+            missing.remove("campaign_lineage_missing")
         if flags["screening_evidence_present"] or flags["oos_evidence_known"]:
             evidence_backed_zero = False
         taxonomy_counter.update(missing)
@@ -398,6 +421,7 @@ def build_real_basket_evidence_coverage(
                     ),
                     "bridge_explanation": str(bridge_row.get("bridge_explanation") or ""),
                 },
+                "lineage_recovery_diagnostic": dict(lineage_row),
                 "follow_up": (
                     "eligible_for_readonly_routing"
                     if score >= 85

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -20,6 +20,7 @@ from typing import Any, Final
 from reporting import qre_trusted_loop_readiness as trusted_readiness
 from research import qre_evidence_complete_basket_closure as basket_closure
 from research import qre_failure_action_from_basket as failure_action
+from research import qre_basket_operator_action_plan as basket_action_plan
 from research import qre_reason_records_v1 as reason_records
 from research import qre_research_memory_current_artifacts as research_memory
 from research import qre_routing_calibration_report as routing_calibration
@@ -192,6 +193,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     routing_packet = routing_calibration.build_routing_calibration_report(repo_root=repo_root)
     sampling_packet = sampling_calibration.build_sampling_calibration_report(repo_root=repo_root)
     memory_packet = research_memory.build_research_memory_current_artifacts(repo_root=repo_root)
+    action_plan_packet = basket_action_plan.build_basket_operator_action_plan(repo_root=repo_root)
 
     protected_artifacts = [
         _path_state(repo_root, "research/research_latest.json"),
@@ -206,6 +208,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     routing_summary = routing_packet.get("summary") if isinstance(routing_packet.get("summary"), Mapping) else {}
     sampling_summary = sampling_packet.get("summary") if isinstance(sampling_packet.get("summary"), Mapping) else {}
     memory_summary = memory_packet if isinstance(memory_packet, Mapping) else {}
+    action_plan_summary = action_plan_packet.get("summary") if isinstance(action_plan_packet.get("summary"), Mapping) else {}
     trust_level, trust_verdict, trust_blockers, exact_next_action = _trusted_loop_level(
         readiness_state=str(readiness_summary.get("readiness_state") or "scaffold"),
         readiness_summary=readiness_summary,
@@ -239,6 +242,11 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
                 (memory_summary.get("summary") or {}).get("final_recommendation") or ""
             )
             == "research_memory_current_artifacts_ready",
+            "basket_operator_action_plan_ready": str(action_plan_summary.get("final_recommendation") or "")
+            == "basket_operator_action_plan_ready",
+            "basket_operator_action_plan_first_batch": list(
+                action_plan_summary.get("first_batch_candidate_symbols") or []
+            ),
             "contradiction_visibility": (
                 readiness_summary.get("contradiction_visibility")
                 if isinstance(readiness_summary.get("contradiction_visibility"), Mapping)

--- a/tests/unit/test_qre_basket_evidence_recovery_plan.py
+++ b/tests/unit/test_qre_basket_evidence_recovery_plan.py
@@ -78,6 +78,32 @@ def test_build_basket_evidence_recovery_plan_preserves_blockers_and_actions(tmp_
         },
     )
     monkeypatch.setattr(
+        recovery.lineage_diag,
+        "build_basket_lineage_recovery_diagnostics",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "preset_id": "preset-a",
+                    "candidate_lineage_proof_status": "candidate_proven_campaign_missing",
+                    "campaign_lineage_proof_status": "gap",
+                    "lineage_recovery_reason": "candidate_lineage_proven_campaign_lineage_missing",
+                    "proof_source_refs": {"density": ["logs/qre_basket_evidence_density_materialization/latest.json#cand-a"]},
+                },
+                {
+                    "candidate_id": "cand-b",
+                    "symbol": "ASMI",
+                    "preset_id": "preset-b",
+                    "candidate_lineage_proof_status": "lineage_gap",
+                    "campaign_lineage_proof_status": "gap",
+                    "lineage_recovery_reason": "lineage_is_not_proven_by_current_local_artifacts",
+                    "proof_source_refs": {"density": ["logs/qre_basket_evidence_density_materialization/latest.json#cand-b"]},
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(
         recovery.coverage,
         "build_real_basket_evidence_coverage",
         lambda **_: {
@@ -189,11 +215,13 @@ def test_build_basket_evidence_recovery_plan_preserves_blockers_and_actions(tmp_
     assert report["summary"]["blocker_row_count"] == 4
     assert report["summary"]["reducible_blocker_count"] == 1
     assert report["summary"]["irreducible_blocker_count"] == 3
+    assert report["summary"]["lineage_diagnostic_row_count"] == 2
     rows = {row["symbol"]: row for row in report["rows"]}
     aapl = rows["AAPL"]
     assert aapl["blocker_count"] == 2
     assert aapl["exact_next_actions"] == ["collect_screening_evidence", "collect_oos_evidence"]
     assert aapl["reducible_blocker_count"] == 1
+    assert aapl["lineage_diagnostic"]["candidate_lineage_proof_status"] == "candidate_proven_campaign_missing"
     asmi = rows["ASMI"]
     assert asmi["blockers"][0]["exact_next_action"] == "require_identity_resolution"
     assert asmi["blockers"][0]["blocked_by_identity"] is True
@@ -254,10 +282,30 @@ def test_build_basket_next_action_queue_flattens_blockers_deterministically(tmp_
                 },
             ],
             "rows": [
-                {"symbol": "AAPL", "preset_id": "preset-a"},
-                {"symbol": "ASMI", "preset_id": "preset-b"},
+                {"candidate_id": "cand-a", "symbol": "AAPL", "preset_id": "preset-a", "evidence_completeness_score_pct": 86},
+                {"candidate_id": "cand-b", "symbol": "ASMI", "preset_id": "preset-b", "evidence_completeness_score_pct": 0},
             ],
             "summary": {"evidence_complete_count": 0},
+        },
+    )
+    monkeypatch.setattr(
+        queue.lineage_diag,
+        "build_basket_lineage_recovery_diagnostics",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "candidate_lineage_proof_status": "candidate_proven_campaign_missing",
+                    "campaign_lineage_proof_status": "gap",
+                },
+                {
+                    "candidate_id": "cand-b",
+                    "symbol": "ASMI",
+                    "candidate_lineage_proof_status": "lineage_gap",
+                    "campaign_lineage_proof_status": "gap",
+                },
+            ]
         },
     )
 
@@ -269,10 +317,116 @@ def test_build_basket_next_action_queue_flattens_blockers_deterministically(tmp_
         "collect_screening_evidence": 1,
         "require_identity_resolution": 1,
     }
+    assert report["summary"]["top_candidate_symbols"] == ["AAPL"]
     rows = {row["symbol"]: row for row in report["rows"]}
     assert rows["AAPL"]["allowed_to_auto_run"] is False
     assert rows["ASMI"]["blocked_by_identity"] is True
     assert rows["ASMI"]["required_artifact"] == "research/production_discovery_catalog.py"
+    assert rows["AAPL"]["priority_bucket"] == "screening_second"
+    assert rows["ASMI"]["priority_bucket"] == "identity_first"
+    assert rows["AAPL"]["is_top_candidate"] is True
+    assert rows["AAPL"]["requires_operator_review"] is True
+
+
+def test_build_basket_next_action_queue_prioritizes_lineage_first_targets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        queue.recovery_plan,
+        "build_basket_evidence_recovery_plan",
+        lambda **_: {
+            "blocker_rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "preset_id": "preset-a",
+                    "hypothesis_id": "hyp-a",
+                    "blocker_code": "campaign_lineage_missing",
+                    "blocker_family": "lineage",
+                    "current_status": "partial",
+                    "exact_next_action": "materialize_lineage_from_existing_artifacts",
+                    "required_artifact": "logs/qre_discovery_basket_grid_evidence_materialization/latest.json",
+                    "safe_action_type": "report_only",
+                    "blocked_by_identity": False,
+                    "blocked_by_source_cache": False,
+                    "blocked_by_lineage": True,
+                    "blocked_by_screening": False,
+                    "blocked_by_oos": False,
+                    "potential_clear_refs": ["logs/qre_discovery_basket_grid_evidence_materialization/latest.json"],
+                    "reason_record_refs": {"record_ids": ["rr-a"]},
+                    "operator_explanation": "AAPL remains blocked by campaign_lineage_missing; the bounded next action is materialize_lineage_from_existing_artifacts.",
+                },
+                {
+                    "candidate_id": "cand-n",
+                    "symbol": "NVDA",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "preset_id": "preset-n",
+                    "hypothesis_id": "hyp-n",
+                    "blocker_code": "no_oos_evidence",
+                    "blocker_family": "oos",
+                    "current_status": "partial",
+                    "exact_next_action": "collect_oos_evidence",
+                    "required_artifact": "research/screening_evidence_latest.v1.json",
+                    "safe_action_type": "report_only",
+                    "blocked_by_identity": False,
+                    "blocked_by_source_cache": False,
+                    "blocked_by_lineage": True,
+                    "blocked_by_screening": False,
+                    "blocked_by_oos": True,
+                    "potential_clear_refs": ["research/screening_evidence_latest.v1.json"],
+                    "reason_record_refs": {"record_ids": ["rr-n"]},
+                    "operator_explanation": "NVDA remains blocked by no_oos_evidence; the bounded next action is collect_oos_evidence.",
+                },
+            ],
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "preset_id": "preset-a",
+                    "evidence_completeness_score_pct": 86,
+                },
+                {
+                    "candidate_id": "cand-n",
+                    "symbol": "NVDA",
+                    "preset_id": "preset-n",
+                    "evidence_completeness_score_pct": 86,
+                },
+            ],
+            "summary": {"evidence_complete_count": 0},
+        },
+    )
+    monkeypatch.setattr(
+        queue.lineage_diag,
+        "build_basket_lineage_recovery_diagnostics",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "candidate_lineage_proof_status": "candidate_proven_campaign_missing",
+                    "campaign_lineage_proof_status": "gap",
+                },
+                {
+                    "candidate_id": "cand-n",
+                    "symbol": "NVDA",
+                    "candidate_lineage_proof_status": "candidate_proven_campaign_missing",
+                    "campaign_lineage_proof_status": "gap",
+                },
+            ]
+        },
+    )
+
+    report = queue.build_basket_next_action_queue(repo_root=tmp_path, max_candidates=2)
+
+    assert report["summary"]["top_candidate_symbols"] == ["AAPL", "NVDA"]
+    assert report["rows"][0]["priority_bucket"] == "lineage_first"
+    assert report["rows"][1]["priority_bucket"] == "lineage_first"
+    assert report["rows"][0]["recommended_batch"] == "batch_lineage_oos"
+    assert report["rows"][0]["allowed_command_template"] == "python -m research.qre_basket_lineage_recovery_diagnostics --write"
 
 
 def test_write_outputs_use_only_allowlisted_log_paths(tmp_path: Path, monkeypatch) -> None:
@@ -294,6 +448,11 @@ def test_write_outputs_use_only_allowlisted_log_paths(tmp_path: Path, monkeypatc
     monkeypatch.setattr(
         recovery.identity_diag,
         "build_source_identity_diagnostics",
+        lambda **_: {"rows": []},
+    )
+    monkeypatch.setattr(
+        recovery.lineage_diag,
+        "build_basket_lineage_recovery_diagnostics",
         lambda **_: {"rows": []},
     )
 

--- a/tests/unit/test_qre_basket_lineage_recovery_diagnostics.py
+++ b/tests/unit/test_qre_basket_lineage_recovery_diagnostics.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_basket_lineage_recovery_diagnostics as lineage_diag
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_lineage_diagnostics_distinguish_proven_lineage_from_gaps(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        lineage_diag.density,
+        "build_basket_evidence_density_materialization",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "preset_id": "preset-a",
+                    "hypothesis_id": "hyp-a",
+                    "behavior_family": "trend_pullback",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "timeframes": ["4h"],
+                    "candidate_lineage_rows": 1,
+                    "campaign_lineage_rows": 1,
+                    "candidate_lineage_refs": ["logs/qre_discovery_basket_grid_evidence_materialization/latest.json#AAPL|preset-a"],
+                    "campaign_lineage_refs": ["logs/qre_grid_candidate_campaign_lineage_bridge/latest.json#AAPL|preset-a"],
+                },
+                {
+                    "candidate_id": "cand-b",
+                    "symbol": "ASMI",
+                    "preset_id": "preset-b",
+                    "hypothesis_id": "hyp-b",
+                    "behavior_family": "trend_pullback",
+                    "region": "NL/EU",
+                    "asset_class": "equity",
+                    "timeframes": ["1d"],
+                    "candidate_lineage_rows": 0,
+                    "campaign_lineage_rows": 0,
+                    "candidate_lineage_refs": [],
+                    "campaign_lineage_refs": [],
+                },
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        lineage_diag.lineage_bridge,
+        "build_grid_candidate_campaign_lineage_bridge",
+        lambda **_: {
+            "rows": [
+                {"asset": "AAPL", "preset": "preset-a", "lineage_bridge_status": "lineage_visible", "exact_next_action": "keep_fail_closed"},
+                {"asset": "ASMI", "preset": "preset-b", "lineage_bridge_status": "blocked_no_grid_match", "exact_next_action": "restore_or_run_grid_artifacts"},
+            ]
+        },
+    )
+
+    report = lineage_diag.build_basket_lineage_recovery_diagnostics(repo_root=tmp_path, max_candidates=2)
+
+    assert report["summary"]["basket_count"] == 2
+    assert report["summary"]["candidate_lineage_proven_count"] == 1
+    assert report["summary"]["campaign_lineage_proven_count"] == 1
+    rows = {row["symbol"]: row for row in report["rows"]}
+    assert rows["AAPL"]["candidate_lineage_proof_status"] == "lineage_visible"
+    assert rows["AAPL"]["campaign_lineage_proof_status"] == "proven"
+    assert rows["ASMI"]["candidate_lineage_proof_status"] == "artifact_missing"
+    assert rows["ASMI"]["exact_next_action"] == "restore_or_run_grid_artifacts"
+
+
+def test_lineage_diagnostics_write_outputs_stays_allowlisted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        lineage_diag.density,
+        "build_basket_evidence_density_materialization",
+        lambda **_: {"rows": []},
+    )
+    monkeypatch.setattr(
+        lineage_diag.lineage_bridge,
+        "build_grid_candidate_campaign_lineage_bridge",
+        lambda **_: {"rows": []},
+    )
+
+    report = lineage_diag.build_basket_lineage_recovery_diagnostics(repo_root=tmp_path, max_candidates=1)
+    paths = lineage_diag.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_basket_lineage_recovery_diagnostics/latest.json"
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()

--- a/tests/unit/test_qre_basket_operator_action_plan.py
+++ b/tests/unit/test_qre_basket_operator_action_plan.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_basket_operator_action_plan as action_plan
+
+
+def test_operator_action_plan_prioritizes_aapl_and_nvda_first_batch(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        action_plan.next_action_queue,
+        "build_basket_next_action_queue",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "cand-a",
+                    "symbol": "AAPL",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "preset_id": "preset-a",
+                    "hypothesis_id": "hyp-a",
+                    "priority_rank": 1,
+                    "priority_bucket": "lineage_first",
+                    "exact_next_action": "materialize_lineage_from_existing_artifacts",
+                    "recommended_batch": "batch_lineage_oos",
+                    "candidate_score": 86,
+                    "lineage_proof_status": "candidate_proven_campaign_missing",
+                    "campaign_lineage_proof_status": "gap",
+                    "allowed_command_template": "python -m research.qre_basket_lineage_recovery_diagnostics --write",
+                    "requires_operator_review": True,
+                    "safe_action_type": "report_only",
+                    "blocker_code": "campaign_lineage_missing",
+                    "blocker_family": "lineage",
+                    "blocked_by_identity": False,
+                    "blocked_by_source_cache": False,
+                    "blocked_by_lineage": True,
+                    "blocked_by_screening": False,
+                    "blocked_by_oos": True,
+                    "operator_explanation": "AAPL remains blocked by campaign_lineage_missing.",
+                },
+                {
+                    "candidate_id": "cand-n",
+                    "symbol": "NVDA",
+                    "region": "US",
+                    "asset_class": "equity",
+                    "preset_id": "preset-n",
+                    "hypothesis_id": "hyp-n",
+                    "priority_rank": 1,
+                    "priority_bucket": "lineage_first",
+                    "exact_next_action": "collect_oos_evidence",
+                    "recommended_batch": "batch_lineage_oos",
+                    "candidate_score": 86,
+                    "lineage_proof_status": "candidate_proven_campaign_missing",
+                    "campaign_lineage_proof_status": "gap",
+                    "allowed_command_template": "python -m research.qre_evidence_complete_basket_closure --write",
+                    "requires_operator_review": True,
+                    "safe_action_type": "report_only",
+                    "blocker_code": "no_oos_evidence",
+                    "blocker_family": "oos",
+                    "blocked_by_identity": False,
+                    "blocked_by_source_cache": False,
+                    "blocked_by_lineage": True,
+                    "blocked_by_screening": False,
+                    "blocked_by_oos": True,
+                    "operator_explanation": "NVDA remains blocked by no_oos_evidence.",
+                },
+                {
+                    "candidate_id": "cand-s",
+                    "symbol": "ASMI",
+                    "region": "NL/EU",
+                    "asset_class": "equity",
+                    "preset_id": "preset-s",
+                    "hypothesis_id": "hyp-s",
+                    "priority_rank": 0,
+                    "priority_bucket": "identity_first",
+                    "exact_next_action": "require_identity_resolution",
+                    "recommended_batch": "batch_identity_review",
+                    "candidate_score": 0,
+                    "lineage_proof_status": "lineage_gap",
+                    "campaign_lineage_proof_status": "gap",
+                    "allowed_command_template": "python -m research.qre_discovery_source_identity_diagnostics --write",
+                    "requires_operator_review": True,
+                    "safe_action_type": "report_only",
+                    "blocker_code": "source_identity_blocked",
+                    "blocker_family": "identity",
+                    "blocked_by_identity": True,
+                    "blocked_by_source_cache": False,
+                    "blocked_by_lineage": False,
+                    "blocked_by_screening": False,
+                    "blocked_by_oos": False,
+                    "operator_explanation": "ASMI remains blocked by source_identity_blocked.",
+                },
+            ],
+            "summary": {"row_count": 3},
+        },
+    )
+    monkeypatch.setattr(
+        action_plan.lineage_diag,
+        "build_basket_lineage_recovery_diagnostics",
+        lambda **_: {
+            "rows": [
+                {"candidate_id": "cand-a", "symbol": "AAPL"},
+                {"candidate_id": "cand-n", "symbol": "NVDA"},
+                {"candidate_id": "cand-s", "symbol": "ASMI"},
+            ]
+        },
+    )
+
+    report = action_plan.build_basket_operator_action_plan(repo_root=tmp_path, max_candidates=3)
+
+    assert report["summary"]["recommended_first_batch"] == "lineage_repair"
+    assert report["summary"]["top_candidates"] == ["AAPL", "NVDA"]
+    assert report["summary"]["top_actions"] == [
+        "materialize_lineage_from_existing_artifacts",
+        "collect_oos_evidence",
+    ]
+    assert report["summary"]["blockers_targeted"] == {
+        "campaign_lineage_missing": 1,
+        "no_oos_evidence": 1,
+    }
+    first_batch = {row["symbol"]: row for row in report["first_batch"]}
+    assert first_batch["AAPL"]["requires_operator_review"] is True
+    assert first_batch["NVDA"]["allowed_command_template"] == "python -m research.qre_evidence_complete_basket_closure --write"
+    assert any("registration" in item for item in report["commands_not_allowed"])
+    assert report["safe_commands_to_run_manually"][0] == "python -m research.qre_basket_evidence_density_materialization --write"
+
+
+def test_operator_action_plan_write_outputs_stays_allowlisted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(action_plan.next_action_queue, "build_basket_next_action_queue", lambda **_: {"rows": [], "summary": {"row_count": 0}})
+    monkeypatch.setattr(action_plan.lineage_diag, "build_basket_lineage_recovery_diagnostics", lambda **_: {"rows": []})
+
+    report = action_plan.build_basket_operator_action_plan(repo_root=tmp_path, max_candidates=1)
+    paths = action_plan.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_basket_operator_action_plan/latest.json"
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()

--- a/tests/unit/test_qre_evidence_complete_basket_closure.py
+++ b/tests/unit/test_qre_evidence_complete_basket_closure.py
@@ -193,6 +193,77 @@ def test_closure_requires_exact_blockers_without_unknowns(monkeypatch) -> None:
     assert report["summary"]["final_recommendation"] == "no_basket_evidence_complete_reason_records_preserved"
 
 
+def test_closure_treats_explicit_oos_gap_states_as_known_blockers(monkeypatch) -> None:
+    monkeypatch.setattr(
+        closure.evidence_coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "c4",
+                    "symbol": "NVDA",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "diagnosis_class": "diagnosable",
+                    "evidence_completeness_score_pct": 42,
+                    "evidence_completeness_status": "thin",
+                    "missing_evidence_taxonomy": [
+                        "oos_evidence_unknown",
+                        "no_oos_evidence",
+                        "oos_evidence_missing",
+                    ],
+                    "follow_up": "collect_more_evidence",
+                    "evidence_presence": {
+                        "source_identity_ready": True,
+                        "source_quality_ready": True,
+                        "cache_ready": True,
+                        "screening_evidence_present": True,
+                        "oos_evidence_known": False,
+                        "campaign_lineage_present": False,
+                        "candidate_lineage_present": False,
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        closure.reason_records,
+        "build_reason_records_snapshot",
+        lambda **_: {
+            "records": [
+                {
+                    "subject_id": "c4",
+                    "record_ids": ["qrr_c4_reason_1"],
+                    "record_families": ["basket_diagnosis"],
+                    "reason_codes": ["oos_evidence_unknown"],
+                    "evidence_refs": ["research/screening_evidence_latest.v1.json"],
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        closure.failure_action,
+        "build_failure_action_from_basket",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "c4",
+                    "recommended_action": "collect_oos_evidence",
+                    "actionability": {"is_actionable": True, "status": "actionable"},
+                }
+            ]
+        },
+    )
+
+    report = closure.build_evidence_complete_basket_closure()
+    row = report["rows"][0]
+    assert row["closure_status"] == "blocked_not_evidence_complete"
+    assert "oos_evidence_unknown" in row["exact_blockers"]
+    assert row["unknown_blocker_count"] == 0
+    assert row["exact_next_action"] == "collect_oos_evidence"
+    assert report["summary"]["unknown_blocker_count"] == 0
+    assert report["summary"]["all_non_complete_baskets_have_no_unknown_blockers"] is True
+
+
 def test_closure_fails_closed_when_reason_records_missing_for_complete_basket(monkeypatch) -> None:
     monkeypatch.setattr(
         closure.evidence_coverage,

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -87,6 +87,16 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         "build_research_memory_current_artifacts",
         lambda **_: snapshots["research_memory"],
     )
+    monkeypatch.setattr(
+        packet_module.basket_action_plan,
+        "build_basket_operator_action_plan",
+        lambda **_: {
+            "summary": {
+                "final_recommendation": "basket_operator_action_plan_ready",
+                "first_batch_candidate_symbols": ["AAPL", "NVDA"],
+            }
+        },
+    )
 
     packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
 
@@ -100,6 +110,8 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["routing_evidence_ready"] is True
     assert packet["summary"]["sampling_evidence_ready"] is True
     assert packet["summary"]["research_memory_ready"] is True
+    assert packet["summary"]["basket_operator_action_plan_ready"] is True
+    assert packet["summary"]["basket_operator_action_plan_first_batch"] == ["AAPL", "NVDA"]
     assert packet["summary"]["trust_blocker_count"] == 0
     assert packet["protected_artifacts"][0]["exists"] is True
     assert packet["protected_artifacts"][1]["exists"] is True
@@ -130,6 +142,7 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
     monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: {"summary": {"final_recommendation": "routing_calibration_scaffold_ready"}})
     monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: {"summary": {"final_recommendation": "sampling_calibration_scaffold_ready"}})
     monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: {"summary": {"final_recommendation": "research_memory_current_artifacts_partial"}})
+    monkeypatch.setattr(packet_module.basket_action_plan, "build_basket_operator_action_plan", lambda **_: {"summary": {"final_recommendation": "basket_operator_action_plan_ready", "first_batch_candidate_symbols": []}})
 
     packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
 
@@ -155,6 +168,7 @@ def test_trusted_loop_review_packet_operator_summary_renders(
     monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: snapshots["routing"])
     monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: snapshots["sampling"])
     monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: snapshots["research_memory"])
+    monkeypatch.setattr(packet_module.basket_action_plan, "build_basket_operator_action_plan", lambda **_: {"summary": {"final_recommendation": "basket_operator_action_plan_ready", "first_batch_candidate_symbols": ["AAPL"]}})
 
     packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
     text = packet_module.render_operator_summary(packet)


### PR DESCRIPTION
PR normalizes explicit OOS gap taxonomy, adds proof-based lineage diagnostics, prioritizes the recovery queue, and introduces a read-only operator action plan.

Validation:
- python -m pytest tests/unit/test_qre_evidence_complete_basket_closure.py tests/unit/test_qre_basket_evidence_density_materialization.py tests/unit/test_qre_real_basket_evidence_coverage.py tests/unit/test_qre_basket_lineage_recovery_diagnostics.py tests/unit/test_qre_basket_evidence_recovery_plan.py tests/unit/test_qre_basket_operator_action_plan.py tests/unit/test_qre_trusted_loop_review_packet.py tests/unit/test_qre_reason_records_v1.py tests/unit/test_qre_failure_action_from_basket.py tests/unit/test_qre_routing_calibration_report.py tests/unit/test_qre_sampling_calibration_report.py -q
- python scripts/governance_lint.py
- python -m pytest tests/smoke -q
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

Safety:
- read-only / report-only only
- no campaign mutation
- no strategy synthesis or registration
- no paper/shadow/live/broker/risk/execution
- frozen contracts untouched

Before/after highlights:
- unknown_blocker_count: 3 -> 0
- all_non_complete_baskets_have_no_unknown_blockers: False -> True
- reducible_blocker_count in recovery plan: 0 -> 3
- top next-action batch now prioritizes AAPL/NVDA lineage recovery
