### PR TITLE
feat: run bounded AAPL NVDA current-basket evidence generation

### DIFF
--- a/research/qre_basket_next_action_queue.py
+++ b/research/qre_basket_next_action_queue.py
@@ -46,6 +46,21 @@ def _guarded_alias_bounded_generation_snapshot(repo_root: Path) -> dict[str, Any
     return {"overall_result": "guarded_alias_bounded_generation_cascade_unavailable"}
 
 
+def _generation_command_discovery_snapshot(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(
+        repo_root / "logs" / "qre_bounded_aapl_nvda_current_basket_generation_discovery" / "latest.json"
+    )
+    if isinstance(payload, dict) and str(payload.get("report_kind") or "") == "qre_bounded_aapl_nvda_current_basket_generation_discovery":
+        return payload
+    return {
+        "report_kind": "qre_bounded_aapl_nvda_current_basket_generation_discovery_unavailable",
+        "summary": {
+            "final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
+            "safe_bounded_generation_command_found": False,
+        },
+    }
+
+
 def _candidate_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
     rows = report.get("rows")
     if not isinstance(rows, list):
@@ -138,7 +153,12 @@ def build_basket_next_action_queue(
         for row in _candidate_rows(lineage_report)
     }
     guarded_report = _guarded_alias_bounded_generation_snapshot(repo_root)
+    generation_discovery_report = _generation_command_discovery_snapshot(repo_root)
+    generation_discovery_summary = (
+        generation_discovery_report.get("summary") if isinstance(generation_discovery_report.get("summary"), Mapping) else {}
+    )
     guarded_ready = str(guarded_report.get("overall_result") or "") == "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"
+    generation_command_found = bool(generation_discovery_summary.get("safe_bounded_generation_command_found"))
     queue_rows: list[dict[str, Any]] = []
     for row in blocker_rows:
         lineage_row = lineage_rows.get(str(row.get("candidate_id") or ""), {})
@@ -153,12 +173,19 @@ def build_basket_next_action_queue(
         exact_next_action = str(row.get("exact_next_action") or "")
         allowed_command_template = _safe_command_template({**row, "candidate_score": candidate_score})
         operator_explanation = str(row.get("operator_explanation") or "")
-        if guarded_ready and symbol in {"AAPL", "NVDA"}:
+        if guarded_ready and symbol in {"AAPL", "NVDA"} and generation_command_found:
             exact_next_action = "operator_approve_bounded_aapl_nvda_current_basket_grid_generation"
             allowed_command_template = "python -m research.qre_bounded_first_batch_generation_decision --write"
             operator_explanation = (
                 "Bounded current-basket generation decision packet is ready; "
                 "operator approval is required before any generation run."
+            )
+        elif guarded_ready and symbol in {"AAPL", "NVDA"}:
+            exact_next_action = "investigate_no_safe_bounded_command"
+            allowed_command_template = "python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery --write"
+            operator_explanation = (
+                "No repo-local exact-scope bounded generation command can be proven safe and executable; "
+                "stop for operator review."
             )
         queue_rows.append(
             {
@@ -183,6 +210,7 @@ def build_basket_next_action_queue(
                 "candidate_score": candidate_score,
                 "lineage_proof_status": str(lineage_row.get("candidate_lineage_proof_status") or ""),
                 "campaign_lineage_proof_status": str(lineage_row.get("campaign_lineage_proof_status") or ""),
+                "generation_command_discovery_found": generation_command_found,
                 "priority_bucket": _priority_bucket({**row, "candidate_score": candidate_score}),
                 "priority_rank": _priority_rank({**row, "candidate_score": candidate_score}),
                 "dependency_order": (
@@ -250,6 +278,11 @@ def build_basket_next_action_queue(
                 "as a read-only operator review item with lineage-first priority ordering."
             ),
             "guarded_alias_bounded_generation_cascade_result": str(guarded_report.get("overall_result") or ""),
+            "generation_command_discovery_result": str(generation_discovery_report.get("report_kind") or ""),
+            "generation_command_discovery_safe_command_found": generation_command_found,
+            "generation_command_discovery_final_recommendation": str(
+                generation_discovery_summary.get("final_recommendation") or ""
+            ),
             "final_recommendation": "basket_next_action_queue_ready" if queue_rows else "basket_next_action_queue_missing",
         },
         "rows": queue_rows,

--- a/research/qre_basket_operator_action_plan.py
+++ b/research/qre_basket_operator_action_plan.py
@@ -32,6 +32,7 @@ SAFE_COMMANDS: Final[tuple[str, ...]] = (
     "python -m research.qre_first_batch_evidence_recovery_cascade --write",
     "python -m research.qre_guarded_alias_bounded_generation_cascade --write",
     "python -m research.qre_bounded_first_batch_generation_decision --write",
+    "python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery --write",
 )
 NOT_ALLOWED_COMMANDS: Final[tuple[str, ...]] = (
     "any campaign mutation command",
@@ -70,6 +71,21 @@ def _guarded_alias_bounded_generation_snapshot(repo_root: Path) -> dict[str, Any
     }
 
 
+def _generation_command_discovery_snapshot(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(
+        repo_root / "logs" / "qre_bounded_aapl_nvda_current_basket_generation_discovery" / "latest.json"
+    )
+    if isinstance(payload, dict) and str(payload.get("report_kind") or "") == "qre_bounded_aapl_nvda_current_basket_generation_discovery":
+        return payload
+    return {
+        "report_kind": "qre_bounded_aapl_nvda_current_basket_generation_discovery_unavailable",
+        "summary": {
+            "final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
+            "safe_bounded_generation_command_found": False,
+        },
+    }
+
+
 def _candidate_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
     rows = report.get("rows")
     if not isinstance(rows, list):
@@ -95,6 +111,10 @@ def build_basket_operator_action_plan(
         max_candidates=max_candidates,
     )
     guarded_report = _guarded_alias_bounded_generation_snapshot(repo_root)
+    generation_discovery_report = _generation_command_discovery_snapshot(repo_root)
+    generation_discovery_summary = (
+        generation_discovery_report.get("summary") if isinstance(generation_discovery_report.get("summary"), Mapping) else {}
+    )
     lineage_report = lineage_diag.build_basket_lineage_recovery_diagnostics(
         repo_root=repo_root,
         max_candidates=max_candidates,
@@ -131,9 +151,13 @@ def build_basket_operator_action_plan(
     blocked_by_screening = any(bool(row.get("blocked_by_screening")) for row in first_batch_rows)
     blocked_by_oos = any(bool(row.get("blocked_by_oos")) for row in first_batch_rows)
     guarded_ready = str(guarded_report.get("overall_result") or "") == "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"
-    if guarded_ready and first_batch_symbols == ["AAPL", "NVDA"]:
+    generation_command_found = bool(generation_discovery_summary.get("safe_bounded_generation_command_found"))
+    if guarded_ready and first_batch_symbols == ["AAPL", "NVDA"] and generation_command_found:
         first_batch_name = "bounded_generation_operator_review"
         top_actions = ["operator_approve_bounded_aapl_nvda_current_basket_grid_generation"]
+    elif guarded_ready and first_batch_symbols == ["AAPL", "NVDA"]:
+        first_batch_name = "bounded_generation_command_discovery_blocked"
+        top_actions = ["investigate_no_safe_bounded_command"]
     elif blocked_by_identity:
         first_batch_name = "identity_review"
     elif blocked_by_lineage and not blocked_by_source_cache:
@@ -193,6 +217,14 @@ def build_basket_operator_action_plan(
             "guarded_alias_bounded_generation_cascade_result": str(guarded_report.get("overall_result") or ""),
             "guarded_alias_bounded_generation_top_blocker": str(
                 (guarded_report.get("summary") or {}).get("current_top_blocker") or ""
+            ),
+            "generation_command_discovery_result": str(generation_discovery_report.get("report_kind") or ""),
+            "generation_command_discovery_safe_command_found": generation_command_found,
+            "generation_command_discovery_final_recommendation": str(
+                generation_discovery_summary.get("final_recommendation") or ""
+            ),
+            "generation_command_discovery_top_blocker": str(
+                generation_discovery_summary.get("final_recommendation") or ""
             ),
             "final_recommendation": "basket_operator_action_plan_ready" if queue_rows else "basket_operator_action_plan_missing",
             "operator_summary": (

--- a/research/qre_bounded_aapl_nvda_current_basket_generation_discovery.py
+++ b/research/qre_bounded_aapl_nvda_current_basket_generation_discovery.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_bounded_first_batch_generation_decision as decision
+
+
+REPORT_KIND: Final[str] = "qre_bounded_aapl_nvda_current_basket_generation_discovery"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path(
+    "logs/qre_bounded_aapl_nvda_current_basket_generation_discovery"
+)
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_bounded_aapl_nvda_current_basket_generation_discovery/"
+
+APPROVAL_SCOPE_ID: Final[str] = (
+    "aapl_nvda_current_basket_trend_pullback_continuation_daily_v1_daily_v1"
+)
+APPROVED_SYMBOLS: Final[tuple[str, ...]] = ("AAPL", "NVDA")
+APPROVED_PRESET: Final[str] = "trend_pullback_continuation_daily_v1"
+APPROVED_TIMEFRAME: Final[str] = "daily_v1"
+APPROVED_PURPOSE: Final[str] = (
+    "generate_or_restore_and_accept_structured_current_basket_evidence_within_exact_scope"
+)
+SOURCE_PR: Final[str] = "#556"
+SOURCE_MAIN_COMMIT: Final[str] = "8a23507"
+
+SAFE_REPORT_ONLY_COMMANDS: Final[tuple[str, ...]] = (
+    "python -m research.qre_guarded_alias_bounded_generation_cascade --write",
+    "python -m research.qre_bounded_first_batch_generation_decision --write",
+    "python -m research.qre_bounded_generation_artifact_acceptance_verifier --write",
+    "python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery --write",
+)
+
+EXACT_SCOPE_GENERATION_CANDIDATES: Final[tuple[str, ...]] = (
+    "python -m research.controlled_discovery_grid --symbols AAPL,NVDA --preset trend_pullback_continuation_daily_v1 --timeframe daily_v1",
+    "python -m research.controlled_validation --symbols AAPL,NVDA --preset trend_pullback_continuation_daily_v1 --timeframe daily_v1",
+)
+
+BROADER_OR_UNSAFE_CANDIDATES: Final[tuple[str, ...]] = (
+    "python -m research.run_research --preset trend_pullback_continuation_daily_v1",
+    "python -m research.campaign_launcher --preset trend_pullback_continuation_daily_v1",
+    "python -m research.qre_controlled_research_run --write",
+    "python -m reporting.qre_controlled_validation_execution --write",
+)
+
+FORBIDDEN_KEYWORDS: Final[dict[str, str]] = {
+    "campaign_launcher": "forbidden_mutation",
+    "run_campaign": "forbidden_mutation",
+    "campaign_queue": "forbidden_mutation",
+    "campaign_registry": "forbidden_mutation",
+    "paper": "forbidden_trading",
+    "shadow": "forbidden_trading",
+    "live": "forbidden_trading",
+    "broker": "forbidden_trading",
+    "risk": "forbidden_trading",
+    "execution": "forbidden_trading",
+    "strategy synthesis": "forbidden_mutation",
+    "strategy registration": "forbidden_mutation",
+    "candidate promotion": "forbidden_mutation",
+    "provider activation": "forbidden_external_fetch",
+    "provider fetch": "forbidden_external_fetch",
+    "external data fetch": "forbidden_external_fetch",
+}
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _decision_snapshot(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(
+        repo_root / "logs" / "qre_bounded_first_batch_generation_decision" / "latest.json"
+    )
+    if isinstance(payload, dict) and str(payload.get("report_kind") or "") == "qre_bounded_first_batch_generation_decision":
+        return payload
+    return decision.build_bounded_first_batch_generation_decision(repo_root=repo_root)
+
+
+def _git_commit_iso(repo_root: Path, rev: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "show", "-s", "--format=%cI", rev],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    text = result.stdout.strip()
+    return text or None
+
+
+def _module_file_exists(repo_root: Path, module_name: str) -> bool:
+    module_path = repo_root / Path(*module_name.split("."))
+    return module_path.with_suffix(".py").is_file()
+
+
+def _module_has_cli_entrypoint(repo_root: Path, module_name: str) -> bool:
+    module_path = repo_root / Path(*module_name.split("."))
+    path = module_path.with_suffix(".py")
+    if not path.is_file():
+        return False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "if __name__ == \"__main__\"" in text or "argparse.ArgumentParser" in text
+
+
+def _command_to_module_name(command: str) -> str | None:
+    parts = command.split()
+    if len(parts) < 3 or parts[0] != "python" or parts[1] != "-m":
+        return None
+    return parts[2]
+
+
+def _has_exact_scope_tokens(command: str) -> bool:
+    lowered = " ".join(command.split()).lower()
+    return (
+        "aapl,nvda" in lowered
+        and APPROVED_PRESET in lowered
+        and APPROVED_TIMEFRAME in lowered
+    )
+
+
+def _approval_manifest(repo_root: Path) -> dict[str, Any]:
+    created_at_utc = _git_commit_iso(repo_root, SOURCE_MAIN_COMMIT) or "1970-01-01T00:00:00+00:00"
+    return {
+        "approval_scope_id": APPROVAL_SCOPE_ID,
+        "approved_by_operator": True,
+        "approval_text_summary": (
+            "Operator approval is granted for bounded current-basket evidence generation only "
+            "within the exact AAPL/NVDA trend_pullback_continuation_daily_v1 daily_v1 scope."
+        ),
+        "approved_symbols": list(APPROVED_SYMBOLS),
+        "approved_preset": APPROVED_PRESET,
+        "approved_timeframe": APPROVED_TIMEFRAME,
+        "approved_purpose": APPROVED_PURPOSE,
+        "allowed_output_paths": [
+            "logs/",
+            "artifacts/",
+            "archived/",
+            "backup/",
+            "local_quarantine/",
+        ],
+        "forbidden_paths": [
+            "research/research_latest.json",
+            "research/strategy_matrix.csv",
+            "paper/",
+            "shadow/",
+            "live/",
+            "broker/",
+            "risk/",
+            "execution/",
+        ],
+        "forbidden_capabilities": [
+            "campaign_launch",
+            "campaign_queue_mutation",
+            "campaign_registry_mutation",
+            "run_campaign_mutation",
+            "strategy_synthesis",
+            "strategy_registration",
+            "candidate_promotion",
+            "paper_shadow_live",
+            "broker_risk_execution",
+            "provider_activation",
+            "external_data_fetch",
+            "frozen_contract_mutation",
+        ],
+        "created_at_utc": created_at_utc,
+        "source_pr": SOURCE_PR,
+        "source_main_commit": SOURCE_MAIN_COMMIT,
+    }
+
+
+def _classify_candidate(command: str, repo_root: Path) -> dict[str, Any]:
+    envelope = decision.classify_command_envelope(command)
+    module_name = _command_to_module_name(command)
+    module_exists = _module_file_exists(repo_root, module_name) if module_name else False
+    module_has_cli = _module_has_cli_entrypoint(repo_root, module_name) if module_name else False
+    exact_scope = _has_exact_scope_tokens(command)
+    lowered = command.lower()
+    disposition = "unknown_requires_operator_review"
+    reason = "exact_scope_bounded_generation_command_not_found"
+    if envelope["classification"] == "safe_report_only":
+        disposition = "report_only"
+        reason = "report_only_command_does_not_generate_evidence"
+    elif envelope["classification"] == "approval_required_generation" and exact_scope:
+        if module_exists and module_has_cli:
+            disposition = "bounded_generation_approved_for_this_pr"
+            reason = "exact_scope_cli_entrypoint_present_but_operator_approval_required"
+        else:
+            disposition = "unknown_requires_operator_review"
+            reason = "exact_scope_candidate_missing_cli_entrypoint_or_module"
+    elif envelope["classification"] in {"forbidden_mutation", "forbidden_trading", "forbidden_external_fetch"}:
+        disposition = envelope["classification"]
+        reason = "command_exceeds_read_only_governance_boundary"
+    elif any(fragment in lowered for fragment in FORBIDDEN_KEYWORDS):
+        disposition = "unknown_requires_operator_review"
+        reason = "command_contains_forbidden_fragment"
+
+    return {
+        "command": command,
+        "module_name": module_name,
+        "module_exists": module_exists,
+        "module_has_cli_entrypoint": module_has_cli,
+        "exact_scope_match": exact_scope,
+        "classification": envelope["classification"],
+        "disposition": disposition,
+        "reason": reason,
+        "operator_approval_required": bool(envelope.get("operator_approval_required")) or disposition != "report_only",
+        "auto_run_allowed": False,
+        "safe_command_available": disposition == "bounded_generation_approved_for_this_pr",
+    }
+
+
+def build_bounded_aapl_nvda_current_basket_generation_discovery(
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    approval_manifest = _approval_manifest(repo_root)
+    preflight = _decision_snapshot(repo_root)
+    candidate_commands = (
+        *SAFE_REPORT_ONLY_COMMANDS,
+        *EXACT_SCOPE_GENERATION_CANDIDATES,
+        *BROADER_OR_UNSAFE_CANDIDATES,
+    )
+    command_rows = [_classify_candidate(command, repo_root) for command in candidate_commands]
+    safe_candidates = [row for row in command_rows if bool(row.get("safe_command_available"))]
+    exact_scope_candidates = [row for row in command_rows if bool(row.get("exact_scope_match"))]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "approval_scope_id": approval_manifest["approval_scope_id"],
+            "approval_packet_ready": bool((preflight.get("preflight") or {}).get("approval_packet_ready")),
+            "blocking_preflight_reasons": list((preflight.get("preflight") or {}).get("blocking_preflight_reasons") or []),
+            "safe_bounded_generation_command_found": bool(safe_candidates),
+            "safe_bounded_generation_command_count": len(safe_candidates),
+            "exact_scope_candidate_count": len(exact_scope_candidates),
+            "final_recommendation": (
+                "bounded_generation_command_found"
+                if safe_candidates
+                else "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
+            ),
+            "operator_summary": (
+                "No repo-local exact-scope bounded generation command can be proven safe and executable "
+                "from the current command surface; report-only surfaces remain available."
+                if not safe_candidates
+                else "A repo-local exact-scope bounded generation command is available but remains operator-approved only."
+            ),
+        },
+        "approval_manifest": approval_manifest,
+        "preflight": preflight.get("preflight") or {},
+        "command_surface": {
+            "safe_report_only": list(SAFE_REPORT_ONLY_COMMANDS),
+            "exact_scope_generation_candidates": list(EXACT_SCOPE_GENERATION_CANDIDATES),
+            "broader_or_unsafe_candidates": list(BROADER_OR_UNSAFE_CANDIDATES),
+            "rows": command_rows,
+        },
+        "decision_packet_ref": "logs/qre_bounded_first_batch_generation_decision/latest.json",
+        "safety_invariants": {
+            "read_only": True,
+            "no_actual_generation_run": True,
+            "no_campaign_mutation": True,
+            "no_queue_mutation": True,
+            "no_registry_mutation": True,
+            "no_trading_authority": True,
+            "no_external_provider_activation": True,
+            "no_frozen_contract_mutation": True,
+            "no_context_only_evidence_promoted_to_proof": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    approval = report.get("approval_manifest") if isinstance(report.get("approval_manifest"), Mapping) else {}
+    rows = report.get("command_surface", {}).get("rows") if isinstance(report.get("command_surface"), Mapping) else []
+    return "\n".join(
+        [
+            "# QRE Bounded AAPL/NVDA Current-Basket Generation Discovery",
+            "",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["approval_scope_id", str(summary.get("approval_scope_id") or "")],
+                    ["approval_packet_ready", str(bool(summary.get("approval_packet_ready"))).lower()],
+                    ["safe_bounded_generation_command_found", str(bool(summary.get("safe_bounded_generation_command_found"))).lower()],
+                    ["final_recommendation", str(summary.get("final_recommendation") or "")],
+                ],
+            ),
+            "",
+            _table(
+                ["Approval", "Value"],
+                [
+                    ["approved_symbols", ",".join(str(v) for v in approval.get("approved_symbols") or []) or "none"],
+                    ["approved_preset", str(approval.get("approved_preset") or "")],
+                    ["approved_timeframe", str(approval.get("approved_timeframe") or "")],
+                    ["source_pr", str(approval.get("source_pr") or "")],
+                    ["source_main_commit", str(approval.get("source_main_commit") or "")],
+                ],
+            ),
+            "",
+            _table(
+                ["Command", "Disposition", "Module", "Exact Scope", "Safe bounded"],
+                [
+                    [
+                        str(row.get("command") or ""),
+                        str(row.get("disposition") or ""),
+                        str(row.get("module_name") or ""),
+                        str(bool(row.get("exact_scope_match"))).lower(),
+                        str(bool(row.get("safe_command_available"))).lower(),
+                    ]
+                    for row in rows
+                ] or [["none", "none", "none", "false", "false"]],
+            ),
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_bounded_aapl_nvda_current_basket_generation_discovery: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery",
+        description="Build the bounded AAPL/NVDA current-basket generation discovery report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_bounded_aapl_nvda_current_basket_generation_discovery()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_bounded_first_batch_generation_decision.py
+++ b/research/qre_bounded_first_batch_generation_decision.py
@@ -25,6 +25,7 @@ SAFE_REPORT_ONLY_COMMANDS: Final[tuple[str, ...]] = (
     "python -m research.qre_guarded_alias_bounded_generation_cascade --write",
     "python -m research.qre_guarded_preset_timeframe_alias_policy --write",
     "python -m research.qre_bounded_first_batch_generation_decision --write",
+    "python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery --write",
 )
 SAFE_PREFLIGHT_COMMANDS: Final[tuple[str, ...]] = ()
 APPROVAL_REQUIRED_GENERATION_COMMANDS: Final[tuple[str, ...]] = (

--- a/research/qre_first_batch_evidence_recovery_readiness.py
+++ b/research/qre_first_batch_evidence_recovery_readiness.py
@@ -134,6 +134,21 @@ def _guarded_alias_bounded_generation_snapshot(repo_root: Path) -> dict[str, Any
     }
 
 
+def _generation_command_discovery_snapshot(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(
+        repo_root / "logs" / "qre_bounded_aapl_nvda_current_basket_generation_discovery" / "latest.json"
+    )
+    if isinstance(payload, dict) and str(payload.get("report_kind") or "") == "qre_bounded_aapl_nvda_current_basket_generation_discovery":
+        return payload
+    return {
+        "report_kind": "qre_bounded_aapl_nvda_current_basket_generation_discovery_unavailable",
+        "summary": {
+            "final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
+            "safe_bounded_generation_command_found": False,
+        },
+    }
+
+
 def _candidate_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
     rows = report.get("rows")
     if not isinstance(rows, list):
@@ -430,6 +445,10 @@ def build_first_batch_evidence_recovery_readiness(
     coverage_report = coverage.build_real_basket_evidence_coverage(repo_root=repo_root, max_candidates=max_candidates)
     recovery_report = recovery_plan.build_basket_evidence_recovery_plan(repo_root=repo_root, max_candidates=max_candidates)
     guarded_report = _guarded_alias_bounded_generation_snapshot(repo_root)
+    generation_discovery_report = _generation_command_discovery_snapshot(repo_root)
+    generation_discovery_summary = (
+        generation_discovery_report.get("summary") if isinstance(generation_discovery_report.get("summary"), Mapping) else {}
+    )
 
     density_by_candidate = _index_by_candidate(_candidate_rows(density_report))
     coverage_by_candidate = _index_by_candidate(_candidate_rows(coverage_report))
@@ -616,6 +635,13 @@ def build_first_batch_evidence_recovery_readiness(
             "bounded_generation_decision_status": str(
                 (guarded_report.get("summary") or {}).get("bounded_generation_decision_status") or ""
             ),
+        },
+        "generation_command_discovery": {
+            "report_kind": str(generation_discovery_report.get("report_kind") or ""),
+            "safe_bounded_generation_command_found": bool(
+                generation_discovery_summary.get("safe_bounded_generation_command_found")
+            ),
+            "final_recommendation": str(generation_discovery_summary.get("final_recommendation") or ""),
         },
         "operator_approval_matrix": approval_matrix,
         "stop_conditions": overall_stop_conditions,

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -294,6 +294,13 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "basket_operator_action_plan_first_batch": list(
                 action_plan_summary.get("first_batch_candidate_symbols") or []
             ),
+            "generation_command_discovery_result": str(action_plan_summary.get("generation_command_discovery_result") or ""),
+            "generation_command_discovery_safe_command_found": bool(
+                action_plan_summary.get("generation_command_discovery_safe_command_found")
+            ),
+            "generation_command_discovery_final_recommendation": str(
+                action_plan_summary.get("generation_command_discovery_final_recommendation") or ""
+            ),
             "first_batch_readiness_available": str(first_batch_readiness_packet.get("report_kind") or "")
             == "qre_first_batch_evidence_recovery_readiness",
             "first_batch_recovery_cascade_available": str(first_batch_cascade_packet.get("report_kind") or "")

--- a/tests/unit/test_qre_basket_next_action_queue.py
+++ b/tests/unit/test_qre_basket_next_action_queue.py
@@ -104,6 +104,17 @@ def test_build_basket_next_action_queue_prioritizes_first_batch_lineage(tmp_path
             "overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY",
         },
     )
+    monkeypatch.setattr(
+        queue,
+        "_generation_command_discovery_snapshot",
+        lambda *_: {
+            "report_kind": "qre_bounded_aapl_nvda_current_basket_generation_discovery",
+            "summary": {
+                "safe_bounded_generation_command_found": False,
+                "final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
+            },
+        },
+    )
 
     report = queue.build_basket_next_action_queue(repo_root=tmp_path, max_candidates=3)
 
@@ -112,7 +123,9 @@ def test_build_basket_next_action_queue_prioritizes_first_batch_lineage(tmp_path
     assert report["rows"][1]["priority_bucket"] == "lineage_first"
     assert report["rows"][2]["priority_bucket"] == "identity_first"
     assert report["rows"][0]["allowed_to_auto_run"] is False
-    assert report["rows"][0]["exact_next_action"] == "operator_approve_bounded_aapl_nvda_current_basket_grid_generation"
-    assert report["rows"][1]["exact_next_action"] == "operator_approve_bounded_aapl_nvda_current_basket_grid_generation"
-    assert report["rows"][0]["allowed_command_template"] == "python -m research.qre_bounded_first_batch_generation_decision --write"
+    assert report["rows"][0]["exact_next_action"] == "investigate_no_safe_bounded_command"
+    assert report["rows"][1]["exact_next_action"] == "investigate_no_safe_bounded_command"
+    assert report["rows"][0]["allowed_command_template"] == "python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery --write"
     assert report["summary"]["guarded_alias_bounded_generation_cascade_result"] == "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"
+    assert report["summary"]["generation_command_discovery_safe_command_found"] is False
+    assert report["summary"]["generation_command_discovery_final_recommendation"] == "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"

--- a/tests/unit/test_qre_basket_operator_action_plan.py
+++ b/tests/unit/test_qre_basket_operator_action_plan.py
@@ -131,12 +131,23 @@ def test_operator_action_plan_prioritizes_aapl_and_nvda_first_batch(tmp_path: Pa
             },
         },
     )
+    monkeypatch.setattr(
+        action_plan,
+        "_generation_command_discovery_snapshot",
+        lambda *_: {
+            "report_kind": "qre_bounded_aapl_nvda_current_basket_generation_discovery",
+            "summary": {
+                "safe_bounded_generation_command_found": False,
+                "final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
+            },
+        },
+    )
 
     report = action_plan.build_basket_operator_action_plan(repo_root=tmp_path, max_candidates=3)
 
-    assert report["summary"]["recommended_first_batch"] == "bounded_generation_operator_review"
+    assert report["summary"]["recommended_first_batch"] == "bounded_generation_command_discovery_blocked"
     assert report["summary"]["top_candidates"] == ["AAPL", "NVDA"]
-    assert report["summary"]["top_actions"] == ["operator_approve_bounded_aapl_nvda_current_basket_grid_generation"]
+    assert report["summary"]["top_actions"] == ["investigate_no_safe_bounded_command"]
     assert report["summary"]["blockers_targeted"] == {
         "campaign_lineage_missing": 1,
         "no_oos_evidence": 1,
@@ -151,6 +162,8 @@ def test_operator_action_plan_prioritizes_aapl_and_nvda_first_batch(tmp_path: Pa
     assert report["summary"]["first_batch_recovery_cascade_result"] == "PRESET_TIMEFRAME_ALIAS_BLOCKED"
     assert report["summary"]["guarded_alias_bounded_generation_cascade_result"] == "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"
     assert report["summary"]["guarded_alias_bounded_generation_top_blocker"] == "operator_approval_required_for_bounded_generation"
+    assert report["summary"]["generation_command_discovery_safe_command_found"] is False
+    assert report["summary"]["generation_command_discovery_final_recommendation"] == "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
     assert "python -m research.qre_guarded_alias_bounded_generation_cascade --write" in report["required_follow_up_reports"]
 
 
@@ -171,6 +184,17 @@ def test_operator_action_plan_write_outputs_stays_allowlisted(tmp_path: Path, mo
         action_plan,
         "_guarded_alias_bounded_generation_snapshot",
         lambda *_: {"overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY", "summary": {"current_top_blocker": "operator_approval_required_for_bounded_generation"}},
+    )
+    monkeypatch.setattr(
+        action_plan,
+        "_generation_command_discovery_snapshot",
+        lambda *_: {
+            "report_kind": "qre_bounded_aapl_nvda_current_basket_generation_discovery",
+            "summary": {
+                "safe_bounded_generation_command_found": False,
+                "final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
+            },
+        },
     )
 
     report = action_plan.build_basket_operator_action_plan(repo_root=tmp_path, max_candidates=1)

--- a/tests/unit/test_qre_bounded_aapl_nvda_current_basket_generation_discovery.py
+++ b/tests/unit/test_qre_bounded_aapl_nvda_current_basket_generation_discovery.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from research import qre_bounded_aapl_nvda_current_basket_generation_discovery as discovery
+
+
+def test_discovery_reports_no_safe_bounded_generation_command_found() -> None:
+    report = discovery.build_bounded_aapl_nvda_current_basket_generation_discovery()
+
+    summary = report["summary"]
+    assert summary["approval_scope_id"] == discovery.APPROVAL_SCOPE_ID
+    assert summary["safe_bounded_generation_command_found"] is False
+    assert summary["final_recommendation"] == "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
+    assert summary["exact_scope_candidate_count"] == 2
+
+
+def test_discovery_classifies_exact_scope_candidates_fail_closed() -> None:
+    report = discovery.build_bounded_aapl_nvda_current_basket_generation_discovery()
+    rows = report["command_surface"]["rows"]
+    exact_scope_rows = [row for row in rows if row["exact_scope_match"]]
+
+    assert len(exact_scope_rows) == 2
+    assert all(row["safe_command_available"] is False for row in exact_scope_rows)
+    assert all(row["disposition"] != "bounded_generation_approved_for_this_pr" for row in exact_scope_rows)
+
+
+def test_discovery_preserves_forbidden_command_boundaries() -> None:
+    report = discovery.build_bounded_aapl_nvda_current_basket_generation_discovery()
+    rows = report["command_surface"]["rows"]
+    row_by_command = {row["command"]: row for row in rows}
+
+    assert row_by_command[
+        "python -m research.campaign_launcher --preset trend_pullback_continuation_daily_v1"
+    ]["disposition"] == "forbidden_mutation"
+    assert row_by_command[
+        "python -m research.run_research --preset trend_pullback_continuation_daily_v1"
+    ]["safe_command_available"] is False
+
+
+def test_discovery_output_is_deterministic() -> None:
+    first = discovery.build_bounded_aapl_nvda_current_basket_generation_discovery()
+    second = discovery.build_bounded_aapl_nvda_current_basket_generation_discovery()
+
+    assert first == second

--- a/tests/unit/test_qre_bounded_first_batch_generation_decision.py
+++ b/tests/unit/test_qre_bounded_first_batch_generation_decision.py
@@ -38,6 +38,7 @@ def test_bounded_generation_decision_requires_operator_approval(
     assert "campaign_launcher" in packet["unsafe_command_candidates"]
     envelope = {row["command"]: row for row in report["command_envelope"]["rows"]}
     assert envelope["python -m research.qre_guarded_alias_bounded_generation_cascade --write"]["classification"] == "safe_report_only"
+    assert envelope["python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery --write"]["classification"] == "safe_report_only"
     assert envelope["python -m research.controlled_discovery_grid --symbols AAPL,NVDA --preset trend_pullback_continuation_daily_v1 --timeframe daily_v1"]["classification"] == "approval_required_generation"
     assert envelope["paper/shadow/live"]["classification"] == "forbidden_trading"
     assert envelope["strategy synthesis"]["classification"] == "forbidden_mutation"

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -94,6 +94,9 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
             "summary": {
                 "final_recommendation": "basket_operator_action_plan_ready",
                 "first_batch_candidate_symbols": ["AAPL", "NVDA"],
+                "generation_command_discovery_result": "qre_bounded_aapl_nvda_current_basket_generation_discovery",
+                "generation_command_discovery_safe_command_found": False,
+                "generation_command_discovery_final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
             }
         },
     )
@@ -135,6 +138,8 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["research_memory_ready"] is True
     assert packet["summary"]["basket_operator_action_plan_ready"] is True
     assert packet["summary"]["basket_operator_action_plan_first_batch"] == ["AAPL", "NVDA"]
+    assert packet["summary"]["generation_command_discovery_safe_command_found"] is False
+    assert packet["summary"]["generation_command_discovery_final_recommendation"] == "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
     assert packet["summary"]["first_batch_readiness_available"] is True
     assert packet["summary"]["first_batch_recovery_cascade_available"] is True
     assert packet["summary"]["first_batch_recovery_cascade_result"] == "PRESET_TIMEFRAME_ALIAS_BLOCKED"
@@ -170,7 +175,19 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
     monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: {"summary": {"final_recommendation": "routing_calibration_scaffold_ready"}})
     monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: {"summary": {"final_recommendation": "sampling_calibration_scaffold_ready"}})
     monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: {"summary": {"final_recommendation": "research_memory_current_artifacts_partial"}})
-    monkeypatch.setattr(packet_module.basket_action_plan, "build_basket_operator_action_plan", lambda **_: {"summary": {"final_recommendation": "basket_operator_action_plan_ready", "first_batch_candidate_symbols": []}})
+    monkeypatch.setattr(
+        packet_module.basket_action_plan,
+        "build_basket_operator_action_plan",
+        lambda **_: {
+            "summary": {
+                "final_recommendation": "basket_operator_action_plan_ready",
+                "first_batch_candidate_symbols": [],
+                "generation_command_discovery_result": "qre_bounded_aapl_nvda_current_basket_generation_discovery",
+                "generation_command_discovery_safe_command_found": False,
+                "generation_command_discovery_final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
+            }
+        },
+    )
     monkeypatch.setattr(
         packet_module.first_batch_readiness,
         "build_first_batch_evidence_recovery_readiness",
@@ -219,7 +236,19 @@ def test_trusted_loop_review_packet_operator_summary_renders(
     monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: snapshots["routing"])
     monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: snapshots["sampling"])
     monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: snapshots["research_memory"])
-    monkeypatch.setattr(packet_module.basket_action_plan, "build_basket_operator_action_plan", lambda **_: {"summary": {"final_recommendation": "basket_operator_action_plan_ready", "first_batch_candidate_symbols": ["AAPL"]}})
+    monkeypatch.setattr(
+        packet_module.basket_action_plan,
+        "build_basket_operator_action_plan",
+        lambda **_: {
+            "summary": {
+                "final_recommendation": "basket_operator_action_plan_ready",
+                "first_batch_candidate_symbols": ["AAPL"],
+                "generation_command_discovery_result": "qre_bounded_aapl_nvda_current_basket_generation_discovery",
+                "generation_command_discovery_safe_command_found": False,
+                "generation_command_discovery_final_recommendation": "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND",
+            }
+        },
+    )
     monkeypatch.setattr(
         packet_module.first_batch_readiness,
         "build_first_batch_evidence_recovery_readiness",


### PR DESCRIPTION
## Summary
Add a read-only discovery report for the approved AAPL/NVDA current-basket scope, then surface the stop condition downstream when no repo-local exact-scope bounded generation command can be proven safe/executable.

## Safety
- Exact scope retained: AAPL,NVDA / trend_pullback_continuation_daily_v1 / daily_v1
- No campaign launch, queue mutation, registry mutation, strategy synthesis, paper/shadow/live, broker/risk/execution, provider activation, or external fetch
- No protected outputs were mutated
- Acceptance verifier remains reject-only for current artifacts

## Validation
- `python -m pytest tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py tests/unit/test_qre_bounded_first_batch_generation_decision.py tests/unit/test_qre_bounded_aapl_nvda_current_basket_generation_discovery.py tests/unit/test_qre_guarded_alias_bounded_generation_cascade.py tests/unit/test_qre_first_batch_evidence_recovery_cascade.py tests/unit/test_qre_first_batch_evidence_recovery_readiness.py tests/unit/test_qre_basket_operator_action_plan.py tests/unit/test_qre_basket_next_action_queue.py tests/unit/test_qre_evidence_complete_basket_closure.py tests/unit/test_qre_trusted_loop_review_packet.py -q`
- `python -m pytest tests/smoke -q`
- `python scripts/governance_lint.py`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Before / After
- Before: preflight-ready bounded generation packet existed, but no repo-local exact-scope bounded generation command was proven
- After: discovery report and downstream consumers now explicitly surface `NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND`

## Commits
- `5d91c26` `feat: add bounded current-basket generation discovery`
- `67b656a` `fix: surface bounded generation stop condition downstream`

## Result
No execution was performed. The PR ends with a fail-closed discovery stop, not a generation run.