### PR TITLE
feat: add first-batch evidence recovery cascade

### DIFF
--- a/research/qre_basket_operator_action_plan.py
+++ b/research/qre_basket_operator_action_plan.py
@@ -10,6 +10,7 @@ from typing import Any, Final
 
 from research import qre_basket_lineage_recovery_diagnostics as lineage_diag
 from research import qre_basket_next_action_queue as next_action_queue
+from research import qre_first_batch_evidence_recovery_cascade as first_batch_cascade
 from research import qre_first_batch_evidence_recovery_readiness as first_batch_readiness
 
 
@@ -28,6 +29,7 @@ SAFE_COMMANDS: Final[tuple[str, ...]] = (
     "python -m research.qre_evidence_complete_basket_closure --write",
     "python -m research.qre_trusted_loop_review_packet --write",
     "python -m research.qre_first_batch_evidence_recovery_readiness --write",
+    "python -m research.qre_first_batch_evidence_recovery_cascade --write",
 )
 NOT_ALLOWED_COMMANDS: Final[tuple[str, ...]] = (
     "any campaign mutation command",
@@ -61,6 +63,10 @@ def build_basket_operator_action_plan(
         max_candidates=max_candidates,
     )
     readiness_report = first_batch_readiness.build_first_batch_evidence_recovery_readiness(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    cascade_report = first_batch_cascade.build_first_batch_evidence_recovery_cascade(
         repo_root=repo_root,
         max_candidates=max_candidates,
     )
@@ -149,6 +155,12 @@ def build_basket_operator_action_plan(
             "commands_not_allowed_count": len(NOT_ALLOWED_COMMANDS),
             "first_batch_readiness_artifact": "logs/qre_first_batch_evidence_recovery_readiness/latest.json",
             "first_batch_readiness_available": str(readiness_report.get("report_kind") or "") == "qre_first_batch_evidence_recovery_readiness",
+            "first_batch_recovery_cascade_artifact": "logs/qre_first_batch_evidence_recovery_cascade/latest.json",
+            "first_batch_recovery_cascade_available": str(cascade_report.get("report_kind") or "") == "qre_first_batch_evidence_recovery_cascade",
+            "first_batch_recovery_cascade_result": str(cascade_report.get("overall_result") or ""),
+            "first_batch_recovery_cascade_top_blocker": str(
+                (cascade_report.get("first_batch_summary") or {}).get("current_top_blocker") or ""
+            ),
             "final_recommendation": "basket_operator_action_plan_ready" if queue_rows else "basket_operator_action_plan_missing",
             "operator_summary": (
                 "Read-only operator action plan groups the closest evidence recovery steps into a bounded first batch "
@@ -172,11 +184,13 @@ def build_basket_operator_action_plan(
             "python -m research.qre_evidence_complete_basket_closure --write",
             "python -m research.qre_trusted_loop_review_packet --write",
             "python -m research.qre_first_batch_evidence_recovery_readiness --write",
+            "python -m research.qre_first_batch_evidence_recovery_cascade --write",
         ],
         "expected_rerun_sequence": [
             "materialize_density",
             "diagnose_lineage",
             "refresh_first_batch_readiness",
+            "refresh_first_batch_recovery_cascade",
             "refresh_recovery_plan",
             "refresh_next_action_queue",
             "refresh_closure",
@@ -224,6 +238,8 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["recommended_first_batch", str(summary.get("recommended_first_batch") or "")],
                     ["top_candidates", ", ".join(str(item) for item in summary.get("top_candidates") or []) or "none"],
                     ["top_actions", ", ".join(str(item) for item in summary.get("top_actions") or []) or "none"],
+                    ["cascade_result", str(summary.get("first_batch_recovery_cascade_result") or "")],
+                    ["cascade_top_blocker", str(summary.get("first_batch_recovery_cascade_top_blocker") or "")],
                 ],
             ),
             "",

--- a/research/qre_first_batch_evidence_recovery_cascade.py
+++ b/research/qre_first_batch_evidence_recovery_cascade.py
@@ -4,6 +4,7 @@ import argparse
 import csv
 import json
 import os
+import re
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
@@ -90,6 +91,8 @@ GENERATED_REPORT_MARKERS: Final[tuple[str, ...]] = (
     "qre_evidence_complete_basket_closure",
     "qre_trusted_loop_review",
 )
+RESULT_WRITTEN_PATTERN: Final[re.Pattern[str]] = re.compile(r"results_written=(?P<count>\d+)")
+VALIDATED_COUNT_PATTERN: Final[re.Pattern[str]] = re.compile(r"validated_count=(?P<count>\d+)")
 
 
 def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
@@ -373,6 +376,131 @@ def _iter_allowlisted_files(repo_root: Path) -> Iterable[Path]:
             yield path
 
 
+def _extract_expected_result_count(row: Mapping[str, Any]) -> int:
+    for field in ("expected_result_count", "validated_count"):
+        value = row.get(field)
+        if isinstance(value, int):
+            return value
+    payload = _read_json_payload(Path(row["path"]))
+    if isinstance(payload, Mapping):
+        summary = payload.get("summary")
+        if isinstance(summary, Mapping):
+            for field in ("validated_count", "result_success_count"):
+                value = summary.get(field)
+                if isinstance(value, int):
+                    return value
+        for field in ("validated_candidate_count", "result_success_count"):
+            value = payload.get(field)
+            if isinstance(value, int):
+                return value
+        stdout_tail = str(payload.get("stdout_tail") or "")
+        for pattern in (RESULT_WRITTEN_PATTERN, VALIDATED_COUNT_PATTERN):
+            match = pattern.search(stdout_tail)
+            if match:
+                return int(match.group("count"))
+    text = _read_text(Path(row["path"]))
+    for pattern in (RESULT_WRITTEN_PATTERN, VALIDATED_COUNT_PATTERN):
+        match = pattern.search(text)
+        if match:
+            return int(match.group("count"))
+    return 0
+
+
+def _extract_validation_candidate_rows(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, Mapping):
+        return []
+    rows = payload.get("candidates")
+    if not isinstance(rows, list):
+        rows = payload.get("rows")
+    if not isinstance(rows, list):
+        return []
+    extracted: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        validation = row.get("validation")
+        if isinstance(validation, Mapping):
+            extracted.append(dict(row))
+    return extracted
+
+
+def _locate_validation_results(
+    repo_root: Path,
+    artifact_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    stdout_rows = [
+        row
+        for row in artifact_rows
+        if row["classification_status"] == "legacy_validation_stdout_only"
+    ]
+    structured_rows = [
+        row
+        for row in artifact_rows
+        if row["relative_path"].startswith("research/history/")
+        and row["has_structured_results"]
+        and (
+            row["contains_validation_fields"]
+            or row["artifact_kind"] in {"legacy_candidate_results", "legacy_validation_state"}
+        )
+    ]
+    locator_rows: list[dict[str, Any]] = []
+    for stdout_row in stdout_rows:
+        expected_result_count = _extract_expected_result_count(stdout_row)
+        matched_structured: list[dict[str, Any]] = []
+        found_symbols: set[str] = set()
+        found_validated_count = 0
+        found_paths: list[str] = []
+        for candidate_row in structured_rows:
+            payload = _read_json_payload(Path(candidate_row["path"]))
+            validation_rows = _extract_validation_candidate_rows(payload)
+            if not validation_rows:
+                continue
+            matched_candidates = [
+                row for row in validation_rows if str(row.get("asset") or "") in TARGET_SYMBOLS
+            ]
+            if not matched_candidates:
+                continue
+            for item in matched_candidates:
+                found_symbols.add(str(item.get("asset") or ""))
+                validation_status = str(((item.get("validation") or {}).get("status")) or "")
+                current_status = str(item.get("current_status") or "")
+                if validation_status == "validated" or current_status == "validated":
+                    found_validated_count += 1
+            found_paths.append(candidate_row["relative_path"])
+            matched_structured.append(dict(candidate_row))
+        found_paths = sorted(set(found_paths))
+        result_schema_status = (
+            "structured_validation_results_found"
+            if found_paths
+            else "structured_validation_results_missing"
+        )
+        missing_result_count = max(expected_result_count - found_validated_count, 0) if expected_result_count else 0
+        locator_rows.append(
+            {
+                "stdout_trace_path": stdout_row["relative_path"],
+                "expected_result_count": expected_result_count,
+                "found_result_count": found_validated_count,
+                "missing_result_count": missing_result_count,
+                "found_result_paths": found_paths,
+                "matched_symbols": sorted(found_symbols),
+                "result_schema_status": result_schema_status,
+                "can_use_as_oos_evidence": False,
+                "can_use_as_campaign_lineage": False,
+                "why_or_why_not": (
+                    "structured_legacy_validation_rows_found_but_current_first_batch_daily_lineage_and_oos_proof_remain_unproven"
+                    if found_paths
+                    else "stdout_trace_exists_but_structured_validation_outputs_were_not_found"
+                ),
+            }
+        )
+    locator_rows.sort(key=lambda row: row["stdout_trace_path"])
+    return {
+        "rows": locator_rows,
+        "trace_count": len(locator_rows),
+        "structured_result_trace_count": sum(bool(row["found_result_paths"]) for row in locator_rows),
+    }
+
+
 def _phase_one_rows(repo_root: Path) -> list[dict[str, Any]]:
     rows = [classify_artifact(path, repo_root=repo_root) for path in _iter_allowlisted_files(repo_root)]
     filtered = [
@@ -400,6 +528,7 @@ def build_first_batch_evidence_recovery_cascade(
     )
     trusted_loop_report = trusted_loop.build_trusted_loop_review_packet(repo_root=repo_root)
     artifact_rows = _phase_one_rows(repo_root)
+    validation_locator = _locate_validation_results(repo_root, artifact_rows)
     counts = Counter(str(row["classification_status"]) for row in artifact_rows)
     closure_rows = closure_report.get("rows") if isinstance(closure_report.get("rows"), list) else []
     closure_by_symbol = {
@@ -429,16 +558,23 @@ def build_first_batch_evidence_recovery_cascade(
             }
         )
     files_scanned = sum(1 for _ in _iter_allowlisted_files(repo_root))
+    locator_rows = validation_locator["rows"]
+    current_top_blocker = (
+        "legacy_schema_bridge_or_alias_analysis_required"
+        if any(row["found_result_paths"] for row in locator_rows)
+        else "legacy_results_missing"
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
-        "overall_result": "IN_PROGRESS_PHASE_1",
+        "overall_result": "IN_PROGRESS_PHASE_2",
         "first_batch_summary": {
             "first_batch": list(FIRST_BATCH_SYMBOLS),
             "second_line": list(SECOND_LINE_SYMBOLS),
             "evidence_complete_count": int((closure_report.get("summary") or {}).get("evidence_complete_count") or 0),
             "unknown_blocker_count": int((closure_report.get("summary") or {}).get("unknown_blocker_count") or 0),
             "trusted_loop_verdict": str((trusted_loop_report.get("summary") or {}).get("trust_verdict") or ""),
+            "current_top_blocker": current_top_blocker,
             "top_blockers": {
                 symbol: list((closure_by_symbol.get(symbol, {}) or {}).get("exact_blockers") or [])
                 for symbol in FIRST_BATCH_SYMBOLS
@@ -451,6 +587,7 @@ def build_first_batch_evidence_recovery_cascade(
             "classification_counts": dict(sorted(counts.items())),
             "rows": artifact_rows,
         },
+        "validation_result_locator": validation_locator,
         "first_batch_candidates": first_batch_rows,
         "phase_reports": [
             {
@@ -464,6 +601,22 @@ def build_first_batch_evidence_recovery_cascade(
                     "classified_temp_fixture_report_registry_and_structured_legacy_artifacts",
                 ],
                 "why_continued_or_stopped": "continue_to_structured_result_location_if_legacy_candidates_exist",
+            },
+            {
+                "phase": "missing_validation_result_output_locator",
+                "result": "executed",
+                "blocker_before": "artifact_classification_completed_pending_result_location",
+                "blocker_after": current_top_blocker,
+                "artifacts_found": validation_locator["structured_result_trace_count"],
+                "actions_taken": [
+                    "matched_stdout_validation_traces_to_allowlisted_structured_history_outputs",
+                    "counted_expected_vs_found_validated_results",
+                ],
+                "why_continued_or_stopped": (
+                    "continue_to_bridge_and_alias_analysis"
+                    if current_top_blocker == "legacy_schema_bridge_or_alias_analysis_required"
+                    else "stop_if_only_stdout_trace_exists_without_structured_results"
+                ),
             }
         ],
         "current_stop_conditions": list(PHASE_ONE_STOP_CONDITIONS),
@@ -500,6 +653,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["candidate_artifacts", str(discovery.get("candidate_artifacts") or 0)],
                     ["evidence_complete_count", str(summary.get("evidence_complete_count") or 0)],
                     ["trusted_loop_verdict", str(summary.get("trusted_loop_verdict") or "")],
+                    ["current_top_blocker", str(summary.get("current_top_blocker") or "")],
                 ],
             ),
             "",
@@ -514,6 +668,22 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ]
                     for row in first_batch_rows
                 ],
+            ),
+            "",
+            "## 3. Validation locator",
+            _table(
+                ["Trace", "Expected", "Found", "Missing", "Schema status"],
+                [
+                    [
+                        str(row.get("stdout_trace_path") or ""),
+                        str(row.get("expected_result_count") or 0),
+                        str(row.get("found_result_count") or 0),
+                        str(row.get("missing_result_count") or 0),
+                        str(row.get("result_schema_status") or ""),
+                    ]
+                    for row in (report.get("validation_result_locator") or {}).get("rows", [])
+                ]
+                or [["none", "0", "0", "0", "none"]],
             ),
         ]
     )

--- a/research/qre_first_batch_evidence_recovery_cascade.py
+++ b/research/qre_first_batch_evidence_recovery_cascade.py
@@ -61,6 +61,16 @@ PHASE_ONE_STOP_CONDITIONS: Final[tuple[str, ...]] = (
     "stop_if_next_step_requires_mutating_campaign_or_registry_state",
     "stop_if_preset_or_timeframe_identity_cannot_be_proven_deterministically",
 )
+TARGET_PRESET_BY_SYMBOL: Final[dict[str, str]] = {
+    "AAPL": "trend_pullback_continuation_daily_v1",
+    "NVDA": "trend_pullback_continuation_daily_v1",
+    "TSM": "trend_pullback_continuation_daily_v1",
+}
+TARGET_TIMEFRAME_BY_SYMBOL: Final[dict[str, str]] = {
+    "AAPL": "daily_v1",
+    "NVDA": "daily_v1",
+    "TSM": "daily_v1",
+}
 AUTHORITY_BOUNDARY: Final[dict[str, Any]] = {
     "read_only_report_only": True,
     "not_campaign_launcher": True,
@@ -501,6 +511,67 @@ def _locate_validation_results(
     }
 
 
+def _analyze_legacy_compatibility(
+    repo_root: Path,
+    validation_locator: Mapping[str, Any],
+) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for locator_row in validation_locator.get("rows") or []:
+        if not isinstance(locator_row, Mapping):
+            continue
+        for relative_path in locator_row.get("found_result_paths") or []:
+            payload = _read_json_payload(repo_root / relative_path)
+            for candidate_row in _extract_validation_candidate_rows(payload):
+                symbol = str(candidate_row.get("asset") or "")
+                if symbol not in TARGET_SYMBOLS:
+                    continue
+                legacy_preset = str(candidate_row.get("strategy_name") or "")
+                legacy_timeframe = str(candidate_row.get("interval") or "")
+                target_preset = TARGET_PRESET_BY_SYMBOL.get(symbol, "")
+                target_timeframe = TARGET_TIMEFRAME_BY_SYMBOL.get(symbol, "")
+                preset_outcome = (
+                    "alias_allowed_for_context_only"
+                    if legacy_preset == "trend_pullback_v1" and target_preset == "trend_pullback_continuation_daily_v1"
+                    else "alias_blocked_no_policy"
+                )
+                timeframe_outcome = (
+                    "alias_blocked_timeframe_mismatch"
+                    if legacy_timeframe == "4h" and target_timeframe == "daily_v1"
+                    else "alias_blocked_no_policy"
+                )
+                rows.append(
+                    {
+                        "symbol": symbol,
+                        "legacy_result_path": relative_path,
+                        "legacy_preset_id": legacy_preset,
+                        "target_preset_id": target_preset,
+                        "legacy_timeframe": legacy_timeframe,
+                        "target_timeframe": target_timeframe,
+                        "preset_alias_outcome": preset_outcome,
+                        "timeframe_alias_outcome": timeframe_outcome,
+                        "campaign_lineage_eligible": False,
+                        "oos_context_eligible": False,
+                        "bridge_status": "context_only_bridge_available",
+                        "result": (
+                            "legacy_result_can_inform_context_but_cannot_prove_current_daily_lineage_or_oos"
+                        ),
+                    }
+                )
+    rows.sort(key=lambda row: (row["symbol"], row["legacy_result_path"]))
+    return {
+        "rows": rows,
+        "alias_policy": "legacy_compatible_for_context_only",
+        "bridge_status": "context_only_bridge_available" if rows else "no_bridgeable_structured_results_found",
+        "result": (
+            "PRESET_TIMEFRAME_ALIAS_BLOCKED"
+            if any(row["timeframe_alias_outcome"] == "alias_blocked_timeframe_mismatch" for row in rows)
+            else "LEGACY_RESULTS_FOUND_BRIDGE_REQUIRED"
+            if rows
+            else "LEGACY_STDOUT_ONLY_RESULTS_MISSING"
+        ),
+    }
+
+
 def _phase_one_rows(repo_root: Path) -> list[dict[str, Any]]:
     rows = [classify_artifact(path, repo_root=repo_root) for path in _iter_allowlisted_files(repo_root)]
     filtered = [
@@ -529,6 +600,7 @@ def build_first_batch_evidence_recovery_cascade(
     trusted_loop_report = trusted_loop.build_trusted_loop_review_packet(repo_root=repo_root)
     artifact_rows = _phase_one_rows(repo_root)
     validation_locator = _locate_validation_results(repo_root, artifact_rows)
+    legacy_compatibility = _analyze_legacy_compatibility(repo_root, validation_locator)
     counts = Counter(str(row["classification_status"]) for row in artifact_rows)
     closure_rows = closure_report.get("rows") if isinstance(closure_report.get("rows"), list) else []
     closure_by_symbol = {
@@ -559,15 +631,16 @@ def build_first_batch_evidence_recovery_cascade(
         )
     files_scanned = sum(1 for _ in _iter_allowlisted_files(repo_root))
     locator_rows = validation_locator["rows"]
-    current_top_blocker = (
-        "legacy_schema_bridge_or_alias_analysis_required"
-        if any(row["found_result_paths"] for row in locator_rows)
-        else "legacy_results_missing"
-    )
+    if legacy_compatibility["result"] == "PRESET_TIMEFRAME_ALIAS_BLOCKED":
+        current_top_blocker = "preset_timeframe_alias_unproven"
+    elif any(row["found_result_paths"] for row in locator_rows):
+        current_top_blocker = "legacy_schema_bridge_or_alias_analysis_required"
+    else:
+        current_top_blocker = "legacy_results_missing"
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
-        "overall_result": "IN_PROGRESS_PHASE_2",
+        "overall_result": legacy_compatibility["result"],
         "first_batch_summary": {
             "first_batch": list(FIRST_BATCH_SYMBOLS),
             "second_line": list(SECOND_LINE_SYMBOLS),
@@ -588,6 +661,7 @@ def build_first_batch_evidence_recovery_cascade(
             "rows": artifact_rows,
         },
         "validation_result_locator": validation_locator,
+        "legacy_compatibility": legacy_compatibility,
         "first_batch_candidates": first_batch_rows,
         "phase_reports": [
             {
@@ -617,8 +691,31 @@ def build_first_batch_evidence_recovery_cascade(
                     if current_top_blocker == "legacy_schema_bridge_or_alias_analysis_required"
                     else "stop_if_only_stdout_trace_exists_without_structured_results"
                 ),
+            },
+            {
+                "phase": "legacy_schema_bridge_and_alias_analysis",
+                "result": legacy_compatibility["result"],
+                "blocker_before": "legacy_schema_bridge_or_alias_analysis_required",
+                "blocker_after": current_top_blocker,
+                "artifacts_found": len(legacy_compatibility["rows"]),
+                "actions_taken": [
+                    "normalized_legacy_first_batch_validation_rows_for_context_only",
+                    "blocked_direct_preset_and_timeframe_alias_for_current_daily_lineage",
+                ],
+                "why_continued_or_stopped": (
+                    "stop_at_preset_timeframe_boundary"
+                    if current_top_blocker == "preset_timeframe_alias_unproven"
+                    else "continue_if_further_safe_context_integration_is_available"
+                ),
             }
         ],
+        "fundamental_stop_condition": (
+            "preset_timeframe_alias_unproven"
+            if current_top_blocker == "preset_timeframe_alias_unproven"
+            else "legacy_results_missing"
+            if current_top_blocker == "legacy_results_missing"
+            else "operator_decision_required"
+        ),
         "current_stop_conditions": list(PHASE_ONE_STOP_CONDITIONS),
         "authority_boundary": dict(AUTHORITY_BOUNDARY),
         "safety_invariants": {
@@ -684,6 +781,23 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     for row in (report.get("validation_result_locator") or {}).get("rows", [])
                 ]
                 or [["none", "0", "0", "0", "none"]],
+            ),
+            "",
+            "## 4. Legacy compatibility",
+            _table(
+                ["Symbol", "Legacy preset", "Target preset", "Legacy tf", "Target tf", "Result"],
+                [
+                    [
+                        str(row.get("symbol") or ""),
+                        str(row.get("legacy_preset_id") or ""),
+                        str(row.get("target_preset_id") or ""),
+                        str(row.get("legacy_timeframe") or ""),
+                        str(row.get("target_timeframe") or ""),
+                        str(row.get("result") or ""),
+                    ]
+                    for row in (report.get("legacy_compatibility") or {}).get("rows", [])
+                ]
+                or [["none", "-", "-", "-", "-", "none"]],
             ),
         ]
     )

--- a/research/qre_first_batch_evidence_recovery_cascade.py
+++ b/research/qre_first_batch_evidence_recovery_cascade.py
@@ -12,7 +12,6 @@ from typing import Any, Final
 
 from research import qre_evidence_complete_basket_closure as closure
 from research import qre_first_batch_evidence_recovery_readiness as readiness
-from research import qre_trusted_loop_review_packet as trusted_loop
 
 
 REPORT_KIND: Final[str] = "qre_first_batch_evidence_recovery_cascade"
@@ -21,6 +20,7 @@ DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_first_batch_evidence_recovery_c
 LATEST_NAME: Final[str] = "latest.json"
 OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
 WRITE_PREFIX: Final[str] = "logs/qre_first_batch_evidence_recovery_cascade/"
+TRUSTED_LOOP_PATH: Final[Path] = Path("logs/qre_trusted_loop_review/latest.json")
 
 FIRST_BATCH_SYMBOLS: Final[tuple[str, ...]] = ("AAPL", "NVDA")
 SECOND_LINE_SYMBOLS: Final[tuple[str, ...]] = ("TSM",)
@@ -140,6 +140,11 @@ def _read_json_payload(path: Path) -> Any | None:
         return json.loads(text)
     except json.JSONDecodeError:
         return None
+
+
+def _read_json_mapping(path: Path) -> dict[str, Any] | None:
+    payload = _read_json_payload(path)
+    return payload if isinstance(payload, dict) else None
 
 
 def _read_csv_rows(path: Path) -> list[dict[str, str]] | None:
@@ -279,13 +284,15 @@ def classify_artifact(path: Path, *, repo_root: Path = Path(".")) -> dict[str, A
         structured_value if structured_value else text,
         ("source_artifact", "source_row_id", "run_manifest_id", "validation_plan_id", "campaign_id"),
     )
-    stdout_only = isinstance(payload, Mapping) and "stdout_tail" in payload and not any(
-        key in payload for key in ("results", "validation_results", "rows", "candidates")
-    )
     has_structured_results = bool(
         (isinstance(payload, Mapping) and any(key in payload for key in ("rows", "candidates", "batches", "validation", "summary")))
         or isinstance(payload, list)
         or (csv_rows is not None and len(csv_rows) > 0)
+    )
+    stdout_only = bool(
+        payload is not None
+        and _contains_any(structured_value if structured_value else text, ("stdout_tail", "results_written=", "validated_count="))
+        and not has_structured_results
     )
     schema_family = _infer_schema_family(payload, text)
     schema_version = _infer_schema_version(payload)
@@ -304,16 +311,16 @@ def classify_artifact(path: Path, *, repo_root: Path = Path(".")) -> dict[str, A
     elif root_type == "test_fixture":
         classification_status = "test_fixture_not_authoritative"
         rejection_reason = "fixture_root_not_authoritative"
+    elif stdout_only:
+        classification_status = "legacy_validation_stdout_only"
+        rejection_reason = "stdout_tail_without_structured_results"
+        recommended_next_action = "locate_structured_validation_results"
     elif artifact_kind == "generated_report" or schema_family in GENERATED_REPORT_MARKERS:
         classification_status = "generated_report_not_source_artifact"
         rejection_reason = "report_is_derived_not_source_evidence"
     elif artifact_kind == "campaign_registry_snapshot":
         classification_status = "registry_snapshot_not_lineage_proof"
         rejection_reason = "registry_snapshot_cannot_prove_lineage_alone"
-    elif stdout_only:
-        classification_status = "legacy_validation_stdout_only"
-        rejection_reason = "stdout_tail_without_structured_results"
-        recommended_next_action = "locate_structured_validation_results"
     elif artifact_kind == "legacy_campaign_manifest" and contains_campaign_id and contains_run_id:
         classification_status = "legacy_validation_evidence_candidate"
         safe_to_restore_copy_only = True
@@ -597,7 +604,7 @@ def build_first_batch_evidence_recovery_cascade(
         repo_root=repo_root,
         max_candidates=max_candidates,
     )
-    trusted_loop_report = trusted_loop.build_trusted_loop_review_packet(repo_root=repo_root)
+    trusted_loop_report = _read_json_mapping(repo_root / TRUSTED_LOOP_PATH) or {}
     artifact_rows = _phase_one_rows(repo_root)
     validation_locator = _locate_validation_results(repo_root, artifact_rows)
     legacy_compatibility = _analyze_legacy_compatibility(repo_root, validation_locator)

--- a/research/qre_first_batch_evidence_recovery_cascade.py
+++ b/research/qre_first_batch_evidence_recovery_cascade.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_evidence_complete_basket_closure as closure
+from research import qre_first_batch_evidence_recovery_readiness as readiness
+from research import qre_trusted_loop_review_packet as trusted_loop
+
+
+REPORT_KIND: Final[str] = "qre_first_batch_evidence_recovery_cascade"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_first_batch_evidence_recovery_cascade")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_first_batch_evidence_recovery_cascade/"
+
+FIRST_BATCH_SYMBOLS: Final[tuple[str, ...]] = ("AAPL", "NVDA")
+SECOND_LINE_SYMBOLS: Final[tuple[str, ...]] = ("TSM",)
+TARGET_SYMBOLS: Final[frozenset[str]] = frozenset((*FIRST_BATCH_SYMBOLS, *SECOND_LINE_SYMBOLS))
+TARGET_PRESETS: Final[tuple[str, ...]] = (
+    "trend_pullback_v1",
+    "trend_pullback_continuation_daily_v1",
+    "trend_pullback_equities_4h",
+)
+TARGET_TIMEFRAMES: Final[tuple[str, ...]] = ("4h", "1d", "daily", "daily_v1")
+ALLOWLISTED_ROOTS: Final[tuple[str, ...]] = (
+    "logs",
+    "research",
+    "local_quarantine",
+    "backup",
+    "archived",
+    "artifacts",
+    ".tmp",
+    "tests/fixtures",
+)
+PROTECTED_DIRS: Final[frozenset[str]] = frozenset(
+    {
+        ".git",
+        ".venv",
+        "node_modules",
+        "dist",
+        "build",
+        "live",
+        "paper",
+        "shadow",
+        "broker",
+        "risk",
+        "execution",
+    }
+)
+PHASE_ONE_STOP_CONDITIONS: Final[tuple[str, ...]] = (
+    "stop_if_only_stdout_or_generated_reports_exist_without_structured_results",
+    "stop_if_next_step_requires_mutating_campaign_or_registry_state",
+    "stop_if_preset_or_timeframe_identity_cannot_be_proven_deterministically",
+)
+AUTHORITY_BOUNDARY: Final[dict[str, Any]] = {
+    "read_only_report_only": True,
+    "not_campaign_launcher": True,
+    "not_campaign_queue_mutation": True,
+    "not_campaign_registry_mutation": True,
+    "not_run_campaign_mutation": True,
+    "not_broad_research_run": True,
+    "not_strategy_synthesis": True,
+    "not_strategy_registration": True,
+    "not_candidate_promotion": True,
+    "not_routing_mutation": True,
+    "not_sampling_mutation": True,
+    "not_paper_shadow_live": True,
+    "not_broker_risk_execution": True,
+    "not_provider_activation": True,
+    "not_external_data_fetch": True,
+    "not_frozen_contract_mutation": True,
+    "not_research_latest_mutation": True,
+    "not_strategy_matrix_mutation": True,
+}
+GENERATED_REPORT_MARKERS: Final[tuple[str, ...]] = (
+    "qre_first_batch_evidence_recovery_readiness",
+    "qre_discovery_basket_grid_evidence_materialization",
+    "qre_grid_candidate_campaign_lineage_bridge",
+    "qre_basket_lineage_recovery_diagnostics",
+    "qre_basket_operator_action_plan",
+    "qre_basket_next_action_queue",
+    "qre_evidence_complete_basket_closure",
+    "qre_trusted_loop_review",
+)
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def _read_json_payload(path: Path) -> Any | None:
+    if path.suffix.lower() not in {".json", ".jsonl"}:
+        return None
+    text = _read_text(path)
+    if not text.strip():
+        return None
+    if path.suffix.lower() == ".jsonl":
+        rows: list[Any] = []
+        for line in text.splitlines():
+            item = line.strip()
+            if not item:
+                continue
+            try:
+                rows.append(json.loads(item))
+            except json.JSONDecodeError:
+                return None
+        return rows
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]] | None:
+    if path.suffix.lower() != ".csv":
+        return None
+    try:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            return [dict(row) for row in csv.DictReader(handle)]
+    except OSError:
+        return None
+
+
+def _flatten_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, Mapping):
+        for item in value.values():
+            yield from _flatten_strings(item)
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _flatten_strings(item)
+
+
+def _symbol_matches(value: Any) -> list[str]:
+    text = " ".join(_flatten_strings(value))
+    return sorted(symbol for symbol in TARGET_SYMBOLS if symbol in text)
+
+
+def _preset_matches(value: Any) -> list[str]:
+    text = " ".join(_flatten_strings(value))
+    return sorted(preset for preset in TARGET_PRESETS if preset in text)
+
+
+def _timeframe_matches(value: Any) -> list[str]:
+    text = " ".join(_flatten_strings(value))
+    return sorted(timeframe for timeframe in TARGET_TIMEFRAMES if timeframe in text)
+
+
+def _contains_any(value: Any, terms: Sequence[str]) -> bool:
+    if isinstance(value, str):
+        text = value.lower()
+    else:
+        try:
+            text = json.dumps(value, default=str).lower()
+        except TypeError:
+            text = str(value).lower()
+    return any(term.lower() in text for term in terms)
+
+
+def _infer_schema_family(payload: Any, text: str) -> str:
+    if isinstance(payload, Mapping):
+        report_kind = str(payload.get("report_kind") or "")
+        if report_kind:
+            return report_kind
+        if "run_id" in payload and "candidates" in payload:
+            return "run_candidates"
+        if "run_id" in payload and "batch_id" in payload:
+            return "run_batch_manifest"
+        if "campaign_id" in payload and "batches" in payload:
+            return "run_campaign_manifest"
+    if isinstance(payload, list):
+        return "jsonl_rows"
+    lowered = text.lower()
+    if "stdout_tail" in lowered:
+        return "legacy_stdout_trace"
+    return "unknown"
+
+
+def _infer_schema_version(payload: Any) -> str:
+    if isinstance(payload, Mapping):
+        for field in ("schema_version", "version"):
+            value = payload.get(field)
+            if value is not None:
+                return str(value)
+    return "unknown"
+
+
+def _root_type(relative_path: str) -> str:
+    for root in ALLOWLISTED_ROOTS:
+        normalized = root.replace("\\", "/").rstrip("/")
+        if relative_path == normalized or relative_path.startswith(normalized + "/"):
+            if normalized == ".tmp":
+                return "temp_smoke"
+            if normalized == "tests/fixtures":
+                return "test_fixture"
+            return normalized
+    return "unknown"
+
+
+def _artifact_kind(path: Path, payload: Any) -> str:
+    name = path.name.lower()
+    if "run_batch_state" in name:
+        return "legacy_validation_state"
+    if "run_batch_manifest" in name:
+        return "legacy_batch_manifest"
+    if "run_campaign_manifest" in name:
+        return "legacy_campaign_manifest"
+    if "run_candidates" in name:
+        return "legacy_candidate_results"
+    if "campaign_registry" in name:
+        return "campaign_registry_snapshot"
+    if "controlled_eval" in name:
+        return "controlled_validation_execution"
+    if "combination_results" in name or "execution_result" in name:
+        return "grid_execution_artifact"
+    if isinstance(payload, Mapping) and str(payload.get("report_kind") or "").startswith("qre_"):
+        return "generated_report"
+    return "unknown"
+
+
+def classify_artifact(path: Path, *, repo_root: Path = Path(".")) -> dict[str, Any]:
+    relative_path = path.relative_to(repo_root).as_posix()
+    root_type = _root_type(relative_path)
+    payload = _read_json_payload(path)
+    csv_rows = None if payload is not None else _read_csv_rows(path)
+    structured_value: Any = payload if payload is not None else csv_rows if csv_rows is not None else {}
+    text = _read_text(path)
+    artifact_kind = _artifact_kind(path, payload)
+    symbol_matches = _symbol_matches(structured_value if structured_value else text)
+    preset_matches = _preset_matches(structured_value if structured_value else text)
+    timeframe_matches = _timeframe_matches(structured_value if structured_value else text)
+    contains_candidate_id = _contains_any(structured_value if structured_value else text, ("candidate_id",))
+    contains_campaign_id = _contains_any(structured_value if structured_value else text, ("campaign_id", "col_campaign_id"))
+    contains_grid_run_id = _contains_any(structured_value if structured_value else text, ("grid_run_id", "grid_id"))
+    contains_run_id = _contains_any(structured_value if structured_value else text, ("run_id",))
+    contains_oos_fields = _contains_any(
+        structured_value if structured_value else text,
+        ("oos_trade_count", "oos_trades", "sufficient_oos_evidence", "no_oos_trades"),
+    )
+    contains_validation_fields = _contains_any(
+        structured_value if structured_value else text,
+        ("validated_count", "results_written", "validation", "result_success"),
+    )
+    contains_lineage_fields = _contains_any(
+        structured_value if structured_value else text,
+        ("source_artifact", "source_row_id", "run_manifest_id", "validation_plan_id", "campaign_id"),
+    )
+    stdout_only = isinstance(payload, Mapping) and "stdout_tail" in payload and not any(
+        key in payload for key in ("results", "validation_results", "rows", "candidates")
+    )
+    has_structured_results = bool(
+        (isinstance(payload, Mapping) and any(key in payload for key in ("rows", "candidates", "batches", "validation", "summary")))
+        or isinstance(payload, list)
+        or (csv_rows is not None and len(csv_rows) > 0)
+    )
+    schema_family = _infer_schema_family(payload, text)
+    schema_version = _infer_schema_version(payload)
+
+    classification_status = "irrelevant"
+    rejection_reason = ""
+    recommended_next_action = "keep_fail_closed"
+    safe_to_use_as_evidence = False
+    safe_to_restore_copy_only = False
+    operator_approval_required = False
+    downstream_expected_effect = "none"
+
+    if root_type == "temp_smoke":
+        classification_status = "smoke_temp_not_authoritative"
+        rejection_reason = "temp_smoke_root_not_authoritative"
+    elif root_type == "test_fixture":
+        classification_status = "test_fixture_not_authoritative"
+        rejection_reason = "fixture_root_not_authoritative"
+    elif artifact_kind == "generated_report" or schema_family in GENERATED_REPORT_MARKERS:
+        classification_status = "generated_report_not_source_artifact"
+        rejection_reason = "report_is_derived_not_source_evidence"
+    elif artifact_kind == "campaign_registry_snapshot":
+        classification_status = "registry_snapshot_not_lineage_proof"
+        rejection_reason = "registry_snapshot_cannot_prove_lineage_alone"
+    elif stdout_only:
+        classification_status = "legacy_validation_stdout_only"
+        rejection_reason = "stdout_tail_without_structured_results"
+        recommended_next_action = "locate_structured_validation_results"
+    elif artifact_kind == "legacy_campaign_manifest" and contains_campaign_id and contains_run_id:
+        classification_status = "legacy_validation_evidence_candidate"
+        safe_to_restore_copy_only = True
+        recommended_next_action = "locate_corresponding_symbol_level_validation_results"
+        downstream_expected_effect = "campaign_run_identity_available_for_safe_bridge_analysis"
+    elif symbol_matches and contains_validation_fields and has_structured_results:
+        if contains_campaign_id and contains_run_id:
+            classification_status = "legacy_validation_evidence_candidate"
+            safe_to_restore_copy_only = True
+            downstream_expected_effect = "legacy_validation_context_available_for_alias_analysis"
+            recommended_next_action = "analyze_schema_and_alias_compatibility"
+        else:
+            classification_status = "missing_required_identity_fields"
+            rejection_reason = "campaign_or_run_identity_missing"
+            recommended_next_action = "locate_more_complete_structured_artifact"
+    elif symbol_matches and has_structured_results:
+        classification_status = "restorable_candidate"
+        safe_to_restore_copy_only = True
+        recommended_next_action = "inspect_for_validation_and_lineage_fields"
+    elif not symbol_matches and artifact_kind == "legacy_candidate_results":
+        classification_status = "legacy_validation_results_missing"
+        rejection_reason = "results_written_context_present_but_first_batch_rows_not_found"
+        recommended_next_action = "continue_allowlisted_search"
+
+    return {
+        "path": str(path.resolve()),
+        "relative_path": relative_path,
+        "root_type": root_type,
+        "artifact_kind": artifact_kind,
+        "schema_family": schema_family,
+        "schema_version": schema_version,
+        "symbol_matches": symbol_matches,
+        "preset_matches": preset_matches,
+        "timeframe_matches": timeframe_matches,
+        "contains_candidate_id": contains_candidate_id,
+        "contains_campaign_id": contains_campaign_id,
+        "contains_grid_run_id": contains_grid_run_id,
+        "contains_run_id": contains_run_id,
+        "contains_oos_fields": contains_oos_fields,
+        "contains_validation_fields": contains_validation_fields,
+        "contains_lineage_fields": contains_lineage_fields,
+        "stdout_only": stdout_only,
+        "has_structured_results": has_structured_results,
+        "file_mtime": int(path.stat().st_mtime) if path.exists() else 0,
+        "file_size": int(path.stat().st_size) if path.exists() else 0,
+        "classification_status": classification_status,
+        "rejection_reason": rejection_reason,
+        "recommended_next_action": recommended_next_action,
+        "safe_to_use_as_evidence": safe_to_use_as_evidence,
+        "safe_to_restore_copy_only": safe_to_restore_copy_only,
+        "operator_approval_required": operator_approval_required,
+        "downstream_expected_effect": downstream_expected_effect,
+    }
+
+
+def _iter_allowlisted_files(repo_root: Path) -> Iterable[Path]:
+    for root in ALLOWLISTED_ROOTS:
+        base = repo_root / root
+        if not base.exists():
+            continue
+        if base.is_file():
+            yield base
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file():
+                continue
+            relative_parts = path.relative_to(repo_root).parts
+            if any(part in PROTECTED_DIRS for part in relative_parts):
+                continue
+            yield path
+
+
+def _phase_one_rows(repo_root: Path) -> list[dict[str, Any]]:
+    rows = [classify_artifact(path, repo_root=repo_root) for path in _iter_allowlisted_files(repo_root)]
+    filtered = [
+        row for row in rows
+        if row["classification_status"] != "irrelevant"
+        or row["symbol_matches"]
+        or row["artifact_kind"] in {"campaign_registry_snapshot", "generated_report", "controlled_validation_execution", "legacy_campaign_manifest"}
+    ]
+    filtered.sort(key=lambda row: (row["classification_status"], row["relative_path"]))
+    return filtered
+
+
+def build_first_batch_evidence_recovery_cascade(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    readiness_report = readiness.build_first_batch_evidence_recovery_readiness(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    closure_report = closure.build_evidence_complete_basket_closure(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    trusted_loop_report = trusted_loop.build_trusted_loop_review_packet(repo_root=repo_root)
+    artifact_rows = _phase_one_rows(repo_root)
+    counts = Counter(str(row["classification_status"]) for row in artifact_rows)
+    closure_rows = closure_report.get("rows") if isinstance(closure_report.get("rows"), list) else []
+    closure_by_symbol = {
+        str(row.get("symbol") or ""): dict(row)
+        for row in closure_rows
+        if isinstance(row, Mapping)
+    }
+    first_batch_rows = []
+    for symbol in FIRST_BATCH_SYMBOLS:
+        closure_row = closure_by_symbol.get(symbol, {})
+        first_batch_rows.append(
+            {
+                "symbol": symbol,
+                "before_blockers": list(closure_row.get("exact_blockers") or []),
+                "artifact_signals": [
+                    {
+                        "relative_path": row["relative_path"],
+                        "classification_status": row["classification_status"],
+                        "preset_matches": row["preset_matches"],
+                        "timeframe_matches": row["timeframe_matches"],
+                    }
+                    for row in artifact_rows
+                    if symbol in row["symbol_matches"]
+                ][:10],
+                "stop_conditions": list(PHASE_ONE_STOP_CONDITIONS),
+                "authority_boundary": dict(AUTHORITY_BOUNDARY),
+            }
+        )
+    files_scanned = sum(1 for _ in _iter_allowlisted_files(repo_root))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "overall_result": "IN_PROGRESS_PHASE_1",
+        "first_batch_summary": {
+            "first_batch": list(FIRST_BATCH_SYMBOLS),
+            "second_line": list(SECOND_LINE_SYMBOLS),
+            "evidence_complete_count": int((closure_report.get("summary") or {}).get("evidence_complete_count") or 0),
+            "unknown_blocker_count": int((closure_report.get("summary") or {}).get("unknown_blocker_count") or 0),
+            "trusted_loop_verdict": str((trusted_loop_report.get("summary") or {}).get("trust_verdict") or ""),
+            "top_blockers": {
+                symbol: list((closure_by_symbol.get(symbol, {}) or {}).get("exact_blockers") or [])
+                for symbol in FIRST_BATCH_SYMBOLS
+            },
+        },
+        "artifact_discovery": {
+            "phase": "controlled_grid_artifact_discovery_classifier",
+            "files_scanned": files_scanned,
+            "candidate_artifacts": len(artifact_rows),
+            "classification_counts": dict(sorted(counts.items())),
+            "rows": artifact_rows,
+        },
+        "first_batch_candidates": first_batch_rows,
+        "phase_reports": [
+            {
+                "phase": "controlled_grid_artifact_discovery_classifier",
+                "result": "executed",
+                "blocker_before": "campaign_lineage_missing,no_oos_evidence",
+                "blocker_after": "artifact_classification_completed_pending_result_location",
+                "artifacts_found": len(artifact_rows),
+                "actions_taken": [
+                    "scanned_allowlisted_local_roots",
+                    "classified_temp_fixture_report_registry_and_structured_legacy_artifacts",
+                ],
+                "why_continued_or_stopped": "continue_to_structured_result_location_if_legacy_candidates_exist",
+            }
+        ],
+        "current_stop_conditions": list(PHASE_ONE_STOP_CONDITIONS),
+        "authority_boundary": dict(AUTHORITY_BOUNDARY),
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_campaigns": False,
+            "mutates_queues": False,
+            "mutates_frozen_contracts": False,
+            "does_not_change_evidence_complete_count": True,
+            "does_not_change_trusted_loop_level_without_real_evidence": True,
+        },
+        "upstream_context": {
+            "readiness_report_kind": readiness_report.get("report_kind"),
+            "readiness_first_batch": (readiness_report.get("first_batch_summary") or {}).get("first_batch") or [],
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    discovery = report.get("artifact_discovery") if isinstance(report.get("artifact_discovery"), Mapping) else {}
+    summary = report.get("first_batch_summary") if isinstance(report.get("first_batch_summary"), Mapping) else {}
+    first_batch_rows = report.get("first_batch_candidates") if isinstance(report.get("first_batch_candidates"), list) else []
+    return "\n".join(
+        [
+            "# QRE First-Batch Evidence Recovery Cascade",
+            "",
+            "## 1. Summary",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["first_batch", ", ".join(str(v) for v in summary.get("first_batch") or []) or "none"],
+                    ["files_scanned", str(discovery.get("files_scanned") or 0)],
+                    ["candidate_artifacts", str(discovery.get("candidate_artifacts") or 0)],
+                    ["evidence_complete_count", str(summary.get("evidence_complete_count") or 0)],
+                    ["trusted_loop_verdict", str(summary.get("trusted_loop_verdict") or "")],
+                ],
+            ),
+            "",
+            "## 2. First batch candidates",
+            _table(
+                ["Symbol", "Before blockers", "Artifact signals"],
+                [
+                    [
+                        str(row.get("symbol") or ""),
+                        ",".join(str(v) for v in row.get("before_blockers") or []) or "none",
+                        str(len(row.get("artifact_signals") or [])),
+                    ]
+                    for row in first_batch_rows
+                ],
+            ),
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_first_batch_evidence_recovery_cascade: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_first_batch_evidence_recovery_cascade",
+        description="Build the read-only first-batch evidence recovery cascade report.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_first_batch_evidence_recovery_cascade(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -20,6 +20,7 @@ from typing import Any, Final
 from reporting import qre_trusted_loop_readiness as trusted_readiness
 from research import qre_evidence_complete_basket_closure as basket_closure
 from research import qre_failure_action_from_basket as failure_action
+from research import qre_first_batch_evidence_recovery_cascade as first_batch_cascade
 from research import qre_first_batch_evidence_recovery_readiness as first_batch_readiness
 from research import qre_basket_operator_action_plan as basket_action_plan
 from research import qre_reason_records_v1 as reason_records
@@ -113,6 +114,11 @@ REPORT_SURFACES: tuple[dict[str, str], ...] = (
         "purpose": "bounded first-batch evidence recovery readiness plan",
     },
     {
+        "report_kind": "qre_first_batch_evidence_recovery_cascade",
+        "path_hint": "logs/qre_first_batch_evidence_recovery_cascade/",
+        "purpose": "bounded first-batch recovery cascade with legacy artifact boundary analysis",
+    },
+    {
         "report_kind": "qre_trusted_loop_review_packet",
         "path_hint": "logs/qre_trusted_loop_review/",
         "purpose": "final trusted-loop operator review packet",
@@ -203,6 +209,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     first_batch_readiness_packet = first_batch_readiness.build_first_batch_evidence_recovery_readiness(
         repo_root=repo_root
     )
+    first_batch_cascade_packet = first_batch_cascade.build_first_batch_evidence_recovery_cascade(
+        repo_root=repo_root
+    )
 
     protected_artifacts = [
         _path_state(repo_root, "research/research_latest.json"),
@@ -258,6 +267,12 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             ),
             "first_batch_readiness_available": str(first_batch_readiness_packet.get("report_kind") or "")
             == "qre_first_batch_evidence_recovery_readiness",
+            "first_batch_recovery_cascade_available": str(first_batch_cascade_packet.get("report_kind") or "")
+            == "qre_first_batch_evidence_recovery_cascade",
+            "first_batch_recovery_cascade_result": str(first_batch_cascade_packet.get("overall_result") or ""),
+            "first_batch_recovery_cascade_top_blocker": str(
+                (first_batch_cascade_packet.get("first_batch_summary") or {}).get("current_top_blocker") or ""
+            ),
             "contradiction_visibility": (
                 readiness_summary.get("contradiction_visibility")
                 if isinstance(readiness_summary.get("contradiction_visibility"), Mapping)
@@ -292,6 +307,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "failure_action": failure_packet,
             "basket_closure": closure_packet,
             "first_batch_readiness": first_batch_readiness_packet,
+            "first_batch_recovery_cascade": first_batch_cascade_packet,
             "routing_calibration": routing_packet,
             "sampling_calibration": sampling_packet,
             "research_memory": memory_packet,

--- a/tests/unit/test_qre_basket_operator_action_plan.py
+++ b/tests/unit/test_qre_basket_operator_action_plan.py
@@ -112,6 +112,15 @@ def test_operator_action_plan_prioritizes_aapl_and_nvda_first_batch(tmp_path: Pa
             "first_batch_summary": {"first_batch": ["AAPL", "NVDA"]},
         },
     )
+    monkeypatch.setattr(
+        action_plan.first_batch_cascade,
+        "build_first_batch_evidence_recovery_cascade",
+        lambda **_: {
+            "report_kind": "qre_first_batch_evidence_recovery_cascade",
+            "overall_result": "PRESET_TIMEFRAME_ALIAS_BLOCKED",
+            "first_batch_summary": {"current_top_blocker": "preset_timeframe_alias_unproven"},
+        },
+    )
 
     report = action_plan.build_basket_operator_action_plan(repo_root=tmp_path, max_candidates=3)
 
@@ -131,6 +140,8 @@ def test_operator_action_plan_prioritizes_aapl_and_nvda_first_batch(tmp_path: Pa
     assert any("registration" in item for item in report["commands_not_allowed"])
     assert report["safe_commands_to_run_manually"][0] == "python -m research.qre_basket_evidence_density_materialization --write"
     assert report["summary"]["first_batch_readiness_available"] is True
+    assert report["summary"]["first_batch_recovery_cascade_available"] is True
+    assert report["summary"]["first_batch_recovery_cascade_result"] == "PRESET_TIMEFRAME_ALIAS_BLOCKED"
 
 
 def test_operator_action_plan_write_outputs_stays_allowlisted(tmp_path: Path, monkeypatch) -> None:
@@ -140,6 +151,11 @@ def test_operator_action_plan_write_outputs_stays_allowlisted(tmp_path: Path, mo
         action_plan.first_batch_readiness,
         "build_first_batch_evidence_recovery_readiness",
         lambda **_: {"report_kind": "qre_first_batch_evidence_recovery_readiness", "first_batch_summary": {"first_batch": []}},
+    )
+    monkeypatch.setattr(
+        action_plan.first_batch_cascade,
+        "build_first_batch_evidence_recovery_cascade",
+        lambda **_: {"report_kind": "qre_first_batch_evidence_recovery_cascade", "first_batch_summary": {}, "overall_result": "PRESET_TIMEFRAME_ALIAS_BLOCKED"},
     )
 
     report = action_plan.build_basket_operator_action_plan(repo_root=tmp_path, max_candidates=1)

--- a/tests/unit/test_qre_first_batch_evidence_recovery_cascade.py
+++ b/tests/unit/test_qre_first_batch_evidence_recovery_cascade.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_first_batch_evidence_recovery_cascade as cascade
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_repo(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_controlled_validation_execution" / "controlled_eval_latest.v1.json",
+        {
+            "stdout_tail": "validation progress AAPL 4h NVDA 4h TSM 4h validated_count=6 results_written=6",
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "history" / "20260604T170735770553Z" / "run_candidates.v1.json",
+        {
+            "run_id": "20260604T170735770553Z",
+            "summary": {"validated_count": 6},
+            "candidates": [
+                {
+                    "candidate_id": "cand-aapl",
+                    "asset": "AAPL",
+                    "interval": "4h",
+                    "strategy_name": "trend_pullback_v1",
+                    "validation": {"evidence_status": "no_oos_trades"},
+                },
+                {
+                    "candidate_id": "cand-nvda",
+                    "asset": "NVDA",
+                    "interval": "4h",
+                    "strategy_name": "trend_pullback_v1",
+                    "validation": {"evidence_status": "no_oos_trades"},
+                },
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "history" / "20260604T170735770553Z" / "run_campaign_manifest.v1.json",
+        {
+            "campaign_id": "campaign-20260604T170735770553Z",
+            "run_id": "20260604T170735770553Z",
+            "col_campaign_id": "col-20260604T190732878212Z-trend_pullback_equities_4h-74e2345880",
+            "batches": [{"batch_id": "batch-trend_pullback-4h-104ec37e"}],
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "campaigns": {
+                "col-20260605T122346491432Z-trend_pullback_equities_4h-b68c030d9c": {
+                    "campaign_id": "col-20260605T122346491432Z-trend_pullback_equities_4h-b68c030d9c",
+                    "universe": ["AAPL", "NVDA", "TSM"],
+                }
+            }
+        },
+    )
+    _write_json(
+        tmp_path / ".tmp" / "qre_grid_smoke_complete" / "combination_results.v1.jsonl",
+        [
+            {
+                "run_id": "qre_grid_smoke_complete",
+                "instrument_symbol": "ADYEN",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+            }
+        ],
+    )
+    _write_json(
+        tmp_path / "tests" / "fixtures" / "qre_controlled_validation" / "equities_exploratory_v1_blocker_diagnosis.json",
+        {"rows": [{"asset": "AAPL", "interval": "4h", "strategy_name": "trend_pullback_v1"}]},
+    )
+    _write_json(tmp_path / "research" / "research_latest.json", {"report_kind": "seed"})
+    (tmp_path / "research" / "strategy_matrix.csv").write_text("seed\n", encoding="utf-8")
+
+
+def _stub_upstream(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cascade.readiness,
+        "build_first_batch_evidence_recovery_readiness",
+        lambda **_: {"report_kind": "qre_first_batch_evidence_recovery_readiness", "first_batch_summary": {"first_batch": ["AAPL", "NVDA"]}},
+    )
+    monkeypatch.setattr(
+        cascade.closure,
+        "build_evidence_complete_basket_closure",
+        lambda **_: {
+            "summary": {"evidence_complete_count": 0, "unknown_blocker_count": 0},
+            "rows": [
+                {"symbol": "AAPL", "exact_blockers": ["campaign_lineage_missing", "no_oos_evidence"]},
+                {"symbol": "NVDA", "exact_blockers": ["campaign_lineage_missing", "no_oos_evidence"]},
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        cascade.trusted_loop,
+        "build_trusted_loop_review_packet",
+        lambda **_: {"summary": {"trust_verdict": "read_only_context_fail_closed", "trust_level": "1"}},
+    )
+
+
+def test_phase_one_artifact_classification_is_deterministic_and_fail_closed(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    _stub_upstream(monkeypatch)
+
+    first = cascade.build_first_batch_evidence_recovery_cascade(repo_root=tmp_path)
+    second = cascade.build_first_batch_evidence_recovery_cascade(repo_root=tmp_path)
+
+    assert first == second
+    assert first["first_batch_summary"]["first_batch"] == ["AAPL", "NVDA"]
+    assert first["first_batch_summary"]["evidence_complete_count"] == 0
+    assert first["first_batch_summary"]["trusted_loop_verdict"] == "read_only_context_fail_closed"
+    assert first["safety_invariants"]["does_not_change_evidence_complete_count"] is True
+
+    rows = {row["relative_path"]: row for row in first["artifact_discovery"]["rows"]}
+    assert rows[".tmp/qre_grid_smoke_complete/combination_results.v1.jsonl"]["classification_status"] == "smoke_temp_not_authoritative"
+    assert rows["tests/fixtures/qre_controlled_validation/equities_exploratory_v1_blocker_diagnosis.json"]["classification_status"] == "test_fixture_not_authoritative"
+    assert rows["research/campaign_registry_latest.v1.json"]["classification_status"] == "registry_snapshot_not_lineage_proof"
+    assert rows["logs/qre_controlled_validation_execution/controlled_eval_latest.v1.json"]["classification_status"] == "legacy_validation_stdout_only"
+    assert rows["research/history/20260604T170735770553Z/run_candidates.v1.json"]["classification_status"] == "missing_required_identity_fields"
+    assert rows["research/history/20260604T170735770553Z/run_campaign_manifest.v1.json"]["classification_status"] == "legacy_validation_evidence_candidate"
+
+
+def test_generated_reports_are_not_treated_as_source_artifacts(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    _stub_upstream(monkeypatch)
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {"report_kind": "qre_discovery_basket_grid_evidence_materialization", "rows": [{"asset": "AAPL"}]},
+    )
+
+    report = cascade.build_first_batch_evidence_recovery_cascade(repo_root=tmp_path)
+    rows = {row["relative_path"]: row for row in report["artifact_discovery"]["rows"]}
+
+    assert rows["logs/qre_discovery_basket_grid_evidence_materialization/latest.json"]["classification_status"] == "generated_report_not_source_artifact"
+
+
+def test_write_outputs_stays_allowlisted(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    _stub_upstream(monkeypatch)
+
+    report = cascade.build_first_batch_evidence_recovery_cascade(repo_root=tmp_path)
+    paths = cascade.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_first_batch_evidence_recovery_cascade/latest.json"
+    assert paths["operator_summary"] == "logs/qre_first_batch_evidence_recovery_cascade/operator_summary.md"
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()

--- a/tests/unit/test_qre_first_batch_evidence_recovery_cascade.py
+++ b/tests/unit/test_qre_first_batch_evidence_recovery_cascade.py
@@ -64,6 +64,10 @@ def _seed_repo(tmp_path: Path) -> None:
         },
     )
     _write_json(
+        tmp_path / "logs" / "qre_trusted_loop_review" / "latest.json",
+        {"summary": {"trust_verdict": "read_only_context_fail_closed", "trust_level": "1"}},
+    )
+    _write_json(
         tmp_path / ".tmp" / "qre_grid_smoke_complete" / "combination_results.v1.jsonl",
         [
             {
@@ -97,11 +101,6 @@ def _stub_upstream(monkeypatch) -> None:
                 {"symbol": "NVDA", "exact_blockers": ["campaign_lineage_missing", "no_oos_evidence"]},
             ],
         },
-    )
-    monkeypatch.setattr(
-        cascade.trusted_loop,
-        "build_trusted_loop_review_packet",
-        lambda **_: {"summary": {"trust_verdict": "read_only_context_fail_closed", "trust_level": "1"}},
     )
 
 

--- a/tests/unit/test_qre_first_batch_evidence_recovery_cascade.py
+++ b/tests/unit/test_qre_first_batch_evidence_recovery_cascade.py
@@ -116,7 +116,8 @@ def test_phase_one_artifact_classification_is_deterministic_and_fail_closed(tmp_
     assert first["first_batch_summary"]["first_batch"] == ["AAPL", "NVDA"]
     assert first["first_batch_summary"]["evidence_complete_count"] == 0
     assert first["first_batch_summary"]["trusted_loop_verdict"] == "read_only_context_fail_closed"
-    assert first["first_batch_summary"]["current_top_blocker"] == "legacy_schema_bridge_or_alias_analysis_required"
+    assert first["first_batch_summary"]["current_top_blocker"] == "preset_timeframe_alias_unproven"
+    assert first["overall_result"] == "PRESET_TIMEFRAME_ALIAS_BLOCKED"
     assert first["safety_invariants"]["does_not_change_evidence_complete_count"] is True
 
     rows = {row["relative_path"]: row for row in first["artifact_discovery"]["rows"]}
@@ -135,6 +136,12 @@ def test_phase_one_artifact_classification_is_deterministic_and_fail_closed(tmp_
     assert locator[0]["can_use_as_oos_evidence"] is False
     assert locator[0]["can_use_as_campaign_lineage"] is False
     assert locator[0]["result_schema_status"] == "structured_validation_results_found"
+
+    compatibility = {row["symbol"]: row for row in first["legacy_compatibility"]["rows"]}
+    assert compatibility["AAPL"]["preset_alias_outcome"] == "alias_allowed_for_context_only"
+    assert compatibility["AAPL"]["timeframe_alias_outcome"] == "alias_blocked_timeframe_mismatch"
+    assert compatibility["AAPL"]["campaign_lineage_eligible"] is False
+    assert compatibility["NVDA"]["target_preset_id"] == "trend_pullback_continuation_daily_v1"
 
 
 def test_generated_reports_are_not_treated_as_source_artifacts(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_qre_first_batch_evidence_recovery_cascade.py
+++ b/tests/unit/test_qre_first_batch_evidence_recovery_cascade.py
@@ -26,6 +26,7 @@ def _seed_repo(tmp_path: Path) -> None:
             "candidates": [
                 {
                     "candidate_id": "cand-aapl",
+                    "current_status": "validated",
                     "asset": "AAPL",
                     "interval": "4h",
                     "strategy_name": "trend_pullback_v1",
@@ -33,6 +34,7 @@ def _seed_repo(tmp_path: Path) -> None:
                 },
                 {
                     "candidate_id": "cand-nvda",
+                    "current_status": "validated",
                     "asset": "NVDA",
                     "interval": "4h",
                     "strategy_name": "trend_pullback_v1",
@@ -114,6 +116,7 @@ def test_phase_one_artifact_classification_is_deterministic_and_fail_closed(tmp_
     assert first["first_batch_summary"]["first_batch"] == ["AAPL", "NVDA"]
     assert first["first_batch_summary"]["evidence_complete_count"] == 0
     assert first["first_batch_summary"]["trusted_loop_verdict"] == "read_only_context_fail_closed"
+    assert first["first_batch_summary"]["current_top_blocker"] == "legacy_schema_bridge_or_alias_analysis_required"
     assert first["safety_invariants"]["does_not_change_evidence_complete_count"] is True
 
     rows = {row["relative_path"]: row for row in first["artifact_discovery"]["rows"]}
@@ -123,6 +126,15 @@ def test_phase_one_artifact_classification_is_deterministic_and_fail_closed(tmp_
     assert rows["logs/qre_controlled_validation_execution/controlled_eval_latest.v1.json"]["classification_status"] == "legacy_validation_stdout_only"
     assert rows["research/history/20260604T170735770553Z/run_candidates.v1.json"]["classification_status"] == "missing_required_identity_fields"
     assert rows["research/history/20260604T170735770553Z/run_campaign_manifest.v1.json"]["classification_status"] == "legacy_validation_evidence_candidate"
+
+    locator = first["validation_result_locator"]["rows"]
+    assert len(locator) == 1
+    assert locator[0]["expected_result_count"] == 6
+    assert locator[0]["found_result_count"] == 2
+    assert locator[0]["missing_result_count"] == 4
+    assert locator[0]["can_use_as_oos_evidence"] is False
+    assert locator[0]["can_use_as_campaign_lineage"] is False
+    assert locator[0]["result_schema_status"] == "structured_validation_results_found"
 
 
 def test_generated_reports_are_not_treated_as_source_artifacts(tmp_path: Path, monkeypatch) -> None:
@@ -137,6 +149,21 @@ def test_generated_reports_are_not_treated_as_source_artifacts(tmp_path: Path, m
     rows = {row["relative_path"]: row for row in report["artifact_discovery"]["rows"]}
 
     assert rows["logs/qre_discovery_basket_grid_evidence_materialization/latest.json"]["classification_status"] == "generated_report_not_source_artifact"
+
+
+def test_results_written_without_structured_outputs_stays_fail_closed(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    _stub_upstream(monkeypatch)
+    (tmp_path / "research" / "history").rename(tmp_path / "research" / "history_hidden")
+
+    report = cascade.build_first_batch_evidence_recovery_cascade(repo_root=tmp_path)
+
+    locator = report["validation_result_locator"]["rows"]
+    assert len(locator) == 1
+    assert locator[0]["expected_result_count"] == 6
+    assert locator[0]["found_result_count"] == 0
+    assert locator[0]["result_schema_status"] == "structured_validation_results_missing"
+    assert report["first_batch_summary"]["current_top_blocker"] == "legacy_results_missing"
 
 
 def test_write_outputs_stays_allowlisted(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -102,6 +102,15 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         "build_first_batch_evidence_recovery_readiness",
         lambda **_: {"report_kind": "qre_first_batch_evidence_recovery_readiness"},
     )
+    monkeypatch.setattr(
+        packet_module.first_batch_cascade,
+        "build_first_batch_evidence_recovery_cascade",
+        lambda **_: {
+            "report_kind": "qre_first_batch_evidence_recovery_cascade",
+            "overall_result": "PRESET_TIMEFRAME_ALIAS_BLOCKED",
+            "first_batch_summary": {"current_top_blocker": "preset_timeframe_alias_unproven"},
+        },
+    )
 
     packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
 
@@ -118,6 +127,8 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["basket_operator_action_plan_ready"] is True
     assert packet["summary"]["basket_operator_action_plan_first_batch"] == ["AAPL", "NVDA"]
     assert packet["summary"]["first_batch_readiness_available"] is True
+    assert packet["summary"]["first_batch_recovery_cascade_available"] is True
+    assert packet["summary"]["first_batch_recovery_cascade_result"] == "PRESET_TIMEFRAME_ALIAS_BLOCKED"
     assert packet["summary"]["trust_blocker_count"] == 0
     assert packet["protected_artifacts"][0]["exists"] is True
     assert packet["protected_artifacts"][1]["exists"] is True
@@ -154,6 +165,15 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
         "build_first_batch_evidence_recovery_readiness",
         lambda **_: {"report_kind": "qre_first_batch_evidence_recovery_readiness"},
     )
+    monkeypatch.setattr(
+        packet_module.first_batch_cascade,
+        "build_first_batch_evidence_recovery_cascade",
+        lambda **_: {
+            "report_kind": "qre_first_batch_evidence_recovery_cascade",
+            "overall_result": "PRESET_TIMEFRAME_ALIAS_BLOCKED",
+            "first_batch_summary": {"current_top_blocker": "preset_timeframe_alias_unproven"},
+        },
+    )
 
     packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
 
@@ -185,6 +205,15 @@ def test_trusted_loop_review_packet_operator_summary_renders(
         "build_first_batch_evidence_recovery_readiness",
         lambda **_: {"report_kind": "qre_first_batch_evidence_recovery_readiness"},
     )
+    monkeypatch.setattr(
+        packet_module.first_batch_cascade,
+        "build_first_batch_evidence_recovery_cascade",
+        lambda **_: {
+            "report_kind": "qre_first_batch_evidence_recovery_cascade",
+            "overall_result": "PRESET_TIMEFRAME_ALIAS_BLOCKED",
+            "first_batch_summary": {"current_top_blocker": "preset_timeframe_alias_unproven"},
+        },
+    )
 
     packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)
     text = packet_module.render_operator_summary(packet)
@@ -212,6 +241,15 @@ def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(
         packet_module.first_batch_readiness,
         "build_first_batch_evidence_recovery_readiness",
         lambda **_: {"report_kind": "qre_first_batch_evidence_recovery_readiness"},
+    )
+    monkeypatch.setattr(
+        packet_module.first_batch_cascade,
+        "build_first_batch_evidence_recovery_cascade",
+        lambda **_: {
+            "report_kind": "qre_first_batch_evidence_recovery_cascade",
+            "overall_result": "PRESET_TIMEFRAME_ALIAS_BLOCKED",
+            "first_batch_summary": {"current_top_blocker": "preset_timeframe_alias_unproven"},
+        },
     )
 
     packet = packet_module.build_trusted_loop_review_packet(repo_root=tmp_path)


### PR DESCRIPTION
## Summary
- add `research.qre_first_batch_evidence_recovery_cascade` with deterministic allowlisted artifact scanning, legacy validation result location, guarded bridge analysis, and fail-closed stop-condition reporting for the AAPL/NVDA first batch
- propagate cascade status into operator action planning and trusted-loop review without improving trust or evidence completeness
- add deterministic unit coverage for first-batch prioritization, protected-root exclusions, stdout-only rejection, legacy result detection, guarded alias blocking, and fail-closed authority boundaries

## Validation
- `python -m pytest tests/unit/test_qre_first_batch_evidence_recovery_cascade.py tests/unit/test_qre_first_batch_evidence_recovery_readiness.py tests/unit/test_qre_basket_operator_action_plan.py tests/unit/test_qre_basket_lineage_recovery_diagnostics.py tests/unit/test_qre_basket_evidence_recovery_plan.py tests/unit/test_qre_basket_next_action_queue.py tests/unit/test_qre_evidence_complete_basket_closure.py tests/unit/test_qre_trusted_loop_review_packet.py -q`
- `python -m pytest tests/smoke -q`
- `python scripts/governance_lint.py`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`
- reran:
  - `python -m research.qre_first_batch_evidence_recovery_cascade --write`
  - `python -m research.qre_first_batch_evidence_recovery_readiness --write`
  - `python -m research.qre_discovery_basket_grid_evidence_materialization --write`
  - `python -m research.qre_grid_candidate_campaign_lineage_bridge --write`
  - `python -m research.qre_basket_lineage_recovery_diagnostics --write`
  - `python -m research.qre_basket_operator_action_plan --write`
  - `python -m research.qre_basket_next_action_queue --write`
  - `python -m research.qre_evidence_complete_basket_closure --write`
  - `python -m research.qre_trusted_loop_review_packet --write`

## Safety
- read-only/report-only only
- no campaign launch or mutation
- no queue or registry mutation
- no external fetch or provider activation
- no strategy synthesis, registration, or promotion
- no broker/risk/execution or paper/shadow/live
- no fake lineage, OOS, screening, source, or cache evidence
- no mutation of `research/research_latest.json` or `research/strategy_matrix.csv`

## Before / After Metrics
- before: `evidence_complete_count=0`, `unknown_blocker_count=0`, first batch `AAPL/NVDA`, `grid_runs_scanned=0`, `matched_baskets=0`
- after: `evidence_complete_count=0`, `unknown_blocker_count=0`, first batch `AAPL/NVDA`, `campaign_lineage_proven=0`, cascade result `PRESET_TIMEFRAME_ALIAS_BLOCKED`, trusted-loop remains `read_only_context_fail_closed`

## Commit-by-Commit Phase Report-Out
- `0982c56` `feat: classify first-batch controlled grid artifacts`
  - added allowlisted local artifact discovery/classification with fail-closed authoritative vs non-authoritative statuses
  - targeted tests: `python -m pytest tests/unit/test_qre_first_batch_evidence_recovery_cascade.py -q`
  - blocker before: `campaign_lineage_missing` / `no_oos_evidence`
  - blocker after: legacy artifact candidates visible; structured result location still missing
  - continued because the next step stayed local, deterministic, and read-only
- `81a0c9b` `feat: locate legacy validation outputs for first batch`
  - added bounded locator for structured legacy validation outputs and explicit rejection of stdout-only traces as evidence
  - targeted tests: `python -m pytest tests/unit/test_qre_first_batch_evidence_recovery_cascade.py -q`
  - blocker before: artifact candidates classified but result outputs not located
  - blocker after: structured legacy results found; bridge and compatibility analysis required
  - continued because structured local artifacts existed and mapping analysis was still safe
- `27b07e2` `feat: add guarded legacy schema bridge`
  - added guarded bridge/context analysis for legacy validation artifacts and explicit preset/timeframe compatibility outcomes
  - targeted tests: `python -m pytest tests/unit/test_qre_first_batch_evidence_recovery_cascade.py -q`
  - blocker before: structured legacy results found but unassessed
  - blocker after: stop condition narrowed to unproven preset/timeframe mapping for current first-batch targets
  - continued because downstream read-only consumers could still surface this result safely
- `f9b000e` `feat: expose cascade status in operator action plan`
  - exposed cascade result and top blocker in operator action planning and trusted-loop context without changing trust
  - targeted tests: `python -m pytest tests/unit/test_qre_first_batch_evidence_recovery_cascade.py tests/unit/test_qre_basket_operator_action_plan.py tests/unit/test_qre_trusted_loop_review_packet.py -q`
  - blocker before: cascade result existed but was not visible in downstream operator/trusted reports
  - blocker after: downstream reports consistently show `PRESET_TIMEFRAME_ALIAS_BLOCKED`
  - stopped because the next recovery step would require a new trusted alias policy or operator decision beyond proven deterministic mapping
