### PR TITLE
feat: add controlled validation adapter for bounded evidence

### DIFF
--- a/research/qre_controlled_validation_adapter.py
+++ b/research/qre_controlled_validation_adapter.py
@@ -1,0 +1,411 @@
+"""Controlled validation adapter for bounded evidence.
+
+The adapter is read-only and fail-closed. It normalizes a bounded request
+plus an explicitly supplied structured validation source into candidate
+lineage/OOS records, but it does not invent identifiers, fetch data,
+execute campaigns, or treat adapter output as proof by itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, Final, Literal
+
+from research.qre_bounded_basket_request import (
+    ALLOWED_OUTPUT_ROOTS,
+    BoundedBasketRequest,
+)
+
+
+AdapterStatus = Literal[
+    "adapter_ready",
+    "no_safe_controlled_validation_source",
+    "blocked_invalid_bounded_request",
+    "blocked_missing_approval_ref",
+    "blocked_forbidden_capability",
+    "blocked_output_path_not_allowlisted",
+    "blocked_source_not_structured",
+    "blocked_missing_candidate_id",
+    "blocked_missing_campaign_or_generation_id",
+    "blocked_missing_oos_window",
+    "blocked_missing_oos_metrics",
+    "blocked_missing_cost_slippage_refs",
+    "rejected_context_only_source",
+    "rejected_stdout_only_source",
+    "rejected_legacy_alias_only_source",
+    "accepted_structured_evidence",
+]
+
+ADAPTER_SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_controlled_validation_adapter"
+NON_AUTHORITATIVE_FLAG: Final[bool] = True
+EVIDENCE_AUTHORITY: Final[str] = "adapter_context_until_verifier_acceptance"
+CAN_AUTHORIZE_EXECUTION: Final[bool] = False
+CAN_PROMOTE_CANDIDATE: Final[bool] = False
+FORBIDDEN_CAPABILITY_MARKERS: Final[tuple[str, ...]] = (
+    "strategy_synthesis",
+    "strategy_registration",
+    "candidate_promotion",
+    "paper_shadow_live",
+    "broker_risk_execution",
+    "execution",
+    "order",
+    "capital_allocation",
+    "external_data_fetch",
+    "frozen_contract_mutation",
+)
+STRUCTURED_SOURCE_TYPES: Final[frozenset[str]] = frozenset(
+    {"structured_controlled_validation", "accepted_structured_validation"}
+)
+
+
+def _unique_in_order(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_sequence(value: Any) -> Sequence[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return value
+    return ()
+
+
+def _normalized_request_payload(request: BoundedBasketRequest | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(request, BoundedBasketRequest):
+        return request.to_payload()
+    return dict(request)
+
+
+def _request_or_error(
+    request: BoundedBasketRequest | Mapping[str, Any],
+) -> tuple[BoundedBasketRequest | None, AdapterStatus | None, tuple[str, ...]]:
+    payload = _normalized_request_payload(request)
+    if not str(payload.get("approval_ref") or "").strip():
+        return None, "blocked_missing_approval_ref", ("missing_approval_ref",)
+    try:
+        bounded_request = BoundedBasketRequest.from_payload(payload)
+    except ValueError as exc:
+        message = str(exc)
+        if "forbidden_capabilities_present" in message:
+            return None, "blocked_forbidden_capability", ("forbidden_capability",)
+        if "path_violation" in message:
+            return None, "blocked_output_path_not_allowlisted", ("output_path_not_allowlisted",)
+        if "missing_approval_ref" in message:
+            return None, "blocked_missing_approval_ref", ("missing_approval_ref",)
+        return None, "blocked_invalid_bounded_request", (message,)
+    forbidden_hits = tuple(
+        capability
+        for capability in bounded_request.forbidden_capabilities
+        if any(marker in capability.lower() for marker in FORBIDDEN_CAPABILITY_MARKERS)
+    )
+    if forbidden_hits:
+        return None, "blocked_forbidden_capability", (
+            *(f"forbidden_capability:{item}" for item in forbidden_hits),
+        )
+    disallowed_paths = tuple(
+        path
+        for path in bounded_request.allowed_output_paths
+        if not any(path.startswith(root) for root in ALLOWED_OUTPUT_ROOTS)
+    )
+    if disallowed_paths:
+        return None, "blocked_output_path_not_allowlisted", (
+            *(f"output_path_not_allowlisted:{path}" for path in disallowed_paths),
+        )
+    return bounded_request, None, ()
+
+
+def _source_status(
+    source: Mapping[str, Any] | None,
+) -> tuple[AdapterStatus | None, tuple[str, ...]]:
+    if not source:
+        return "no_safe_controlled_validation_source", ("no_safe_controlled_validation_source",)
+    source_type = str(source.get("source_type") or "").strip()
+    source_authority = str(source.get("source_authority") or "").strip()
+    if source_type == "context_only" or source_authority == "context_only":
+        return "rejected_context_only_source", ("context_only_source_rejected",)
+    if source_type == "stdout_only":
+        return "rejected_stdout_only_source", ("stdout_only_source_rejected",)
+    if source_type == "legacy_alias_only":
+        return "rejected_legacy_alias_only_source", ("legacy_alias_only_source_rejected",)
+    if source_type not in STRUCTURED_SOURCE_TYPES:
+        return "blocked_source_not_structured", ("source_not_structured",)
+    return None, ()
+
+
+def _lineage_candidate(
+    *,
+    bounded_request: BoundedBasketRequest,
+    source_ref: str,
+    record: Mapping[str, Any],
+) -> tuple[dict[str, Any], tuple[str, ...]]:
+    candidate_id = str(record.get("candidate_id") or "").strip()
+    campaign_id = str(record.get("campaign_id") or "").strip()
+    generation_id = str(
+        record.get("generation_run_id")
+        or record.get("controlled_generation_id")
+        or record.get("grid_run_id")
+        or ""
+    ).strip()
+    rejection_reasons: list[str] = []
+    if not candidate_id:
+        rejection_reasons.append("missing_candidate_id")
+    if not campaign_id and not generation_id:
+        rejection_reasons.append("missing_campaign_or_generation_id")
+    accepted = not rejection_reasons
+    return (
+        {
+            "artifact_type": "structured_lineage_candidate",
+            "request_id": bounded_request.request_id,
+            "candidate_id": candidate_id,
+            "campaign_id": campaign_id,
+            "generation_id": generation_id,
+            "preset_id": bounded_request.preset_id,
+            "timeframe": bounded_request.timeframe,
+            "source_ref": source_ref,
+            "reason_record_refs": list(_unique_in_order(record.get("reason_record_refs") or ())),
+            "accepted_by_adapter": accepted,
+            "accepted_for_campaign_lineage": accepted,
+            "rejection_reasons": rejection_reasons,
+        },
+        tuple(rejection_reasons),
+    )
+
+
+def _oos_candidate(
+    *,
+    bounded_request: BoundedBasketRequest,
+    source_ref: str,
+    record: Mapping[str, Any],
+) -> tuple[dict[str, Any], tuple[str, ...]]:
+    candidate_id = str(record.get("candidate_id") or "").strip()
+    oos_window = _as_mapping(record.get("oos_window"))
+    metrics = _as_mapping(record.get("oos_metric_fields"))
+    cost_refs = _as_sequence(record.get("cost_slippage_assumption_refs"))
+    rejection_reasons: list[str] = []
+    if not candidate_id:
+        rejection_reasons.append("missing_candidate_id")
+    if not str(oos_window.get("start") or "").strip() or not str(oos_window.get("end") or "").strip():
+        rejection_reasons.append("missing_oos_window")
+    if not metrics:
+        rejection_reasons.append("missing_oos_metrics")
+    if not cost_refs:
+        rejection_reasons.append("missing_cost_slippage_refs")
+    accepted = not rejection_reasons
+    return (
+        {
+            "artifact_type": "structured_oos_candidate",
+            "request_id": bounded_request.request_id,
+            "candidate_id": candidate_id,
+            "preset_id": bounded_request.preset_id,
+            "timeframe": bounded_request.timeframe,
+            "source_ref": source_ref,
+            "oos_window": dict(oos_window),
+            "oos_metric_fields": dict(metrics),
+            "cost_slippage_assumption_refs": list(_unique_in_order(cost_refs)),
+            "reason_record_refs": list(_unique_in_order(record.get("reason_record_refs") or ())),
+            "accepted_by_adapter": accepted,
+            "accepted_for_oos_evidence": accepted,
+            "rejection_reasons": rejection_reasons,
+        },
+        tuple(rejection_reasons),
+    )
+
+
+def _status_from_rejections(
+    *,
+    accepted_lineage_count: int,
+    accepted_oos_count: int,
+    rejection_reasons: Sequence[str],
+) -> AdapterStatus:
+    if accepted_lineage_count > 0 and accepted_oos_count > 0 and not rejection_reasons:
+        return "accepted_structured_evidence"
+    ordered: tuple[tuple[str, AdapterStatus], ...] = (
+        ("missing_candidate_id", "blocked_missing_candidate_id"),
+        ("missing_campaign_or_generation_id", "blocked_missing_campaign_or_generation_id"),
+        ("missing_oos_window", "blocked_missing_oos_window"),
+        ("missing_oos_metrics", "blocked_missing_oos_metrics"),
+        ("missing_cost_slippage_refs", "blocked_missing_cost_slippage_refs"),
+    )
+    for reason, status in ordered:
+        if reason in rejection_reasons:
+            return status
+    return "adapter_ready"
+
+
+def _canonicalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": result.get("schema_version", ADAPTER_SCHEMA_VERSION),
+        "report_kind": result.get("report_kind", REPORT_KIND),
+        "adapter_status": result.get("adapter_status"),
+        "request_ref": result.get("request_ref"),
+        "controlled_validation_source_ref": result.get("controlled_validation_source_ref"),
+        "lineage_candidate_refs": list(result.get("lineage_candidate_refs", [])),
+        "oos_candidate_refs": list(result.get("oos_candidate_refs", [])),
+        "accepted_lineage_count": int(result.get("accepted_lineage_count", 0) or 0),
+        "accepted_oos_count": int(result.get("accepted_oos_count", 0) or 0),
+        "rejected_reasons": list(result.get("rejected_reasons", [])),
+        "can_clear_blockers": bool(result.get("can_clear_blockers", False)),
+        "non_authoritative": bool(result.get("non_authoritative", NON_AUTHORITATIVE_FLAG)),
+        "evidence_authority": result.get("evidence_authority", EVIDENCE_AUTHORITY),
+        "can_authorize_execution": bool(result.get("can_authorize_execution", CAN_AUTHORIZE_EXECUTION)),
+        "can_promote_candidate": bool(result.get("can_promote_candidate", CAN_PROMOTE_CANDIDATE)),
+    }
+
+
+def compute_adapter_hash(payload: Mapping[str, Any]) -> str:
+    canonical = _canonicalize_result(payload)
+    blob = json.dumps(canonical, sort_keys=True, ensure_ascii=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _finalize(result: dict[str, Any]) -> dict[str, Any]:
+    result["rejected_reasons"] = list(_unique_in_order(result.get("rejected_reasons") or ()))
+    result["lineage_candidate_refs"] = list(_unique_in_order(result.get("lineage_candidate_refs") or ()))
+    result["oos_candidate_refs"] = list(_unique_in_order(result.get("oos_candidate_refs") or ()))
+    result["hash"] = compute_adapter_hash(result)
+    return result
+
+
+def build_controlled_validation_adapter_result(
+    request: BoundedBasketRequest | Mapping[str, Any],
+    *,
+    controlled_validation_source: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    bounded_request, request_status, request_reasons = _request_or_error(request)
+    if bounded_request is None:
+        return _finalize(
+            {
+                "schema_version": ADAPTER_SCHEMA_VERSION,
+                "report_kind": REPORT_KIND,
+                "adapter_status": request_status,
+                "request_ref": str(_as_mapping(request).get("request_id") or ""),
+                "controlled_validation_source_ref": "",
+                "lineage_candidate_refs": [],
+                "oos_candidate_refs": [],
+                "accepted_lineage_count": 0,
+                "accepted_oos_count": 0,
+                "rejected_reasons": list(request_reasons),
+                "can_clear_blockers": False,
+                "non_authoritative": NON_AUTHORITATIVE_FLAG,
+                "evidence_authority": EVIDENCE_AUTHORITY,
+                "can_authorize_execution": CAN_AUTHORIZE_EXECUTION,
+                "can_promote_candidate": CAN_PROMOTE_CANDIDATE,
+                "lineage_candidates": [],
+                "oos_candidates": [],
+            }
+        )
+
+    source_status, source_reasons = _source_status(controlled_validation_source)
+    source = _as_mapping(controlled_validation_source)
+    source_ref = str(source.get("source_ref") or "").strip()
+    if source_status is not None:
+        return _finalize(
+            {
+                "schema_version": ADAPTER_SCHEMA_VERSION,
+                "report_kind": REPORT_KIND,
+                "adapter_status": source_status,
+                "request_ref": bounded_request.request_id,
+                "controlled_validation_source_ref": source_ref,
+                "lineage_candidate_refs": [],
+                "oos_candidate_refs": [],
+                "accepted_lineage_count": 0,
+                "accepted_oos_count": 0,
+                "rejected_reasons": list(source_reasons),
+                "can_clear_blockers": False,
+                "non_authoritative": NON_AUTHORITATIVE_FLAG,
+                "evidence_authority": EVIDENCE_AUTHORITY,
+                "can_authorize_execution": CAN_AUTHORIZE_EXECUTION,
+                "can_promote_candidate": CAN_PROMOTE_CANDIDATE,
+                "lineage_candidates": [],
+                "oos_candidates": [],
+            }
+        )
+
+    lineage_candidates: list[dict[str, Any]] = []
+    oos_candidates: list[dict[str, Any]] = []
+    rejected_reasons: list[str] = []
+    for record in _as_sequence(source.get("lineage_records")):
+        candidate, reasons = _lineage_candidate(
+            bounded_request=bounded_request,
+            source_ref=source_ref,
+            record=_as_mapping(record),
+        )
+        lineage_candidates.append(candidate)
+        rejected_reasons.extend(reasons)
+    for record in _as_sequence(source.get("oos_records")):
+        candidate, reasons = _oos_candidate(
+            bounded_request=bounded_request,
+            source_ref=source_ref,
+            record=_as_mapping(record),
+        )
+        oos_candidates.append(candidate)
+        rejected_reasons.extend(reasons)
+
+    accepted_lineage_count = sum(1 for item in lineage_candidates if item["accepted_by_adapter"])
+    accepted_oos_count = sum(1 for item in oos_candidates if item["accepted_by_adapter"])
+    status = _status_from_rejections(
+        accepted_lineage_count=accepted_lineage_count,
+        accepted_oos_count=accepted_oos_count,
+        rejection_reasons=rejected_reasons,
+    )
+    can_clear_blockers = status == "accepted_structured_evidence"
+    return _finalize(
+        {
+            "schema_version": ADAPTER_SCHEMA_VERSION,
+            "report_kind": REPORT_KIND,
+            "adapter_status": status,
+            "request_ref": bounded_request.request_id,
+            "controlled_validation_source_ref": source_ref,
+            "lineage_candidate_refs": [
+                f"{source_ref}#lineage:{item['candidate_id']}"
+                for item in lineage_candidates
+                if item["accepted_by_adapter"]
+            ],
+            "oos_candidate_refs": [
+                f"{source_ref}#oos:{item['candidate_id']}"
+                for item in oos_candidates
+                if item["accepted_by_adapter"]
+            ],
+            "accepted_lineage_count": accepted_lineage_count,
+            "accepted_oos_count": accepted_oos_count,
+            "rejected_reasons": rejected_reasons,
+            "can_clear_blockers": can_clear_blockers,
+            "non_authoritative": NON_AUTHORITATIVE_FLAG,
+            "evidence_authority": EVIDENCE_AUTHORITY,
+            "can_authorize_execution": CAN_AUTHORIZE_EXECUTION,
+            "can_promote_candidate": CAN_PROMOTE_CANDIDATE,
+            "lineage_candidates": lineage_candidates,
+            "oos_candidates": oos_candidates,
+        }
+    )
+
+
+def validate_adapter_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    rejection_reasons: list[str] = []
+    canonical = _canonicalize_result(result)
+    if canonical["can_clear_blockers"] and (
+        canonical["accepted_lineage_count"] <= 0 or canonical["accepted_oos_count"] <= 0
+    ):
+        rejection_reasons.append("can_clear_blockers_requires_accepted_lineage_and_oos")
+    if canonical["non_authoritative"] is not True:
+        rejection_reasons.append("non_authoritative_must_be_true")
+    if canonical["can_authorize_execution"] is not False:
+        rejection_reasons.append("can_authorize_execution_must_be_false")
+    if canonical["can_promote_candidate"] is not False:
+        rejection_reasons.append("can_promote_candidate_must_be_false")
+    computed_hash = compute_adapter_hash(result)
+    if str(result.get("hash") or "") and str(result.get("hash")) != computed_hash:
+        rejection_reasons.append("hash_mismatch")
+    return {
+        "valid": not rejection_reasons,
+        "rejection_reasons": list(_unique_in_order(rejection_reasons)),
+        "hash": computed_hash,
+        "schema_version": ADAPTER_SCHEMA_VERSION,
+    }

--- a/tests/unit/test_qre_controlled_validation_adapter.py
+++ b/tests/unit/test_qre_controlled_validation_adapter.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research.qre_controlled_validation_adapter import (
+    build_controlled_validation_adapter_result,
+    compute_adapter_hash,
+    validate_adapter_result,
+)
+
+
+def _request(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "request_id": "req-controlled-validation-001",
+        "symbols": ("AAA", "BBB"),
+        "preset_id": "trend_pullback_continuation_daily_v1",
+        "timeframe": "1d",
+        "approval_ref": "approval/operator/bounded-validation-001",
+        "required_artifact_types": ("structured_lineage", "structured_oos"),
+        "allowed_output_paths": (
+            "logs/qre_controlled_validation_adapter/latest.json",
+            "artifacts/qre_controlled_validation/accepted.json",
+        ),
+        "forbidden_capabilities": (),
+        "created_at_utc": "2026-06-18T00:00:00Z",
+        "source": "unit-test",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _structured_source(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "source_type": "structured_controlled_validation",
+        "source_authority": "structured_source",
+        "source_ref": "artifacts/qre_controlled_validation/source-001.json",
+        "lineage_records": (
+            {
+                "candidate_id": "cand-001",
+                "campaign_id": "camp-001",
+                "generation_run_id": "gen-001",
+                "reason_record_refs": ("rr-lineage-001",),
+            },
+        ),
+        "oos_records": (
+            {
+                "candidate_id": "cand-001",
+                "oos_window": {"start": "2025-01-01", "end": "2025-06-30"},
+                "oos_metric_fields": {"oos_trade_count": 24, "oos_return_pct": 3.1},
+                "cost_slippage_assumption_refs": ("cost-model-001",),
+                "reason_record_refs": ("rr-oos-001",),
+            },
+        ),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_invalid_bounded_request_fails_closed() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(request_id=""),
+        controlled_validation_source=_structured_source(),
+    )
+    assert result["adapter_status"] == "blocked_invalid_bounded_request"
+    assert result["accepted_lineage_count"] == 0
+    assert result["accepted_oos_count"] == 0
+    assert result["can_clear_blockers"] is False
+
+
+def test_missing_approval_ref_fails_closed() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(approval_ref=""),
+        controlled_validation_source=_structured_source(),
+    )
+    assert result["adapter_status"] == "blocked_missing_approval_ref"
+    assert result["rejected_reasons"] == ["missing_approval_ref"]
+
+
+def test_forbidden_capabilities_fail_closed() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(forbidden_capabilities=("strategy_synthesis",)),
+        controlled_validation_source=_structured_source(),
+    )
+    assert result["adapter_status"] == "blocked_forbidden_capability"
+    assert result["can_clear_blockers"] is False
+
+
+def test_disallowed_output_paths_fail_closed() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(allowed_output_paths=("/tmp/out.json",)),
+        controlled_validation_source=_structured_source(),
+    )
+    assert result["adapter_status"] == "blocked_output_path_not_allowlisted"
+
+
+def test_no_safe_controlled_validation_source_returns_no_accepted_evidence() -> None:
+    result = build_controlled_validation_adapter_result(_request())
+    assert result["adapter_status"] == "no_safe_controlled_validation_source"
+    assert result["accepted_lineage_count"] == 0
+    assert result["accepted_oos_count"] == 0
+    assert result["can_clear_blockers"] is False
+
+
+def test_stdout_only_source_rejected() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source={"source_type": "stdout_only", "source_ref": "stdout"},
+    )
+    assert result["adapter_status"] == "rejected_stdout_only_source"
+
+
+def test_context_only_source_rejected() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source={"source_type": "context_only", "source_ref": "report"},
+    )
+    assert result["adapter_status"] == "rejected_context_only_source"
+
+
+def test_legacy_alias_only_source_rejected() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source={"source_type": "legacy_alias_only", "source_ref": "alias"},
+    )
+    assert result["adapter_status"] == "rejected_legacy_alias_only_source"
+
+
+def test_missing_candidate_or_campaign_generation_ids_rejected_for_lineage_acceptance() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source=_structured_source(
+            lineage_records=(
+                {
+                    "candidate_id": "",
+                    "campaign_id": "",
+                    "generation_run_id": "",
+                },
+            )
+        ),
+    )
+    assert result["adapter_status"] == "blocked_missing_candidate_id"
+    assert "missing_candidate_id" in result["rejected_reasons"]
+    assert "missing_campaign_or_generation_id" in result["rejected_reasons"]
+    assert result["accepted_lineage_count"] == 0
+
+
+def test_missing_oos_window_metrics_or_cost_refs_rejected_for_oos_acceptance() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source=_structured_source(
+            oos_records=(
+                {
+                    "candidate_id": "cand-001",
+                    "oos_window": {},
+                    "oos_metric_fields": {},
+                    "cost_slippage_assumption_refs": (),
+                },
+            )
+        ),
+    )
+    assert result["adapter_status"] == "blocked_missing_oos_window"
+    assert "missing_oos_window" in result["rejected_reasons"]
+    assert "missing_oos_metrics" in result["rejected_reasons"]
+    assert "missing_cost_slippage_refs" in result["rejected_reasons"]
+    assert result["accepted_oos_count"] == 0
+
+
+def test_accepted_structured_source_can_produce_accepted_candidate_artifacts() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source=_structured_source(),
+    )
+    assert result["adapter_status"] == "accepted_structured_evidence"
+    assert result["accepted_lineage_count"] == 1
+    assert result["accepted_oos_count"] == 1
+    assert result["lineage_candidate_refs"] == [
+        "artifacts/qre_controlled_validation/source-001.json#lineage:cand-001"
+    ]
+    assert result["oos_candidate_refs"] == [
+        "artifacts/qre_controlled_validation/source-001.json#oos:cand-001"
+    ]
+    assert result["can_clear_blockers"] is True
+
+
+def test_adapter_never_invents_ids() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source=_structured_source(
+            lineage_records=({"candidate_id": "", "campaign_id": "", "generation_run_id": ""},),
+            oos_records=(
+                {
+                    "candidate_id": "",
+                    "oos_window": {"start": "2025-01-01", "end": "2025-06-30"},
+                    "oos_metric_fields": {"oos_trade_count": 1},
+                    "cost_slippage_assumption_refs": ("cost",),
+                },
+            ),
+        ),
+    )
+    assert result["lineage_candidates"][0]["candidate_id"] == ""
+    assert result["lineage_candidates"][0]["campaign_id"] == ""
+    assert result["lineage_candidates"][0]["generation_id"] == ""
+    assert result["oos_candidates"][0]["candidate_id"] == ""
+
+
+def test_adapter_output_deterministic() -> None:
+    result_1 = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source=_structured_source(),
+    )
+    result_2 = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source=_structured_source(),
+    )
+    assert result_1 == result_2
+    assert compute_adapter_hash(result_1) == compute_adapter_hash(result_2)
+
+
+def test_adapter_cannot_authorize_strategy_candidate_or_deployment() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source=_structured_source(),
+    )
+    assert result["non_authoritative"] is True
+    assert result["can_authorize_execution"] is False
+    assert result["can_promote_candidate"] is False
+    validation = validate_adapter_result(result)
+    assert validation["valid"] is True
+
+
+def test_core_adapter_logic_has_no_aapl_or_nvda_hardcoding() -> None:
+    source = Path("research/qre_controlled_validation_adapter.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source


### PR DESCRIPTION
## Track

Track 2 / E1 Evidence Production - controlled validation adapter

## Scope

Adds a generic, bounded-request-driven, read-only controlled validation adapter. The adapter normalizes explicitly supplied structured validation source payloads into lineage/OOS candidate records and fails closed for unsafe or incomplete sources.

## Files Changed

- `research/qre_controlled_validation_adapter.py`
- `tests/unit/test_qre_controlled_validation_adapter.py`

## Adapter API

- `build_controlled_validation_adapter_result(request, controlled_validation_source=...)`
- `compute_adapter_hash(payload)`
- `validate_adapter_result(result)`

## Statuses

- `adapter_ready`
- `no_safe_controlled_validation_source`
- `blocked_invalid_bounded_request`
- `blocked_missing_approval_ref`
- `blocked_forbidden_capability`
- `blocked_output_path_not_allowlisted`
- `blocked_source_not_structured`
- `blocked_missing_candidate_id`
- `blocked_missing_campaign_or_generation_id`
- `blocked_missing_oos_window`
- `blocked_missing_oos_metrics`
- `blocked_missing_cost_slippage_refs`
- `rejected_context_only_source`
- `rejected_stdout_only_source`
- `rejected_legacy_alias_only_source`
- `accepted_structured_evidence`

## Evidence Impact

This PR adds the adapter path only. It does not run validation, fetch data, write generated logs, or change current accepted evidence counts. Accepted structured records are possible only from fully structured supplied payloads with real IDs/windows/metrics/cost refs; the adapter never invents IDs.

## Tests Run

- `python -m pytest tests/unit/test_qre_controlled_validation_adapter.py -q` -> 15 passed
- `python -m pytest tests/unit/test_qre_bounded_basket_request.py tests/unit/test_qre_bounded_current_basket_generation_discovery.py -q` -> 15 passed
- `python -m pytest tests/unit/test_qre_structured_lineage_artifacts.py tests/unit/test_qre_structured_oos_artifacts.py -q` -> 6 passed
- `python -m pytest tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py tests/unit/test_qre_evidence_complete_basket_closure.py -q` -> 6 passed
- `python -m pytest tests/smoke -q` -> 18 passed
- `python scripts/governance_lint.py` -> Governance lint OK
- `git diff --check` -> pass
- `git diff -- research/research_latest.json research/strategy_matrix.csv` -> no diff
- `git diff --name-only -- live paper shadow broker risk execution` -> no diff

## Safety Confirmation

- no fake evidence
- no invented candidate/campaign/generation IDs
- no context-only proof
- no stdout-only proof
- no legacy alias-only proof
- no strategy synthesis
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution
- no external fetch without approval
- no AAPL/NVDA core hardcoding
- frozen contracts unchanged
- protected paths untouched

## Next Recommended PR

`feat: connect bounded runner to controlled validation adapter`