### PR TITLE
feat: add generic bounded command discovery

### DIFF
--- a/research/qre_bounded_aapl_nvda_current_basket_generation_discovery.py
+++ b/research/qre_bounded_aapl_nvda_current_basket_generation_discovery.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import subprocess
-from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
 
-from research import qre_bounded_first_batch_generation_decision as decision
+from research import qre_bounded_current_basket_generation_discovery as generic_discovery
 
 
 REPORT_KIND: Final[str] = "qre_bounded_aapl_nvda_current_basket_generation_discovery"
@@ -20,327 +17,103 @@ LATEST_NAME: Final[str] = "latest.json"
 OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
 WRITE_PREFIX: Final[str] = "logs/qre_bounded_aapl_nvda_current_basket_generation_discovery/"
 
+DEPRECATED_WRAPPER_FOR: Final[str] = generic_discovery.REPORT_KIND
 APPROVAL_SCOPE_ID: Final[str] = (
     "aapl_nvda_current_basket_trend_pullback_continuation_daily_v1_daily_v1"
 )
-APPROVED_SYMBOLS: Final[tuple[str, ...]] = ("AAPL", "NVDA")
-APPROVED_PRESET: Final[str] = "trend_pullback_continuation_daily_v1"
-APPROVED_TIMEFRAME: Final[str] = "daily_v1"
-APPROVED_PURPOSE: Final[str] = (
-    "generate_or_restore_and_accept_structured_current_basket_evidence_within_exact_scope"
-)
-SOURCE_PR: Final[str] = "#556"
-SOURCE_MAIN_COMMIT: Final[str] = "8a23507"
 
-SAFE_REPORT_ONLY_COMMANDS: Final[tuple[str, ...]] = (
-    "python -m research.qre_guarded_alias_bounded_generation_cascade --write",
-    "python -m research.qre_bounded_first_batch_generation_decision --write",
-    "python -m research.qre_bounded_generation_artifact_acceptance_verifier --write",
-    "python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery --write",
-)
+_WRAPPER_FIXTURE_REQUEST: Final[dict[str, Any]] = {
+    "request_id": "deprecated-aapl-nvda-fixture",
+    "symbols": ["AAPL", "NVDA"],
+    "preset_id": "trend_pullback_continuation_daily_v1",
+    "timeframe": "daily_v1",
+    "approval_ref": "deprecated-wrapper-fixture",
+    "required_artifact_types": [
+        "generation_manifest",
+        "structured_lineage_artifact",
+        "structured_oos_artifact",
+    ],
+    "allowed_output_paths": [
+        "logs/qre_bounded_aapl_nvda_current_basket_generation_discovery/",
+        "logs/qre_bounded_current_basket_generation_discovery/",
+    ],
+    "forbidden_capabilities": [],
+    "created_at_utc": "2026-06-17T00:00:00Z",
+    "source": "deprecated_compatibility_wrapper",
+}
 
