### PR TITLE
feat: add behavior catalog and hypothesis model foundations

### DIFF
--- a/research/qre_behavior_catalog.py
+++ b/research/qre_behavior_catalog.py
@@ -1,0 +1,426 @@
+"""Canonical QRE behavior catalog.
+
+This module defines the research-intelligence taxonomy for market
+behaviors. It is context-only: it does not create strategy authority,
+does not authorize execution, and does not clear evidence blockers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final, Literal
+
+
+BehaviorStatus = Literal["active", "provisional", "deprecated", "blocked"]
+
+BEHAVIOR_CATALOG_SCHEMA_VERSION: Final[str] = "1.0"
+
+
+@dataclass(frozen=True)
+class BehaviorFamily:
+    behavior_id: str
+    display_name: str
+    description: str
+    expected_observables: tuple[str, ...]
+    typical_timeframes: tuple[str, ...]
+    compatible_preset_patterns: tuple[str, ...]
+    required_data_capabilities: tuple[str, ...]
+    common_failure_modes: tuple[str, ...]
+    forbidden_interpretations: tuple[str, ...]
+    evidence_requirements: tuple[str, ...]
+    status: BehaviorStatus
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "behavior_id": self.behavior_id,
+            "display_name": self.display_name,
+            "description": self.description,
+            "expected_observables": list(self.expected_observables),
+            "typical_timeframes": list(self.typical_timeframes),
+            "compatible_preset_patterns": list(self.compatible_preset_patterns),
+            "required_data_capabilities": list(self.required_data_capabilities),
+            "common_failure_modes": list(self.common_failure_modes),
+            "forbidden_interpretations": list(self.forbidden_interpretations),
+            "evidence_requirements": list(self.evidence_requirements),
+            "status": self.status,
+        }
+
+
+BEHAVIOR_CATALOG: Final[tuple[BehaviorFamily, ...]] = (
+    BehaviorFamily(
+        behavior_id="trend_continuation",
+        display_name="Trend Continuation",
+        description=(
+            "Price continues in the direction of an established trend after "
+            "a bounded consolidation or minor retracement."
+        ),
+        expected_observables=(
+            "higher_highs_or_lower_lows",
+            "trend_aligned_breakout_follow_through",
+            "compression_then_expansion",
+        ),
+        typical_timeframes=("1d", "4h", "1h"),
+        compatible_preset_patterns=("trend_*", "*continuation*", "*breakout*"),
+        required_data_capabilities=(
+            "time_series_ohlcv",
+            "regime_context",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "trend_exhaustion",
+            "late_entry",
+            "mean_reversion_snapback",
+        ),
+        forbidden_interpretations=(
+            "guaranteed_alpha",
+            "execution_authorization",
+            "candidate_authority",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="active",
+    ),
+    BehaviorFamily(
+        behavior_id="pullback_continuation",
+        display_name="Pullback Continuation",
+        description=(
+            "Temporary retracement within a trend resolves and resumes the "
+            "prior directional move."
+        ),
+        expected_observables=(
+            "retracement_into_trend_zone",
+            "support_or_resistance_reclaim",
+            "post_pullback_expansion",
+        ),
+        typical_timeframes=("1d", "4h"),
+        compatible_preset_patterns=("trend_pullback*", "*reclaim*", "*retracement*"),
+        required_data_capabilities=(
+            "time_series_ohlcv",
+            "trend_context",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "pullback_becomes_reversal",
+            "insufficient_trades",
+            "cost_fragility",
+        ),
+        forbidden_interpretations=(
+            "guaranteed_rebound",
+            "strategy_registration",
+            "campaign_launch_authority",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="active",
+    ),
+    BehaviorFamily(
+        behavior_id="volatility_compression_breakout",
+        display_name="Volatility Compression Breakout",
+        description=(
+            "Compressed volatility resolves into expansion with a directional "
+            "breakout after a bounded consolidation."
+        ),
+        expected_observables=(
+            "narrow_range_compression",
+            "range_break_or_gap",
+            "post_breakout_expansion",
+        ),
+        typical_timeframes=("1d", "4h"),
+        compatible_preset_patterns=("vol_compression*", "*breakout*", "*expansion*"),
+        required_data_capabilities=(
+            "time_series_ohlcv",
+            "volatility_measurements",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "false_breakout",
+            "whipsaw",
+            "liquidity_thinness",
+        ),
+        forbidden_interpretations=(
+            "signal_to_trade_without_validation",
+            "proof_of_edge",
+            "candidate_promotion_authority",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="active",
+    ),
+    BehaviorFamily(
+        behavior_id="relative_strength",
+        display_name="Relative Strength",
+        description=(
+            "A basket or symbol outperforms a peer set or benchmark across a "
+            "bounded window."
+        ),
+        expected_observables=(
+            "benchmark_relative_outperformance",
+            "peer_rank_persistence",
+            "leadership_retention",
+        ),
+        typical_timeframes=("1d", "1w", "4h"),
+        compatible_preset_patterns=("relative_strength*", "*leader*", "*outperform*"),
+        required_data_capabilities=(
+            "cross_sectional_prices",
+            "benchmark_series",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "benchmark_instability",
+            "narrow_sample",
+            "regime_shift",
+        ),
+        forbidden_interpretations=(
+            "portfolio_allocation_authority",
+            "execution_authority",
+            "alpha_proof_without_oos",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="active",
+    ),
+    BehaviorFamily(
+        behavior_id="post_shock_stabilization",
+        display_name="Post-Shock Stabilization",
+        description=(
+            "After a shock event, price action compresses and stabilizes "
+            "before choosing a direction."
+        ),
+        expected_observables=(
+            "shock_gap_or_spike",
+            "volatility_decay",
+            "range_contraction",
+        ),
+        typical_timeframes=("1d", "4h"),
+        compatible_preset_patterns=("post_shock*", "*stabilization*", "*recovery*"),
+        required_data_capabilities=(
+            "event_context",
+            "time_series_ohlcv",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "continuing_dislocation",
+            "news_driven_instability",
+            "thin_liquidity",
+        ),
+        forbidden_interpretations=(
+            "shock_recovery_assurance",
+            "strategy_synthesis_authority",
+            "live_trading_permission",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="active",
+    ),
+    BehaviorFamily(
+        behavior_id="index_regime_filter",
+        display_name="Index Regime Filter",
+        description=(
+            "Broad index regime state informs whether a tighter research or "
+            "sampling path is appropriate."
+        ),
+        expected_observables=(
+            "index_trend_state",
+            "breadth_pressure",
+            "regime_shift_signal",
+        ),
+        typical_timeframes=("1d", "1w"),
+        compatible_preset_patterns=("index_*", "*regime*", "*filter*"),
+        required_data_capabilities=(
+            "index_series",
+            "breadth_context",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "regime_label_drift",
+            "broad_market_noise",
+            "sample_misalignment",
+        ),
+        forbidden_interpretations=(
+            "trade_signal_on_its_own",
+            "campaign_authority",
+            "candidate_authority",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="active",
+    ),
+    BehaviorFamily(
+        behavior_id="mean_reversion",
+        display_name="Mean Reversion",
+        description=(
+            "Transient deviations revert toward a local mean after bounded "
+            "extreme moves or overextension."
+        ),
+        expected_observables=(
+            "overshoot_then_revert",
+            "extreme_distance_from_mean",
+            "fade_then_normalize",
+        ),
+        typical_timeframes=("1d", "4h", "1h"),
+        compatible_preset_patterns=("mean_reversion*", "*fade*", "*revert*"),
+        required_data_capabilities=(
+            "time_series_ohlcv",
+            "mean_reversion_context",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "trend_regime_inversion",
+            "cost_fragility",
+            "tail_risk",
+        ),
+        forbidden_interpretations=(
+            "guaranteed_recovery",
+            "alpha_proof_without_oos",
+            "deployment_authority",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="provisional",
+    ),
+    BehaviorFamily(
+        behavior_id="momentum_acceleration",
+        display_name="Momentum Acceleration",
+        description=(
+            "Momentum strengthens over a bounded window, often with rising "
+            "participation or volatility."
+        ),
+        expected_observables=(
+            "range_expansion",
+            "increasing_slope",
+            "participation_strength",
+        ),
+        typical_timeframes=("1d", "4h"),
+        compatible_preset_patterns=("momentum*", "*acceleration*", "*impulse*"),
+        required_data_capabilities=(
+            "time_series_ohlcv",
+            "participation_context",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "late_entry",
+            "exhaustion_move",
+            "whipsaw",
+        ),
+        forbidden_interpretations=(
+            "strategy_authority",
+            "execution_authority",
+            "candidate_promotion_authority",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="active",
+    ),
+    BehaviorFamily(
+        behavior_id="defensive_rotation",
+        display_name="Defensive Rotation",
+        description=(
+            "Risk-off style rotation into defensive exposures during stress or "
+            "uncertainty."
+        ),
+        expected_observables=(
+            "relative_defensive_strength",
+            "risk_off_breadth",
+            "rotation_persistence",
+        ),
+        typical_timeframes=("1d", "1w"),
+        compatible_preset_patterns=("defensive_rotation*", "*defensive*", "*risk_off*"),
+        required_data_capabilities=(
+            "cross_sectional_prices",
+            "sector_context",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "regime_flip",
+            "benchmark_mismatch",
+            "sector_concentration",
+        ),
+        forbidden_interpretations=(
+            "capital_allocation_authority",
+            "live_permission",
+            "risk_override",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="provisional",
+    ),
+    BehaviorFamily(
+        behavior_id="liquidity_stress_response",
+        display_name="Liquidity Stress Response",
+        description=(
+            "Price and spread behavior under stress, thin liquidity, or "
+            "market microstructure strain."
+        ),
+        expected_observables=(
+            "widened_spread_proxy",
+            "gap_or_slippage_stress",
+            "microstructure_instability",
+        ),
+        typical_timeframes=("1d", "4h", "1h"),
+        compatible_preset_patterns=("liquidity*", "*stress*", "*microstructure*"),
+        required_data_capabilities=(
+            "microstructure_context",
+            "time_series_ohlcv",
+            "cost_model",
+        ),
+        common_failure_modes=(
+            "thin_liquidity",
+            "cost_blindness",
+            "data_instability",
+        ),
+        forbidden_interpretations=(
+            "trade_signal_on_its_own",
+            "execution_authority",
+            "provider_activation_authority",
+        ),
+        evidence_requirements=(
+            "screening_evidence",
+            "oos_evidence",
+            "lineage_evidence",
+        ),
+        status="blocked",
+    ),
+)
+
+_BEHAVIOR_BY_ID: Final[dict[str, BehaviorFamily]] = {
+    behavior.behavior_id: behavior for behavior in BEHAVIOR_CATALOG
+}
+
+
+def list_behavior_families() -> tuple[BehaviorFamily, ...]:
+    return BEHAVIOR_CATALOG
+
+
+def get_behavior_family(behavior_id: str) -> BehaviorFamily:
+    try:
+        return _BEHAVIOR_BY_ID[behavior_id]
+    except KeyError as exc:
+        raise KeyError(f"unknown behavior_id: {behavior_id!r}") from exc
+

--- a/research/qre_hypothesis_model.py
+++ b/research/qre_hypothesis_model.py
@@ -1,0 +1,238 @@
+"""Generic QRE hypothesis object model.
+
+The hypothesis model is a research-intelligence foundation only. It is
+not strategy authority, not candidate authority, and not deployment
+authority. It can be schema-validated and scored against the canonical
+behavior catalog, but it does not authorize execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Final, Iterable, Literal, Mapping
+
+from research.qre_behavior_catalog import get_behavior_family, list_behavior_families
+
+
+HypothesisStatus = Literal[
+    "draft",
+    "research_ready",
+    "evidence_incomplete",
+    "evidence_complete",
+    "rejected",
+    "suppressed",
+    "deprecated",
+]
+
+HYPOTHESIS_MODEL_SCHEMA_VERSION: Final[str] = "1.0"
+HYPOTHESIS_STATUS_VALUES: Final[tuple[str, ...]] = (
+    "draft",
+    "research_ready",
+    "evidence_incomplete",
+    "evidence_complete",
+    "rejected",
+    "suppressed",
+    "deprecated",
+)
+EXECUTION_AUTHORITATIVE_STATUSES: Final[frozenset[str]] = frozenset()
+
+
+@dataclass(frozen=True)
+class Hypothesis:
+    hypothesis_id: str
+    behavior_id: str
+    title: str
+    description: str
+    universe_ref: str | None = None
+    universe_description: str | None = None
+    symbols: tuple[str, ...] = ()
+    preset_id: str | None = None
+    timeframe: str | None = None
+    expected_mechanism: str = ""
+    expected_observables: tuple[str, ...] = ()
+    falsification_criteria: tuple[str, ...] = ()
+    required_evidence_types: tuple[str, ...] = ()
+    required_data_capabilities: tuple[str, ...] = ()
+    known_risks: tuple[str, ...] = ()
+    status: HypothesisStatus = "draft"
+    created_at_utc: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    source: str = ""
+    reason_record_refs: tuple[str, ...] = ()
+    scope_hash: str = ""
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "hypothesis_id": self.hypothesis_id,
+            "behavior_id": self.behavior_id,
+            "title": self.title,
+            "description": self.description,
+            "universe_ref": self.universe_ref,
+            "universe_description": self.universe_description,
+            "symbols": list(self.symbols),
+            "preset_id": self.preset_id,
+            "timeframe": self.timeframe,
+            "expected_mechanism": self.expected_mechanism,
+            "expected_observables": list(self.expected_observables),
+            "falsification_criteria": list(self.falsification_criteria),
+            "required_evidence_types": list(self.required_evidence_types),
+            "required_data_capabilities": list(self.required_data_capabilities),
+            "known_risks": list(self.known_risks),
+            "status": self.status,
+            "created_at_utc": self.created_at_utc.isoformat(),
+            "source": self.source,
+            "reason_record_refs": list(self.reason_record_refs),
+            "scope_hash": self.scope_hash,
+        }
+
+
+@dataclass(frozen=True)
+class HypothesisValidationResult:
+    valid: bool
+    status: str
+    scope_hash: str
+    rejection_reasons: tuple[str, ...] = ()
+    behavior_known: bool = False
+    execution_authoritative: bool = False
+    strategy_authority: bool = False
+    candidate_authority: bool = False
+    deployment_authority: bool = False
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "valid": self.valid,
+            "status": self.status,
+            "scope_hash": self.scope_hash,
+            "rejection_reasons": list(self.rejection_reasons),
+            "behavior_known": self.behavior_known,
+            "execution_authoritative": self.execution_authoritative,
+            "strategy_authority": self.strategy_authority,
+            "candidate_authority": self.candidate_authority,
+            "deployment_authority": self.deployment_authority,
+        }
+
+
+def _iso_or_blank(value: datetime | None) -> str:
+    if value is None:
+        return ""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _canonical_payload(hypothesis: Hypothesis | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(hypothesis, Hypothesis):
+        payload = hypothesis.to_payload()
+    else:
+        payload = dict(hypothesis)
+        symbols = payload.get("symbols")
+        if isinstance(symbols, tuple):
+            payload["symbols"] = list(symbols)
+        if isinstance(payload.get("created_at_utc"), datetime):
+            payload["created_at_utc"] = _iso_or_blank(payload["created_at_utc"])
+        if isinstance(payload.get("reason_record_refs"), tuple):
+            payload["reason_record_refs"] = list(payload["reason_record_refs"])
+        if isinstance(payload.get("expected_observables"), tuple):
+            payload["expected_observables"] = list(payload["expected_observables"])
+        if isinstance(payload.get("falsification_criteria"), tuple):
+            payload["falsification_criteria"] = list(payload["falsification_criteria"])
+        if isinstance(payload.get("required_evidence_types"), tuple):
+            payload["required_evidence_types"] = list(payload["required_evidence_types"])
+        if isinstance(payload.get("required_data_capabilities"), tuple):
+            payload["required_data_capabilities"] = list(payload["required_data_capabilities"])
+        if isinstance(payload.get("known_risks"), tuple):
+            payload["known_risks"] = list(payload["known_risks"])
+    payload.setdefault("created_at_utc", "")
+    payload.setdefault("scope_hash", "")
+    return {
+        key: payload.get(key)
+        for key in (
+            "hypothesis_id",
+            "behavior_id",
+            "title",
+            "description",
+            "universe_ref",
+            "universe_description",
+            "symbols",
+            "preset_id",
+            "timeframe",
+            "expected_mechanism",
+            "expected_observables",
+            "falsification_criteria",
+            "required_evidence_types",
+            "required_data_capabilities",
+            "known_risks",
+            "status",
+            "created_at_utc",
+            "source",
+            "reason_record_refs",
+        )
+    }
+
+
+def compute_hypothesis_scope_hash(hypothesis: Hypothesis | Mapping[str, Any]) -> str:
+    payload = _canonical_payload(hypothesis)
+    if isinstance(payload.get("created_at_utc"), datetime):
+        payload["created_at_utc"] = _iso_or_blank(payload["created_at_utc"])
+    blob = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def validate_hypothesis(
+    hypothesis: Hypothesis | Mapping[str, Any],
+    *,
+    provisional_behavior_ids: Iterable[str] = (),
+) -> HypothesisValidationResult:
+    payload = _canonical_payload(hypothesis)
+    behavior_id = str(payload.get("behavior_id") or "").strip()
+    status = str(payload.get("status") or "").strip()
+    rejection_reasons: list[str] = []
+    provisional_set = frozenset(str(item) for item in provisional_behavior_ids)
+
+    if not behavior_id:
+        rejection_reasons.append("missing_behavior_id")
+    else:
+        known_behavior = behavior_id in {item.behavior_id for item in list_behavior_families()}
+        if not known_behavior and behavior_id not in provisional_set:
+            rejection_reasons.append("unknown_behavior_id")
+
+    if status not in HYPOTHESIS_STATUS_VALUES:
+        rejection_reasons.append("unknown_status")
+
+    if not str(payload.get("title") or "").strip():
+        rejection_reasons.append("missing_title")
+
+    if not str(payload.get("description") or "").strip():
+        rejection_reasons.append("missing_description")
+
+    if status == "research_ready" and not tuple(payload.get("falsification_criteria") or ()):
+        rejection_reasons.append("missing_falsification_criteria")
+
+    if status == "evidence_complete" and not tuple(payload.get("reason_record_refs") or ()):
+        rejection_reasons.append("missing_accepted_evidence_refs")
+
+    if status == "evidence_complete" and behavior_id and behavior_id not in provisional_set:
+        try:
+            get_behavior_family(behavior_id)
+        except KeyError:
+            rejection_reasons.append("unknown_behavior_id")
+
+    scope_hash = compute_hypothesis_scope_hash(payload)
+    execution_authoritative = status in EXECUTION_AUTHORITATIVE_STATUSES
+    valid = not rejection_reasons
+    return HypothesisValidationResult(
+        valid=valid,
+        status=status or "unknown",
+        scope_hash=scope_hash,
+        rejection_reasons=tuple(dict.fromkeys(rejection_reasons)),
+        behavior_known=bool(behavior_id) and (
+            behavior_id in {item.behavior_id for item in list_behavior_families()}
+            or behavior_id in provisional_set
+        ),
+        execution_authoritative=execution_authoritative,
+        strategy_authority=False,
+        candidate_authority=False,
+        deployment_authority=False,
+    )

--- a/tests/unit/test_qre_behavior_catalog.py
+++ b/tests/unit/test_qre_behavior_catalog.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_behavior_catalog as catalog
+
+
+def test_behavior_catalog_contains_canonical_families() -> None:
+    behavior_ids = [behavior.behavior_id for behavior in catalog.list_behavior_families()]
+    assert behavior_ids == [
+        "trend_continuation",
+        "pullback_continuation",
+        "volatility_compression_breakout",
+        "relative_strength",
+        "post_shock_stabilization",
+        "index_regime_filter",
+        "mean_reversion",
+        "momentum_acceleration",
+        "defensive_rotation",
+        "liquidity_stress_response",
+    ]
+
+
+def test_behavior_catalog_is_deterministic() -> None:
+    payload_1 = [behavior.to_payload() for behavior in catalog.list_behavior_families()]
+    payload_2 = [behavior.to_payload() for behavior in catalog.list_behavior_families()]
+    assert payload_1 == payload_2
+
+
+def test_unknown_behavior_lookup_fails_closed() -> None:
+    try:
+        catalog.get_behavior_family("unknown_behavior")
+    except KeyError as exc:
+        assert "unknown behavior_id" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected KeyError")
+
+
+def test_catalog_source_has_no_aapl_or_nvda_hardcoding() -> None:
+    source = Path(catalog.__file__).read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source
+

--- a/tests/unit/test_qre_hypothesis_model.py
+++ b/tests/unit/test_qre_hypothesis_model.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from research.qre_hypothesis_model import (
+    Hypothesis,
+    compute_hypothesis_scope_hash,
+    validate_hypothesis,
+)
+
+
+_T = datetime(2026, 6, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _hypothesis(**overrides: object) -> Hypothesis:
+    base = {
+        "hypothesis_id": "qre_hypothesis_v1",
+        "behavior_id": "trend_continuation",
+        "title": "Trend continuation hypothesis",
+        "description": "A bounded continuation setup for research validation.",
+        "universe_ref": "equity_us_largecap",
+        "universe_description": "US large-cap equity universe",
+        "symbols": ("AAPL", "NVDA"),
+        "preset_id": "trend_pullback_continuation_daily_v1",
+        "timeframe": "1d",
+        "expected_mechanism": "Continuation after bounded pullback resolves.",
+        "expected_observables": ("trend_alignment", "breakout_follow_through"),
+        "falsification_criteria": ("Fails OOS on bounded holdout",),
+        "required_evidence_types": ("screening", "lineage"),
+        "required_data_capabilities": ("time_series_ohlcv", "cost_model"),
+        "known_risks": ("late_entry",),
+        "status": "draft",
+        "created_at_utc": _T,
+        "source": "unit-test",
+        "reason_record_refs": ("rr-1",),
+        "scope_hash": "",
+    }
+    base.update(overrides)
+    return Hypothesis(**base)
+
+
+def test_valid_draft_hypothesis_validates() -> None:
+    hyp = _hypothesis()
+    result = validate_hypothesis(hyp)
+    assert result.valid is True
+    assert result.status == "draft"
+    assert result.strategy_authority is False
+    assert result.candidate_authority is False
+    assert result.deployment_authority is False
+
+
+def test_research_ready_requires_falsification_criteria() -> None:
+    hyp = _hypothesis(status="research_ready", falsification_criteria=())
+    result = validate_hypothesis(hyp)
+    assert result.valid is False
+    assert "missing_falsification_criteria" in result.rejection_reasons
+
+
+def test_evidence_complete_requires_accepted_evidence_refs() -> None:
+    hyp = _hypothesis(status="evidence_complete", reason_record_refs=())
+    result = validate_hypothesis(hyp)
+    assert result.valid is False
+    assert "missing_accepted_evidence_refs" in result.rejection_reasons
+
+
+def test_scope_hash_is_deterministic() -> None:
+    hyp_1 = _hypothesis()
+    hyp_2 = _hypothesis()
+    assert compute_hypothesis_scope_hash(hyp_1) == compute_hypothesis_scope_hash(hyp_2)
+    assert validate_hypothesis(hyp_1).scope_hash == validate_hypothesis(hyp_2).scope_hash
+
+
+def test_hypothesis_is_symbol_agnostic() -> None:
+    hyp = _hypothesis(symbols=("AAPL", "NVDA"))
+    result = validate_hypothesis(hyp)
+    assert result.valid is True
+    assert hyp.symbols == ("AAPL", "NVDA")
+    assert hyp.behavior_id == "trend_continuation"
+
+
+def test_unknown_behavior_id_fails_closed_by_default() -> None:
+    hyp = _hypothesis(behavior_id="unknown_behavior")
+    result = validate_hypothesis(hyp)
+    assert result.valid is False
+    assert "unknown_behavior_id" in result.rejection_reasons
+
+
+def test_unknown_behavior_id_can_be_marked_provisional_without_authority() -> None:
+    hyp = _hypothesis(
+        behavior_id="provisional_behavior",
+        status="draft",
+        reason_record_refs=("rr-1",),
+    )
+    result = validate_hypothesis(hyp, provisional_behavior_ids=("provisional_behavior",))
+    assert result.valid is True
+    assert result.execution_authoritative is False
+    assert result.strategy_authority is False
+    assert result.candidate_authority is False
+    assert result.deployment_authority is False
+
+
+def test_hypothesis_does_not_authorize_strategy_candidate_or_deployment() -> None:
+    hyp = _hypothesis(status="research_ready")
+    result = validate_hypothesis(hyp)
+    assert result.valid is True
+    assert result.execution_authoritative is False
+    assert result.strategy_authority is False
+    assert result.candidate_authority is False
+    assert result.deployment_authority is False
+


### PR DESCRIPTION
Phase 7A: research-intelligence foundation only.

Scope
- add canonical behavior catalog taxonomy
- add generic hypothesis object model
- keep the modules context-only and non-authoritative
- no strategy synthesis, candidate promotion, paper/shadow/live, broker/risk/execution, or fake evidence

Validation
- python -m pytest tests/unit/test_qre_behavior_catalog.py tests/unit/test_qre_hypothesis_model.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

Safety
- behavior catalog is taxonomy/context only
- hypothesis model is non-authoritative
- no strategy synthesis
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution
- no fake evidence
- no context-only evidence promoted to proof
- no AAPL/NVDA hardcoding in core paths
- frozen contracts unchanged

Next recommended PR
- feat: add preset feasibility mapper
