### PR TITLE
feat: add routing score scaffold

### DIFF
--- a/research/qre_routing_score.py
+++ b/research/qre_routing_score.py
@@ -1,0 +1,399 @@
+"""Context-only QRE routing score scaffold.
+
+This module ranks potential research next-actions from non-authoritative
+context. It does not execute campaigns, synthesize strategies, clear
+evidence blockers, or promote candidates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Final, Iterable, Literal, Mapping
+
+from research.qre_behavior_catalog import get_behavior_family
+from research.qre_hypothesis_model import validate_hypothesis
+from research.qre_preset_feasibility_mapper import validate_feasibility_result
+
+
+RoutingStatus = Literal[
+    "routable_context_only",
+    "provisional",
+    "blocked_missing_feasibility",
+    "blocked_unknown_behavior",
+    "blocked_missing_hypothesis",
+    "blocked_missing_required_context",
+    "blocked_not_evidence_authoritative",
+]
+
+ROUTING_SCORE_SCHEMA_VERSION: Final[str] = "1.0"
+NON_AUTHORITATIVE_FLAG: Final[bool] = True
+EVIDENCE_AUTHORITY: Final[str] = "context_only"
+CAN_AUTHORIZE_EXECUTION: Final[bool] = False
+CAN_CLEAR_EVIDENCE_BLOCKERS: Final[bool] = False
+CAN_PROMOTE_CANDIDATE: Final[bool] = False
+VALID_ROUTING_STATUSES: Final[frozenset[str]] = frozenset(
+    {
+        "routable_context_only",
+        "provisional",
+        "blocked_missing_feasibility",
+        "blocked_unknown_behavior",
+        "blocked_missing_hypothesis",
+        "blocked_missing_required_context",
+        "blocked_not_evidence_authoritative",
+    }
+)
+SCORE_COMPONENT_NAMES: Final[tuple[str, ...]] = (
+    "evidence_gap_reduction_score",
+    "source_cache_readiness_score",
+    "blocker_severity_score",
+    "information_gain_proxy_score",
+    "prior_failure_penalty",
+    "compute_cost_penalty",
+    "behavior_diversity_score",
+    "feasibility_score",
+)
+REQUIRED_CONTEXT_FIELDS: Final[tuple[str, ...]] = (
+    "evidence_gap_information",
+    "blocker_severity",
+    "source_cache_readiness",
+    "expected_information_gain_proxy",
+    "compute_budget_proxy",
+    "behavior_diversity_proxy",
+)
+
+
+def _unique_in_order(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _bounded_float(value: Any, *, default: float = 0.0) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if number < 0.0:
+        return 0.0
+    if number > 1.0:
+        return 1.0
+    return round(number, 6)
+
+
+def _canonicalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": result.get("schema_version", ROUTING_SCORE_SCHEMA_VERSION),
+        "behavior_id": result.get("behavior_id"),
+        "hypothesis_id": result.get("hypothesis_id"),
+        "routing_status": result.get("routing_status"),
+        "routing_score": result.get("routing_score"),
+        "score_components": dict(result.get("score_components", {})),
+        "recommended_next_action": result.get("recommended_next_action"),
+        "blocked_reasons": list(result.get("blocked_reasons", [])),
+        "non_authoritative": bool(result.get("non_authoritative", NON_AUTHORITATIVE_FLAG)),
+        "evidence_authority": result.get("evidence_authority", EVIDENCE_AUTHORITY),
+        "can_authorize_execution": bool(
+            result.get("can_authorize_execution", CAN_AUTHORIZE_EXECUTION)
+        ),
+        "can_clear_evidence_blockers": bool(
+            result.get("can_clear_evidence_blockers", CAN_CLEAR_EVIDENCE_BLOCKERS)
+        ),
+        "can_promote_candidate": bool(result.get("can_promote_candidate", CAN_PROMOTE_CANDIDATE)),
+    }
+
+
+def compute_routing_hash(payload: Mapping[str, Any]) -> str:
+    canonical = _canonicalize_result(payload)
+    blob = json.dumps(canonical, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _base_result(
+    *,
+    behavior_id: str,
+    hypothesis_id: str | None,
+    routing_status: RoutingStatus,
+    recommended_next_action: str,
+    blocked_reasons: Iterable[str] = (),
+    score_components: Mapping[str, float] | None = None,
+) -> dict[str, Any]:
+    components = {
+        component_name: round(float((score_components or {}).get(component_name, 0.0)), 6)
+        for component_name in SCORE_COMPONENT_NAMES
+    }
+    positive_score = (
+        components["evidence_gap_reduction_score"]
+        + components["source_cache_readiness_score"]
+        + components["blocker_severity_score"]
+        + components["information_gain_proxy_score"]
+        + components["behavior_diversity_score"]
+        + components["feasibility_score"]
+    )
+    penalty = components["prior_failure_penalty"] + components["compute_cost_penalty"]
+    routing_score = round(max(0.0, min(1.0, (positive_score / 6.0) - (penalty / 2.0))), 6)
+    if routing_status.startswith("blocked_"):
+        routing_score = 0.0
+
+    result = {
+        "schema_version": ROUTING_SCORE_SCHEMA_VERSION,
+        "behavior_id": behavior_id,
+        "hypothesis_id": hypothesis_id,
+        "routing_status": routing_status,
+        "routing_score": routing_score,
+        "score_components": components,
+        "recommended_next_action": recommended_next_action,
+        "blocked_reasons": list(_unique_in_order(blocked_reasons)),
+        "non_authoritative": NON_AUTHORITATIVE_FLAG,
+        "evidence_authority": EVIDENCE_AUTHORITY,
+        "can_authorize_execution": CAN_AUTHORIZE_EXECUTION,
+        "can_clear_evidence_blockers": CAN_CLEAR_EVIDENCE_BLOCKERS,
+        "can_promote_candidate": CAN_PROMOTE_CANDIDATE,
+    }
+    result["hash"] = compute_routing_hash(result)
+    return result
+
+
+def _missing_required_context(context: Mapping[str, Any]) -> tuple[str, ...]:
+    return tuple(
+        f"missing_required_context:{field_name}"
+        for field_name in REQUIRED_CONTEXT_FIELDS
+        if field_name not in context or context[field_name] is None
+    )
+
+
+def _feasibility_score(feasibility_result: Mapping[str, Any]) -> float:
+    feasible_count = len(list(feasibility_result.get("feasible_mappings") or []))
+    blocked_count = len(list(feasibility_result.get("blocked_mappings") or []))
+    total = feasible_count + blocked_count
+    if total == 0:
+        return 0.0
+    return round(feasible_count / total, 6)
+
+
+def _score_components(
+    *,
+    feasibility_result: Mapping[str, Any],
+    evidence_gap_information: Mapping[str, Any],
+    blocker_severity: Mapping[str, Any],
+    source_cache_readiness: Mapping[str, Any],
+    prior_failure_density: Any,
+    expected_information_gain_proxy: Any,
+    compute_budget_proxy: Any,
+    behavior_diversity_proxy: Any,
+) -> dict[str, float]:
+    missing_gap_count = float(evidence_gap_information.get("missing_evidence_count", 0) or 0)
+    visible_gap_count = float(evidence_gap_information.get("visible_gap_count", 0) or 0)
+    total_gap_count = max(1.0, missing_gap_count + visible_gap_count)
+    evidence_gap_reduction_score = min(1.0, missing_gap_count / total_gap_count)
+
+    ready_fraction = source_cache_readiness.get("ready_fraction")
+    if ready_fraction is None:
+        ready = float(source_cache_readiness.get("ready_count", 0) or 0)
+        total = max(1.0, ready + float(source_cache_readiness.get("blocked_count", 0) or 0))
+        ready_fraction = ready / total
+
+    severity_score = blocker_severity.get("severity_score")
+    if severity_score is None:
+        severity_score = {
+            "low": 0.25,
+            "medium": 0.5,
+            "high": 0.75,
+            "critical": 1.0,
+        }.get(str(blocker_severity.get("max_severity") or "").lower(), 0.0)
+
+    return {
+        "evidence_gap_reduction_score": _bounded_float(evidence_gap_reduction_score),
+        "source_cache_readiness_score": _bounded_float(ready_fraction),
+        "blocker_severity_score": _bounded_float(severity_score),
+        "information_gain_proxy_score": _bounded_float(expected_information_gain_proxy),
+        "prior_failure_penalty": _bounded_float(prior_failure_density),
+        "compute_cost_penalty": _bounded_float(compute_budget_proxy),
+        "behavior_diversity_score": _bounded_float(behavior_diversity_proxy),
+        "feasibility_score": _bounded_float(_feasibility_score(feasibility_result)),
+    }
+
+
+def evaluate_routing_score(
+    *,
+    behavior_id: str,
+    hypothesis: Mapping[str, Any] | None = None,
+    hypothesis_ref: str | None = None,
+    preset_feasibility_result: Mapping[str, Any] | None = None,
+    evidence_gap_information: Mapping[str, Any] | None = None,
+    blocker_severity: Mapping[str, Any] | None = None,
+    source_cache_readiness: Mapping[str, Any] | None = None,
+    prior_failure_density: Any = 0.0,
+    expected_information_gain_proxy: Any = None,
+    compute_budget_proxy: Any = None,
+    behavior_diversity_proxy: Any = None,
+    provisional_evidence_visibility_context: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_behavior_id = str(behavior_id or "").strip()
+    hypothesis_id = str((hypothesis or {}).get("hypothesis_id") or hypothesis_ref or "").strip() or None
+
+    try:
+        behavior = get_behavior_family(normalized_behavior_id)
+    except KeyError:
+        return _base_result(
+            behavior_id=normalized_behavior_id,
+            hypothesis_id=hypothesis_id,
+            routing_status="blocked_unknown_behavior",
+            recommended_next_action="keep_fail_closed",
+            blocked_reasons=("unknown_behavior_id",),
+        )
+
+    if hypothesis is None and not hypothesis_ref:
+        return _base_result(
+            behavior_id=normalized_behavior_id,
+            hypothesis_id=None,
+            routing_status="blocked_missing_hypothesis",
+            recommended_next_action="route_to_operator_review",
+            blocked_reasons=("missing_hypothesis_or_ref",),
+        )
+
+    if hypothesis is not None:
+        validation = validate_hypothesis(hypothesis)
+        if not validation.valid:
+            return _base_result(
+                behavior_id=normalized_behavior_id,
+                hypothesis_id=hypothesis_id,
+                routing_status="blocked_missing_hypothesis",
+                recommended_next_action="route_to_operator_review",
+                blocked_reasons=validation.rejection_reasons,
+            )
+
+    if preset_feasibility_result is None:
+        return _base_result(
+            behavior_id=normalized_behavior_id,
+            hypothesis_id=hypothesis_id,
+            routing_status="blocked_missing_feasibility",
+            recommended_next_action="evaluate_preset_feasibility",
+            blocked_reasons=("missing_preset_feasibility_result",),
+        )
+
+    feasibility_validation = validate_feasibility_result(preset_feasibility_result)
+    if not feasibility_validation["valid"]:
+        return _base_result(
+            behavior_id=normalized_behavior_id,
+            hypothesis_id=hypothesis_id,
+            routing_status="blocked_missing_feasibility",
+            recommended_next_action="evaluate_preset_feasibility",
+            blocked_reasons=feasibility_validation["rejection_reasons"],
+        )
+
+    if preset_feasibility_result.get("evidence_authority") != EVIDENCE_AUTHORITY:
+        return _base_result(
+            behavior_id=normalized_behavior_id,
+            hypothesis_id=hypothesis_id,
+            routing_status="blocked_not_evidence_authoritative",
+            recommended_next_action="keep_fail_closed",
+            blocked_reasons=("routing_requires_context_only_feasibility",),
+        )
+
+    required_context = {
+        "evidence_gap_information": evidence_gap_information,
+        "blocker_severity": blocker_severity,
+        "source_cache_readiness": source_cache_readiness,
+        "expected_information_gain_proxy": expected_information_gain_proxy,
+        "compute_budget_proxy": compute_budget_proxy,
+        "behavior_diversity_proxy": behavior_diversity_proxy,
+    }
+    missing_context = _missing_required_context(required_context)
+    if missing_context:
+        return _base_result(
+            behavior_id=normalized_behavior_id,
+            hypothesis_id=hypothesis_id,
+            routing_status="blocked_missing_required_context",
+            recommended_next_action="collect_required_context",
+            blocked_reasons=missing_context,
+        )
+
+    blocked_reasons: list[str] = []
+    if provisional_evidence_visibility_context:
+        if provisional_evidence_visibility_context.get("provisional_artifacts_visible"):
+            blocked_reasons.append("provisional_artifacts_visible_context_only")
+
+    components = _score_components(
+        feasibility_result=preset_feasibility_result,
+        evidence_gap_information=evidence_gap_information or {},
+        blocker_severity=blocker_severity or {},
+        source_cache_readiness=source_cache_readiness or {},
+        prior_failure_density=prior_failure_density,
+        expected_information_gain_proxy=expected_information_gain_proxy,
+        compute_budget_proxy=compute_budget_proxy,
+        behavior_diversity_proxy=behavior_diversity_proxy,
+    )
+    status: RoutingStatus = "routable_context_only"
+    if behavior.status != "active" or blocked_reasons:
+        status = "provisional"
+    if not preset_feasibility_result.get("feasible_mappings"):
+        status = "blocked_missing_feasibility"
+        blocked_reasons.extend(
+            str(reason) for reason in preset_feasibility_result.get("blocker_reasons", ())
+        )
+
+    return _base_result(
+        behavior_id=normalized_behavior_id,
+        hypothesis_id=hypothesis_id,
+        routing_status=status,
+        recommended_next_action="build_sampling_plan_context_only"
+        if status in {"routable_context_only", "provisional"}
+        else "evaluate_preset_feasibility",
+        blocked_reasons=blocked_reasons,
+        score_components=components,
+    )
+
+
+def validate_routing_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    rejection_reasons: list[str] = []
+    canonical = _canonicalize_result(result)
+
+    for field_name in (
+        "behavior_id",
+        "routing_status",
+        "routing_score",
+        "score_components",
+        "recommended_next_action",
+        "blocked_reasons",
+        "non_authoritative",
+        "evidence_authority",
+        "can_authorize_execution",
+        "can_clear_evidence_blockers",
+        "can_promote_candidate",
+    ):
+        if field_name not in canonical:
+            rejection_reasons.append(f"missing_field:{field_name}")
+
+    if canonical["routing_status"] not in VALID_ROUTING_STATUSES:
+        rejection_reasons.append(f"invalid_routing_status:{canonical['routing_status']}")
+
+    for component_name in SCORE_COMPONENT_NAMES:
+        if component_name not in canonical["score_components"]:
+            rejection_reasons.append(f"missing_score_component:{component_name}")
+
+    if canonical["non_authoritative"] is not True:
+        rejection_reasons.append("non_authoritative_must_be_true")
+
+    if canonical["evidence_authority"] != EVIDENCE_AUTHORITY:
+        rejection_reasons.append("invalid_evidence_authority")
+
+    if canonical["can_authorize_execution"] is not False:
+        rejection_reasons.append("can_authorize_execution_must_be_false")
+
+    if canonical["can_clear_evidence_blockers"] is not False:
+        rejection_reasons.append("can_clear_evidence_blockers_must_be_false")
+
+    if canonical["can_promote_candidate"] is not False:
+        rejection_reasons.append("can_promote_candidate_must_be_false")
+
+    computed_hash = compute_routing_hash(result)
+    if str(result.get("hash") or "") and str(result.get("hash")) != computed_hash:
+        rejection_reasons.append("hash_mismatch")
+
+    return {
+        "valid": not rejection_reasons,
+        "rejection_reasons": list(_unique_in_order(rejection_reasons)),
+        "hash": computed_hash,
+        "schema_version": ROUTING_SCORE_SCHEMA_VERSION,
+    }

--- a/tests/unit/test_qre_routing_score.py
+++ b/tests/unit/test_qre_routing_score.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from research.qre_preset_feasibility_mapper import (
+    evaluate_preset_feasibility_for_hypothesis,
+)
+from research.qre_routing_score import (
+    SCORE_COMPONENT_NAMES,
+    compute_routing_hash,
+    evaluate_routing_score,
+    validate_routing_result,
+)
+
+
+_T = datetime(2026, 6, 18, 8, 0, 0, tzinfo=timezone.utc)
+
+
+def _hypothesis(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "hypothesis_id": "hyp-route-001",
+        "behavior_id": "trend_continuation",
+        "title": "Trend continuation routing check",
+        "description": "Context-only routing scaffold for a continuation hypothesis.",
+        "timeframe": "1d",
+        "expected_mechanism": "Trend resumes after bounded consolidation.",
+        "falsification_criteria": ("Fails bounded OOS holdout",),
+        "required_data_capabilities": ("time_series_ohlcv", "regime_context", "cost_model"),
+        "required_evidence_types": ("screening_evidence", "oos_evidence", "lineage_evidence"),
+        "status": "research_ready",
+        "created_at_utc": _T,
+        "source": "unit-test",
+        "reason_record_refs": (),
+        "symbols": ("AAA", "BBB"),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _context() -> dict[str, object]:
+    return {
+        "evidence_gap_information": {"missing_evidence_count": 3, "visible_gap_count": 1},
+        "blocker_severity": {"max_severity": "high"},
+        "source_cache_readiness": {"ready_count": 3, "blocked_count": 1},
+        "prior_failure_density": 0.2,
+        "expected_information_gain_proxy": 0.8,
+        "compute_budget_proxy": 0.3,
+        "behavior_diversity_proxy": 0.6,
+        "provisional_evidence_visibility_context": {
+            "provisional_artifacts_visible": False,
+        },
+    }
+
+
+def _routing_result(**overrides: object) -> dict[str, object]:
+    hypothesis = _hypothesis()
+    feasibility = evaluate_preset_feasibility_for_hypothesis(hypothesis)
+    payload: dict[str, object] = {
+        "behavior_id": "trend_continuation",
+        "hypothesis": hypothesis,
+        "preset_feasibility_result": feasibility,
+    }
+    payload.update(_context())
+    payload.update(overrides)
+    return evaluate_routing_score(**payload)  # type: ignore[arg-type]
+
+
+def test_deterministic_scoring() -> None:
+    result_1 = _routing_result()
+    result_2 = _routing_result()
+    assert result_1 == result_2
+    assert compute_routing_hash(result_1) == compute_routing_hash(result_2)
+
+
+def test_unknown_behavior_fails_closed() -> None:
+    result = _routing_result(behavior_id="unknown_behavior")
+    assert result["routing_status"] == "blocked_unknown_behavior"
+    assert result["routing_score"] == 0.0
+    assert result["blocked_reasons"] == ["unknown_behavior_id"]
+
+
+def test_missing_feasibility_fails_closed() -> None:
+    result = evaluate_routing_score(
+        behavior_id="trend_continuation",
+        hypothesis=_hypothesis(),
+        preset_feasibility_result=None,
+        **_context(),
+    )
+    assert result["routing_status"] == "blocked_missing_feasibility"
+    assert result["recommended_next_action"] == "evaluate_preset_feasibility"
+    assert result["blocked_reasons"] == ["missing_preset_feasibility_result"]
+
+
+def test_missing_hypothesis_fails_closed() -> None:
+    result = evaluate_routing_score(
+        behavior_id="trend_continuation",
+        hypothesis=None,
+        hypothesis_ref=None,
+        preset_feasibility_result={},
+        **_context(),
+    )
+    assert result["routing_status"] == "blocked_missing_hypothesis"
+    assert result["blocked_reasons"] == ["missing_hypothesis_or_ref"]
+
+
+def test_missing_required_context_fails_closed() -> None:
+    hypothesis = _hypothesis()
+    feasibility = evaluate_preset_feasibility_for_hypothesis(hypothesis)
+    result = evaluate_routing_score(
+        behavior_id="trend_continuation",
+        hypothesis=hypothesis,
+        preset_feasibility_result=feasibility,
+    )
+    assert result["routing_status"] == "blocked_missing_required_context"
+    assert "missing_required_context:evidence_gap_information" in result["blocked_reasons"]
+
+
+def test_routing_is_non_authoritative() -> None:
+    result = _routing_result()
+    assert result["non_authoritative"] is True
+    assert result["evidence_authority"] == "context_only"
+
+
+def test_routing_cannot_authorize_execution_clear_or_promote() -> None:
+    result = _routing_result()
+    assert result["can_authorize_execution"] is False
+    assert result["can_clear_evidence_blockers"] is False
+    assert result["can_promote_candidate"] is False
+
+
+def test_core_routing_logic_has_no_aapl_or_nvda_hardcoding() -> None:
+    source = Path("research/qre_routing_score.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source
+
+
+def test_score_components_are_visible_and_stable() -> None:
+    result = _routing_result()
+    assert tuple(result["score_components"].keys()) == SCORE_COMPONENT_NAMES
+    assert result["score_components"] == {
+        "evidence_gap_reduction_score": 0.75,
+        "source_cache_readiness_score": 0.75,
+        "blocker_severity_score": 0.75,
+        "information_gain_proxy_score": 0.8,
+        "prior_failure_penalty": 0.2,
+        "compute_cost_penalty": 0.3,
+        "behavior_diversity_score": 0.6,
+        "feasibility_score": 1.0,
+    }
+    assert result["routing_score"] == 0.525
+
+
+def test_blocked_statuses_preserve_reason_codes() -> None:
+    hypothesis = _hypothesis(required_data_capabilities=("time_series_ohlcv",))
+    feasibility = evaluate_preset_feasibility_for_hypothesis(hypothesis)
+    result = _routing_result(hypothesis=hypothesis, preset_feasibility_result=feasibility)
+    assert result["routing_status"] == "blocked_missing_feasibility"
+    assert "missing_data_capability:regime_context" in result["blocked_reasons"]
+    assert "missing_data_capability:cost_model" in result["blocked_reasons"]
+
+
+def test_provisional_visibility_context_marks_result_provisional() -> None:
+    context = _context()
+    context["provisional_evidence_visibility_context"] = {
+        "provisional_artifacts_visible": True,
+    }
+    result = _routing_result(**context)
+    assert result["routing_status"] == "provisional"
+    assert "provisional_artifacts_visible_context_only" in result["blocked_reasons"]
+
+
+def test_validate_routing_result_accepts_valid_payload() -> None:
+    result = _routing_result()
+    validation = validate_routing_result(result)
+    assert validation["valid"] is True
+    assert validation["rejection_reasons"] == []
+
+
+def test_validate_routing_result_rejects_authoritative_claims() -> None:
+    result = _routing_result()
+    result["can_promote_candidate"] = True
+    validation = validate_routing_result(result)
+    assert validation["valid"] is False
+    assert "can_promote_candidate_must_be_false" in validation["rejection_reasons"]


### PR DESCRIPTION
## Phase

7C - Routing score scaffold

## Scope

Research-intelligence scaffold only. Adds a deterministic, context-only routing score evaluator for non-authoritative research next-action ranking.

## Authority

- scaffold / context-only
- non-authoritative
- evidence authority: `context_only`
- cannot authorize execution
- cannot clear evidence blockers
- cannot promote candidates

## Files Changed

- `research/qre_routing_score.py`
- `tests/unit/test_qre_routing_score.py`

## Routing API

- `evaluate_routing_score(...)`
- `compute_routing_hash(payload)`
- `validate_routing_result(result)`

## Statuses

- `routable_context_only`
- `provisional`
- `blocked_missing_feasibility`
- `blocked_unknown_behavior`
- `blocked_missing_hypothesis`
- `blocked_missing_required_context`
- `blocked_not_evidence_authoritative`

## Tests Run

- `python -m pytest tests/unit/test_qre_routing_score.py -q` -> 13 passed
- `python -m pytest tests/unit/test_qre_behavior_catalog.py tests/unit/test_qre_hypothesis_model.py tests/unit/test_qre_preset_feasibility_mapper.py -q` -> 25 passed
- `python -m pytest tests/smoke -q` -> 18 passed
- `python scripts/governance_lint.py` -> Governance lint OK
- `git diff --check` -> pass
- `git diff -- research/research_latest.json research/strategy_matrix.csv` -> no diff
- `git diff --name-only -- live paper shadow broker risk execution` -> no diff

## Maturity Note

Research intelligence improves modestly because routing score scaffolding now exists. Evidence production, candidate quality, and deployment readiness do not increase: this PR produces no accepted evidence, no lifecycle authority, no promotion, and no deployment gate.

## Safety Confirmation

- no runtime feature implementation
- no strategy synthesis
- no strategy registration
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution/order/capital allocation
- no fake evidence
- no evidence blocker clearance
- no AAPL/NVDA core hardcoding
- frozen contracts unchanged
- protected paths untouched

## Next Recommended PR

`feat: add sampling plan scaffold`