-EXACT_SCOPE_GENERATION_CANDIDATES: Final[tuple[str, ...]] = (
+_WRAPPER_EXACT_SCOPE_COMMANDS: Final[tuple[str, ...]] = (
     "python -m research.controlled_discovery_grid --symbols AAPL,NVDA --preset trend_pullback_continuation_daily_v1 --timeframe daily_v1",
     "python -m research.controlled_validation --symbols AAPL,NVDA --preset trend_pullback_continuation_daily_v1 --timeframe daily_v1",
 )
 
-BROADER_OR_UNSAFE_CANDIDATES: Final[tuple[str, ...]] = (
-    "python -m research.run_research --preset trend_pullback_continuation_daily_v1",
-    "python -m research.campaign_launcher --preset trend_pullback_continuation_daily_v1",
-    "python -m research.qre_controlled_research_run --write",
-    "python -m reporting.qre_controlled_validation_execution --write",
-)
-
-FORBIDDEN_KEYWORDS: Final[dict[str, str]] = {
-    "campaign_launcher": "forbidden_mutation",
-    "run_campaign": "forbidden_mutation",
-    "campaign_queue": "forbidden_mutation",
-    "campaign_registry": "forbidden_mutation",
-    "paper": "forbidden_trading",
-    "shadow": "forbidden_trading",
-    "live": "forbidden_trading",
-    "broker": "forbidden_trading",
-    "risk": "forbidden_trading",
-    "execution": "forbidden_trading",
-    "strategy synthesis": "forbidden_mutation",
-    "strategy registration": "forbidden_mutation",
-    "candidate promotion": "forbidden_mutation",
-    "provider activation": "forbidden_external_fetch",
-    "provider fetch": "forbidden_external_fetch",
-    "external data fetch": "forbidden_external_fetch",
-}
-
-
-def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
-    head = "| " + " | ".join(headers) + " |"
-    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
-    body = ["| " + " | ".join(row) + " |" for row in rows]
-    return "\n".join([head, divider, *body])
-
-
-def _read_json(path: Path) -> dict[str, Any] | None:
-    if not path.is_file():
-        return None
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    return payload if isinstance(payload, dict) else None
-
-
-def _decision_snapshot(repo_root: Path) -> dict[str, Any]:
-    payload = _read_json(
-        repo_root / "logs" / "qre_bounded_first_batch_generation_decision" / "latest.json"
-    )
-    if isinstance(payload, dict) and str(payload.get("report_kind") or "") == "qre_bounded_first_batch_generation_decision":
-        return payload
-    return decision.build_bounded_first_batch_generation_decision(repo_root=repo_root)
-
-
-def _git_commit_iso(repo_root: Path, rev: str) -> str | None:
-    try:
-        result = subprocess.run(
-            ["git", "show", "-s", "--format=%cI", rev],
-            cwd=repo_root,
-            check=False,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-        )
-    except OSError:
-        return None
-    if result.returncode != 0:
-        return None
-    text = result.stdout.strip()
-    return text or None
-
-
-def _module_file_exists(repo_root: Path, module_name: str) -> bool:
-    module_path = repo_root / Path(*module_name.split("."))
-    return module_path.with_suffix(".py").is_file()
-
-
-def _module_has_cli_entrypoint(repo_root: Path, module_name: str) -> bool:
-    module_path = repo_root / Path(*module_name.split("."))
-    path = module_path.with_suffix(".py")
-    if not path.is_file():
-        return False
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    return "if __name__ == \"__main__\"" in text or "argparse.ArgumentParser" in text
-
-
-def _command_to_module_name(command: str) -> str | None:
-    parts = command.split()
-    if len(parts) < 3 or parts[0] != "python" or parts[1] != "-m":
-        return None
-    return parts[2]
-
-
-def _has_exact_scope_tokens(command: str) -> bool:
-    lowered = " ".join(command.split()).lower()
-    return (
-        "aapl,nvda" in lowered
-        and APPROVED_PRESET in lowered
-        and APPROVED_TIMEFRAME in lowered
-    )
-
-
-def _approval_manifest(repo_root: Path) -> dict[str, Any]:
-    created_at_utc = _git_commit_iso(repo_root, SOURCE_MAIN_COMMIT) or "1970-01-01T00:00:00+00:00"
-    return {
-        "approval_scope_id": APPROVAL_SCOPE_ID,
-        "approved_by_operator": True,
-        "approval_text_summary": (
-            "Operator approval is granted for bounded current-basket evidence generation only "
-            "within the exact AAPL/NVDA trend_pullback_continuation_daily_v1 daily_v1 scope."
-        ),
-        "approved_symbols": list(APPROVED_SYMBOLS),
-        "approved_preset": APPROVED_PRESET,
-        "approved_timeframe": APPROVED_TIMEFRAME,
-        "approved_purpose": APPROVED_PURPOSE,
-        "allowed_output_paths": [
-            "logs/",
-            "artifacts/",
-            "archived/",
-            "backup/",
-            "local_quarantine/",
-        ],
-        "forbidden_paths": [
-            "research/research_latest.json",
-            "research/strategy_matrix.csv",
-            "paper/",
-            "shadow/",
-            "live/",
-            "broker/",
-            "risk/",
-            "execution/",
-        ],
-        "forbidden_capabilities": [
-            "campaign_launch",
-            "campaign_queue_mutation",
-            "campaign_registry_mutation",
-            "run_campaign_mutation",
-            "strategy_synthesis",
-            "strategy_registration",
-            "candidate_promotion",
-            "paper_shadow_live",
-            "broker_risk_execution",
-            "provider_activation",
-            "external_data_fetch",
-            "frozen_contract_mutation",
-        ],
-        "created_at_utc": created_at_utc,
-        "source_pr": SOURCE_PR,
-        "source_main_commit": SOURCE_MAIN_COMMIT,
-    }
-
-
-def _classify_candidate(command: str, repo_root: Path) -> dict[str, Any]:
-    envelope = decision.classify_command_envelope(command)
-    module_name = _command_to_module_name(command)
-    module_exists = _module_file_exists(repo_root, module_name) if module_name else False
-    module_has_cli = _module_has_cli_entrypoint(repo_root, module_name) if module_name else False
-    exact_scope = _has_exact_scope_tokens(command)
-    lowered = command.lower()
-    disposition = "unknown_requires_operator_review"
-    reason = "exact_scope_bounded_generation_command_not_found"
-    if envelope["classification"] == "safe_report_only":
-        disposition = "report_only"
-        reason = "report_only_command_does_not_generate_evidence"
-    elif envelope["classification"] == "approval_required_generation" and exact_scope:
-        if module_exists and module_has_cli:
-            disposition = "bounded_generation_approved_for_this_pr"
-            reason = "exact_scope_cli_entrypoint_present_but_operator_approval_required"
-        else:
-            disposition = "unknown_requires_operator_review"
-            reason = "exact_scope_candidate_missing_cli_entrypoint_or_module"
-    elif envelope["classification"] in {"forbidden_mutation", "forbidden_trading", "forbidden_external_fetch"}:
-        disposition = envelope["classification"]
-        reason = "command_exceeds_read_only_governance_boundary"
-    elif any(fragment in lowered for fragment in FORBIDDEN_KEYWORDS):
-        disposition = "unknown_requires_operator_review"
-        reason = "command_contains_forbidden_fragment"
-
-    return {
-        "command": command,
-        "module_name": module_name,
-        "module_exists": module_exists,
-        "module_has_cli_entrypoint": module_has_cli,
-        "exact_scope_match": exact_scope,
-        "classification": envelope["classification"],
-        "disposition": disposition,
-        "reason": reason,
-        "operator_approval_required": bool(envelope.get("operator_approval_required")) or disposition != "report_only",
-        "auto_run_allowed": False,
-        "safe_command_available": disposition == "bounded_generation_approved_for_this_pr",
-    }
-
 
 def build_bounded_aapl_nvda_current_basket_generation_discovery(
-    *,
-    repo_root: Path = Path("."),
+    *, repo_root: Path = Path(".")
 ) -> dict[str, Any]:
-    approval_manifest = _approval_manifest(repo_root)
-    preflight = _decision_snapshot(repo_root)
-    candidate_commands = (
-        *SAFE_REPORT_ONLY_COMMANDS,
-        *EXACT_SCOPE_GENERATION_CANDIDATES,
-        *BROADER_OR_UNSAFE_CANDIDATES,
+    generic_report = generic_discovery.build_bounded_current_basket_generation_discovery(
+        _WRAPPER_FIXTURE_REQUEST,
+        repo_root=repo_root,
     )
-    command_rows = [_classify_candidate(command, repo_root) for command in candidate_commands]
-    safe_candidates = [row for row in command_rows if bool(row.get("safe_command_available"))]
-    exact_scope_candidates = [row for row in command_rows if bool(row.get("exact_scope_match"))]
+    generic_rows = (
+        generic_report.get("command_surface", {}).get("rows")
+        if isinstance(generic_report.get("command_surface"), dict)
+        else []
+    )
+    transformed_rows: list[dict[str, Any]] = []
+    for row in generic_rows if isinstance(generic_rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        command = str(row.get("command") or "")
+        exact_scope_match = command in _WRAPPER_EXACT_SCOPE_COMMANDS
+        disposition = str(row.get("classification") or "")
+        transformed_rows.append(
+            {
+                "command": command,
+                "module_name": row.get("module_name"),
+                "module_exists": row.get("module_exists"),
+                "module_has_cli_entrypoint": row.get("module_has_cli_entrypoint"),
+                "exact_scope_match": exact_scope_match,
+                "classification": row.get("classification"),
+                "disposition": disposition,
+                "reason": row.get("classification_reason"),
+                "operator_approval_required": row.get("operator_approval_required"),
+                "auto_run_allowed": row.get("auto_run_allowed"),
+                "safe_command_available": row.get("safe_command_available"),
+            }
+        )
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
+        "deprecated_wrapper_for": DEPRECATED_WRAPPER_FOR,
+        "approval_scope_id": APPROVAL_SCOPE_ID,
+        "request": generic_report.get("request", {}),
         "summary": {
-            "approval_scope_id": approval_manifest["approval_scope_id"],
-            "approval_packet_ready": bool((preflight.get("preflight") or {}).get("approval_packet_ready")),
-            "blocking_preflight_reasons": list((preflight.get("preflight") or {}).get("blocking_preflight_reasons") or []),
-            "safe_bounded_generation_command_found": bool(safe_candidates),
-            "safe_bounded_generation_command_count": len(safe_candidates),
-            "exact_scope_candidate_count": len(exact_scope_candidates),
-            "final_recommendation": (
-                "bounded_generation_command_found"
-                if safe_candidates
-                else "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
+            "approval_scope_id": APPROVAL_SCOPE_ID,
+            "safe_bounded_generation_command_found": bool(
+                generic_report.get("summary", {}).get("safe_bounded_generation_command_found")
+            ),
+            "exact_scope_candidate_count": sum(1 for row in transformed_rows if row["exact_scope_match"]),
+            "final_recommendation": str(
+                generic_report.get("summary", {}).get("final_recommendation")
+                or "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
             ),
             "operator_summary": (
-                "No repo-local exact-scope bounded generation command can be proven safe and executable "
-                "from the current command surface; report-only surfaces remain available."
-                if not safe_candidates
-                else "A repo-local exact-scope bounded generation command is available but remains operator-approved only."
+                "Deprecated AAPL/NVDA compatibility wrapper delegates to the generic bounded "
+                "current-basket discovery report."
             ),
         },
-        "approval_manifest": approval_manifest,
-        "preflight": preflight.get("preflight") or {},
-        "command_surface": {
-            "safe_report_only": list(SAFE_REPORT_ONLY_COMMANDS),
-            "exact_scope_generation_candidates": list(EXACT_SCOPE_GENERATION_CANDIDATES),
-            "broader_or_unsafe_candidates": list(BROADER_OR_UNSAFE_CANDIDATES),
-            "rows": command_rows,
-        },
-        "decision_packet_ref": "logs/qre_bounded_first_batch_generation_decision/latest.json",
-        "safety_invariants": {
-            "read_only": True,
-            "no_actual_generation_run": True,
-            "no_campaign_mutation": True,
-            "no_queue_mutation": True,
-            "no_registry_mutation": True,
-            "no_trading_authority": True,
-            "no_external_provider_activation": True,
-            "no_frozen_contract_mutation": True,
-            "no_context_only_evidence_promoted_to_proof": True,
-        },
+        "command_surface": {"rows": transformed_rows},
+        "safety_invariants": generic_report.get("safety_invariants", {}),
+        "generic_discovery_report": generic_report,
     }
 
 
-def render_operator_summary(report: Mapping[str, Any]) -> str:
-    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
-    approval = report.get("approval_manifest") if isinstance(report.get("approval_manifest"), Mapping) else {}
-    rows = report.get("command_surface", {}).get("rows") if isinstance(report.get("command_surface"), Mapping) else []
-    return "\n".join(
-        [
-            "# QRE Bounded AAPL/NVDA Current-Basket Generation Discovery",
-            "",
-            _table(
-                ["Field", "Value"],
-                [
-                    ["approval_scope_id", str(summary.get("approval_scope_id") or "")],
-                    ["approval_packet_ready", str(bool(summary.get("approval_packet_ready"))).lower()],
-                    ["safe_bounded_generation_command_found", str(bool(summary.get("safe_bounded_generation_command_found"))).lower()],
-                    ["final_recommendation", str(summary.get("final_recommendation") or "")],
-                ],
-            ),
-            "",
-            _table(
-                ["Approval", "Value"],
-                [
-                    ["approved_symbols", ",".join(str(v) for v in approval.get("approved_symbols") or []) or "none"],
-                    ["approved_preset", str(approval.get("approved_preset") or "")],
-                    ["approved_timeframe", str(approval.get("approved_timeframe") or "")],
-                    ["source_pr", str(approval.get("source_pr") or "")],
-                    ["source_main_commit", str(approval.get("source_main_commit") or "")],
-                ],
-            ),
-            "",
-            _table(
-                ["Command", "Disposition", "Module", "Exact Scope", "Safe bounded"],
-                [
-                    [
-                        str(row.get("command") or ""),
-                        str(row.get("disposition") or ""),
-                        str(row.get("module_name") or ""),
-                        str(bool(row.get("exact_scope_match"))).lower(),
-                        str(bool(row.get("safe_command_available"))).lower(),
-                    ]
-                    for row in rows
-                ] or [["none", "none", "none", "false", "false"]],
-            ),
-        ]
+def render_operator_summary(report: dict[str, Any]) -> str:
+    return generic_discovery.render_operator_summary(
+        report.get("generic_discovery_report", {})
+        if isinstance(report, dict)
+        else {}
     )
 
 
@@ -352,7 +125,7 @@ def _validate_write_target(path: Path) -> None:
 
 
 def write_outputs(
-    report: Mapping[str, Any],
+    report: dict[str, Any],
     *,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
     repo_root: Path = Path("."),
@@ -363,22 +136,25 @@ def write_outputs(
     summary_path = base / OPERATOR_SUMMARY_NAME
     for target in (latest, summary_path):
         _validate_write_target(target)
-    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
-    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    os.replace(tmp_json, latest)
-    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
-    tmp_md.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
-    os.replace(tmp_md, summary_path)
+    generic_paths = generic_discovery.write_outputs(
+        report.get("generic_discovery_report", {}),
+        output_dir=Path("logs/qre_bounded_current_basket_generation_discovery"),
+        repo_root=repo_root,
+    )
+    latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_path.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
     return {
         "latest": latest.relative_to(repo_root).as_posix(),
         "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+        "generic_latest": generic_paths["latest"],
+        "generic_operator_summary": generic_paths["operator_summary"],
     }
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery",
-        description="Build the bounded AAPL/NVDA current-basket generation discovery report.",
+        description="Build the deprecated AAPL/NVDA compatibility wrapper report.",
     )
     parser.add_argument("--write", action="store_true")
     args = parser.parse_args(argv)

--- a/research/qre_bounded_current_basket_generation_discovery.py
+++ b/research/qre_bounded_current_basket_generation_discovery.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_bounded_basket_request as basket_request
+
+
+REPORT_KIND: Final[str] = "qre_bounded_current_basket_generation_discovery"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_bounded_current_basket_generation_discovery")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_bounded_current_basket_generation_discovery/"
+
+SAFE_REPORT_ONLY_COMMANDS: Final[tuple[str, ...]] = (
+    "python -m research.qre_bounded_basket_request --write",
+    "python -m research.qre_bounded_current_basket_generation_discovery --write",
+)
+
+FORBIDDEN_KEYWORDS: Final[dict[str, str]] = {
+    "campaign_launcher": "forbidden_mutation",
+    "run_campaign": "forbidden_mutation",
+    "campaign_queue": "forbidden_mutation",
+    "campaign_registry": "forbidden_mutation",
+    "paper": "forbidden_trading",
+    "shadow": "forbidden_trading",
+    "live": "forbidden_trading",
+    "broker": "forbidden_trading",
+    "risk": "forbidden_trading",
+    "execution": "forbidden_trading",
+    "strategy synthesis": "forbidden_mutation",
+    "strategy registration": "forbidden_mutation",
+    "candidate promotion": "forbidden_mutation",
+    "provider activation": "forbidden_external_fetch",
+    "provider fetch": "forbidden_external_fetch",
+    "external data fetch": "forbidden_external_fetch",
+}
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _request_snapshot(
+    request_payload: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if request_payload is None:
+        return {
+            "schema_version": basket_request.SCHEMA_VERSION,
+            "report_kind": basket_request.REPORT_KIND,
+            "request": {},
+            "validation_status": "rejected",
+            "rejection_reasons": ["missing_request_payload"],
+        }
+    return basket_request.build_bounded_basket_request_snapshot(request_payload)
+
+
+def _git_commit_iso(repo_root: Path, rev: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "show", "-s", "--format=%cI", rev],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    text = result.stdout.strip()
+    return text or None
+
+
+def _module_file_exists(repo_root: Path, module_name: str) -> bool:
+    module_path = repo_root / Path(*module_name.split("."))
+    return module_path.with_suffix(".py").is_file()
+
+
+def _module_has_cli_entrypoint(repo_root: Path, module_name: str) -> bool:
+    module_path = repo_root / Path(*module_name.split("."))
+    path = module_path.with_suffix(".py")
+    if not path.is_file():
+        return False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "if __name__ == \"__main__\"" in text or "argparse.ArgumentParser" in text
+
+
+def _command_to_module_name(command: str) -> str | None:
+    parts = command.split()
+    if len(parts) < 3 or parts[0] != "python" or parts[1] != "-m":
+        return None
+    return parts[2]
+
+
+def _request_tokens(request_payload: Mapping[str, Any]) -> tuple[str, str, str]:
+    request = request_payload.get("request")
+    if not isinstance(request, Mapping):
+        return "", "", ""
+    symbols = ",".join(str(symbol) for symbol in request.get("symbols") or [])
+    preset_id = str(request.get("preset_id") or "")
+    timeframe = str(request.get("timeframe") or "")
+    return symbols, preset_id, timeframe
+
+
+def _scope_fit(command: str, *, request_payload: Mapping[str, Any]) -> str:
+    symbols, preset_id, timeframe = _request_tokens(request_payload)
+    lowered = " ".join(command.split()).lower()
+    if "research.qre_bounded_current_basket_generation_runner" in lowered:
+        return "exact" if symbols and preset_id and timeframe else "mismatch"
+    if not symbols or not preset_id or not timeframe:
+        return "mismatch"
+    if symbols.lower() in lowered and preset_id.lower() in lowered and timeframe.lower() in lowered:
+        return "exact"
+    if any(token in lowered for token in (symbols.lower(), preset_id.lower(), timeframe.lower())):
+        return "partial"
+    return "mismatch"
+
+
+def _classify_candidate(
+    command: str,
+    *,
+    request_payload: Mapping[str, Any],
+    repo_root: Path,
+) -> dict[str, Any]:
+    module_name = _command_to_module_name(command)
+    module_exists = _module_file_exists(repo_root, module_name) if module_name else False
+    module_has_cli = _module_has_cli_entrypoint(repo_root, module_name) if module_name else False
+    scope_fit = _scope_fit(command, request_payload=request_payload)
+    lowered = " ".join(command.split()).lower()
+    missing_prerequisites: list[str] = []
+    classification = "unknown_requires_operator_review"
+    classification_reason = "command_requires_operator_review"
+    next_action = "operator_review_required"
+
+    if command in SAFE_REPORT_ONLY_COMMANDS:
+        classification = "report_only"
+        classification_reason = "read_only_report_command"
+        next_action = "use_for_read_only_review"
+    elif any(fragment in lowered for fragment in FORBIDDEN_KEYWORDS):
+        for fragment, mapped in FORBIDDEN_KEYWORDS.items():
+            if fragment in lowered:
+                classification = mapped
+                classification_reason = f"contains_forbidden_fragment:{fragment}"
+                next_action = "reject_command"
+                break
+    elif module_name == "research.controlled_discovery_grid" and scope_fit == "exact":
+        classification = "bounded_generation_candidate"
+        classification_reason = "exact_scope_discovery_candidate"
+        next_action = "operator_approval_required"
+        if not module_exists:
+            missing_prerequisites.append("module_missing")
+        if module_exists and not module_has_cli:
+            missing_prerequisites.append("module_has_no_cli_entrypoint")
+    elif module_name == "research.controlled_validation" and scope_fit == "exact":
+        classification = "approval_required_generation"
+        classification_reason = "exact_scope_validation_requires_operator_approval"
+        next_action = "operator_approval_required"
+        if not module_exists:
+            missing_prerequisites.append("module_missing")
+        if module_exists and not module_has_cli:
+            missing_prerequisites.append("module_has_no_cli_entrypoint")
+    elif module_name == "research.qre_bounded_current_basket_generation_runner" and scope_fit == "exact":
+        classification = "unknown_requires_operator_review"
+        classification_reason = "runner_scaffold_not_yet_available"
+        next_action = "build_runner_scaffold_or_keep_fail_closed"
+        if not module_exists:
+            missing_prerequisites.append("module_missing")
+    elif scope_fit == "exact":
+        classification = "unknown_requires_operator_review"
+        classification_reason = "exact_scope_command_requires_operator_review"
+        next_action = "operator_review_required"
+
+    return {
+        "command": command,
+        "module_name": module_name,
+        "module_exists": module_exists,
+        "module_has_cli_entrypoint": module_has_cli,
+        "scope_fit": scope_fit,
+        "exact_scope_match": scope_fit == "exact",
+        "classification": classification,
+        "classification_reason": classification_reason,
+        "missing_prerequisites": missing_prerequisites,
+        "next_action": next_action,
+        "operator_approval_required": classification != "report_only",
+        "auto_run_allowed": False,
+        "safe_command_available": classification == "report_only",
+    }
+
+
+def _candidate_commands(request_payload: Mapping[str, Any]) -> list[str]:
+    symbols, preset_id, timeframe = _request_tokens(request_payload)
+    symbols_arg = symbols or ""
+    exact_scope = f"--symbols {symbols_arg} --preset {preset_id} --timeframe {timeframe}"
+    return [
+        *SAFE_REPORT_ONLY_COMMANDS,
+        "python -m research.controlled_discovery_grid " + exact_scope,
+        "python -m research.controlled_validation " + exact_scope,
+        "python -m research.qre_bounded_current_basket_generation_runner --request-file logs/qre_bounded_basket_request/latest.json",
+        f"python -m research.run_research --preset {preset_id}",
+        f"python -m research.campaign_launcher --preset {preset_id}",
+        "python -m research.campaign_queue mutation",
+        "python -m research.campaign_registry mutation",
+        "python -m research.paper shadow live",
+        "python -m research.broker risk execution",
+        "python -m research.strategy synthesis",
+        "python -m research.strategy registration",
+        "python -m research.candidate promotion",
+        "python -m research.provider activation",
+        "python -m research.external data fetch",
+    ]
+
+
+def build_bounded_current_basket_generation_discovery(
+    request_payload: Mapping[str, Any] | None = None,
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    request_report = _request_snapshot(request_payload)
+    request = request_report.get("request") if isinstance(request_report.get("request"), Mapping) else {}
+    command_rows = []
+    if request_report.get("validation_status") == "valid":
+        command_rows = [
+            _classify_candidate(command, request_payload=request_report, repo_root=repo_root)
+            for command in _candidate_commands(request_report)
+        ]
+    counts = Counter(str(row["classification"]) for row in command_rows)
+    exact_scope_candidates = [row for row in command_rows if row["scope_fit"] == "exact"]
+    safe_candidates = [
+        row
+        for row in exact_scope_candidates
+        if row["classification"] == "bounded_generation_candidate"
+        and row["module_exists"]
+        and row["module_has_cli_entrypoint"]
+        and not row["missing_prerequisites"]
+    ]
+    top_blocker = ""
+    for row in exact_scope_candidates:
+        if row["classification"] != "report_only":
+            top_blocker = row["classification_reason"]
+            if row["missing_prerequisites"]:
+                top_blocker = f"{top_blocker}:{','.join(row['missing_prerequisites'])}"
+            break
+    final_recommendation = (
+        "request_invalid_fails_closed"
+        if request_report.get("validation_status") != "valid"
+        else "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "request": request,
+        "request_validation_status": request_report.get("validation_status"),
+        "request_rejection_reasons": list(request_report.get("rejection_reasons") or []),
+        "summary": {
+            "request_id": str(request.get("request_id") or ""),
+            "symbols": list(request.get("symbols") or []),
+            "preset_id": str(request.get("preset_id") or ""),
+            "timeframe": str(request.get("timeframe") or ""),
+            "scope_hash": str(request.get("scope_hash") or ""),
+            "exact_scope_candidate_count": len(exact_scope_candidates),
+            "report_only_count": sum(1 for row in command_rows if row["classification"] == "report_only"),
+            "bounded_generation_candidate_count": sum(
+                1 for row in command_rows if row["classification"] == "bounded_generation_candidate"
+            ),
+            "approval_required_generation_count": sum(
+                1 for row in command_rows if row["classification"] == "approval_required_generation"
+            ),
+            "forbidden_count": sum(
+                1
+                for row in command_rows
+                if row["classification"] in {"forbidden_mutation", "forbidden_trading", "forbidden_external_fetch"}
+            ),
+            "unknown_count": sum(1 for row in command_rows if row["classification"] == "unknown_requires_operator_review"),
+            "safe_bounded_generation_command_found": bool(safe_candidates),
+            "top_blocker": top_blocker,
+            "operator_summary": (
+                "Generic bounded command discovery is request-driven and remains fail-closed until a safe bounded command exists."
+            ),
+            "final_recommendation": final_recommendation,
+        },
+        "command_surface": {
+            "rows": command_rows,
+            "classification_counts": dict(sorted(counts.items())),
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "request_driven": True,
+            "symbol_agnostic_core_paths": True,
+            "no_trading_authority": True,
+            "no_auto_run": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    request = report.get("request") if isinstance(report.get("request"), Mapping) else {}
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    rows = report.get("command_surface", {}).get("rows") if isinstance(report.get("command_surface"), Mapping) else []
+    rows = rows if isinstance(rows, list) else []
+    return "\n".join(
+        [
+            "# QRE Bounded Current Basket Generation Discovery",
+            "",
+            "## Summary",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["request_id", str(summary.get("request_id") or "")],
+                    ["validation_status", str(report.get("request_validation_status") or "")],
+                    ["final_recommendation", str(summary.get("final_recommendation") or "")],
+                    ["top_blocker", str(summary.get("top_blocker") or "")],
+                ],
+            ),
+            "",
+            "## Request",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["symbols", ", ".join(str(v) for v in request.get("symbols") or []) or "none"],
+                    ["preset_id", str(request.get("preset_id") or "")],
+                    ["timeframe", str(request.get("timeframe") or "")],
+                    ["scope_hash", str(request.get("scope_hash") or "")],
+                ],
+            ),
+            "",
+            "## Command Surface",
+            _table(
+                ["Command", "Classification", "Scope fit"],
+                [
+                    [
+                        str(row.get("command") or ""),
+                        str(row.get("classification") or ""),
+                        str(row.get("scope_fit") or ""),
+                    ]
+                    for row in rows[:20]
+                ]
+                or [["none", "none", "none"]],
+            ),
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_bounded_current_basket_generation_discovery: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_bounded_current_basket_generation_discovery",
+        description="Build the generic bounded current-basket generation discovery report.",
+    )
+    parser.add_argument("--request-file", type=Path, required=True)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    payload = json.loads(args.request_file.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("request file must contain a JSON object")
+    report = build_bounded_current_basket_generation_discovery(payload)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_bounded_first_batch_generation_decision.py
+++ b/research/qre_bounded_first_batch_generation_decision.py
@@ -25,6 +25,7 @@ SAFE_REPORT_ONLY_COMMANDS: Final[tuple[str, ...]] = (
     "python -m research.qre_guarded_alias_bounded_generation_cascade --write",
     "python -m research.qre_guarded_preset_timeframe_alias_policy --write",
     "python -m research.qre_bounded_first_batch_generation_decision --write",
+    "python -m research.qre_bounded_current_basket_generation_discovery --write",
     "python -m research.qre_bounded_aapl_nvda_current_basket_generation_discovery --write",
 )
 SAFE_PREFLIGHT_COMMANDS: Final[tuple[str, ...]] = ()

--- a/tests/unit/test_qre_bounded_current_basket_generation_discovery.py
+++ b/tests/unit/test_qre_bounded_current_basket_generation_discovery.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from research import qre_bounded_basket_request as basket_request
+from research import qre_bounded_current_basket_generation_discovery as discovery
+
+
+def _request_payload() -> dict[str, object]:
+    return {
+        "request_id": "req-generic-001",
+        "symbols": ["QQQ", "MSFT"],
+        "preset_id": "trend_pullback_continuation_daily_v1",
+        "timeframe": "daily_v1",
+        "approval_ref": "approval-manifest-001",
+        "required_artifact_types": [
+            "generation_manifest",
+            "structured_lineage_artifact",
+            "structured_oos_artifact",
+        ],
+        "allowed_output_paths": [
+            "logs/qre_bounded_current_basket_generation_discovery/",
+            "artifacts/qre_bounded_current_basket_generation_discovery/",
+        ],
+        "forbidden_capabilities": [],
+        "created_at_utc": "2026-06-17T16:05:00Z",
+        "source": "request_fixture",
+    }
+
+
+def test_generic_discovery_reports_request_driven_command_surface() -> None:
+    report = discovery.build_bounded_current_basket_generation_discovery(_request_payload())
+
+    assert report["report_kind"] == "qre_bounded_current_basket_generation_discovery"
+    assert report["request"]["symbols"] == ["MSFT", "QQQ"]
+    assert report["summary"]["exact_scope_candidate_count"] == 3
+    assert report["summary"]["safe_bounded_generation_command_found"] is False
+    assert report["summary"]["final_recommendation"] == "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
+
+
+def test_generic_discovery_classifies_candidate_commands() -> None:
+    report = discovery.build_bounded_current_basket_generation_discovery(_request_payload())
+    rows = report["command_surface"]["rows"]
+    row_by_command = {row["command"]: row for row in rows}
+
+    assert row_by_command[
+        "python -m research.qre_bounded_current_basket_generation_discovery --write"
+    ]["classification"] == "report_only"
+    assert row_by_command[
+        "python -m research.controlled_discovery_grid --symbols MSFT,QQQ --preset trend_pullback_continuation_daily_v1 --timeframe daily_v1"
+    ]["classification"] == "bounded_generation_candidate"
+    assert row_by_command[
+        "python -m research.controlled_validation --symbols MSFT,QQQ --preset trend_pullback_continuation_daily_v1 --timeframe daily_v1"
+    ]["classification"] == "approval_required_generation"
+    assert row_by_command[
+        "python -m research.qre_bounded_current_basket_generation_runner --request-file logs/qre_bounded_basket_request/latest.json"
+    ]["classification"] == "unknown_requires_operator_review"
+    assert row_by_command[
+        "python -m research.campaign_launcher --preset trend_pullback_continuation_daily_v1"
+    ]["classification"] == "forbidden_mutation"
+
+
+def test_generic_discovery_is_deterministic() -> None:
+    first = discovery.build_bounded_current_basket_generation_discovery(_request_payload())
+    second = discovery.build_bounded_current_basket_generation_discovery(_request_payload())
+
+    assert first == second
+
+
+def test_compatibility_wrapper_delegates_to_generic_surface() -> None:
+    from research import qre_bounded_aapl_nvda_current_basket_generation_discovery as wrapper
+
+    report = wrapper.build_bounded_aapl_nvda_current_basket_generation_discovery()
+
+    assert report["report_kind"] == "qre_bounded_aapl_nvda_current_basket_generation_discovery"
+    assert report["deprecated_wrapper_for"] == discovery.REPORT_KIND
+    assert report["generic_discovery_report"]["report_kind"] == discovery.REPORT_KIND
+    assert report["summary"]["final_recommendation"] == "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
+    assert basket_request.REPORT_KIND == "qre_bounded_basket_request"


### PR DESCRIPTION
feat: add generic bounded command discovery

Summary
- Adds a request-driven bounded current-basket command discovery module that classifies report-only, bounded-generation, approval-required, forbidden, and unknown commands.
- Keeps the older AAPL/NVDA discovery surface as a deprecated compatibility wrapper that delegates to the generic request-driven module.
- Updates the first-batch decision report to recognize the new generic discovery report as a safe report-only command.

Safety
- No command execution was added.
- No trading, execution, provider fetch, or frozen-contract behavior was introduced.
- No research/research_latest.json or strategy_matrix.csv mutation.

Validation
- python -m pytest tests/unit/test_qre_bounded_basket_request.py tests/unit/test_qre_bounded_current_basket_generation_discovery.py tests/unit/test_qre_bounded_aapl_nvda_current_basket_generation_discovery.py tests/unit/test_qre_bounded_first_batch_generation_decision.py tests/unit/test_qre_first_batch_evidence_recovery_readiness.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

Phase report-out
- phase: generic bounded command discovery
- blocker before: discovery logic was still AAPL/NVDA-specific
- blocker after: generic request-driven discovery exists; bounded generation remains fail-closed because no safe bounded execution command is proven yet
- why continuing: this makes the next runner/authority phases possible without symbol-special-case core logic
