### PR TITLE
feat: connect bounded runner to controlled validation adapter

### DIFF
--- a/research/qre_bounded_current_basket_generation_runner.py
+++ b/research/qre_bounded_current_basket_generation_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from collections.abc import Mapping, Sequence
@@ -9,6 +10,7 @@ from typing import Any, Final
 
 from research import qre_bounded_basket_request as basket_request
 from research import qre_bounded_current_basket_generation_discovery as discovery
+from research import qre_controlled_validation_adapter as validation_adapter
 
 
 REPORT_KIND: Final[str] = "qre_bounded_current_basket_generation_runner"
@@ -22,6 +24,8 @@ RUNNER_COMMAND: Final[str] = (
     "python -m research.qre_bounded_current_basket_generation_runner "
     "--request-file logs/qre_bounded_basket_request/latest.json --dry-run --write"
 )
+NON_AUTHORITATIVE_FLAG: Final[bool] = True
+EVIDENCE_AUTHORITY: Final[str] = "runner_context_until_verifier_acceptance"
 
 
 def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
@@ -59,6 +63,44 @@ def _request_from_file(request_file: Path | None) -> dict[str, Any] | None:
     return _read_json(request_file)
 
 
+def _source_from_file(source_file: Path | None) -> dict[str, Any] | None:
+    if source_file is None:
+        return None
+    return _read_json(source_file)
+
+
+def _unique_in_order(values: Sequence[str]) -> list[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _canonical_runner_payload(report: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": report.get("schema_version", SCHEMA_VERSION),
+        "report_kind": report.get("report_kind", REPORT_KIND),
+        "runner_status": report.get("runner_status"),
+        "request_ref": report.get("request_ref"),
+        "controlled_validation_source_ref": report.get("controlled_validation_source_ref"),
+        "lineage_candidate_refs": list(report.get("lineage_candidate_refs", [])),
+        "oos_candidate_refs": list(report.get("oos_candidate_refs", [])),
+        "accepted_lineage_count": int(report.get("accepted_lineage_count", 0) or 0),
+        "accepted_oos_count": int(report.get("accepted_oos_count", 0) or 0),
+        "rejected_reasons": list(report.get("rejected_reasons", [])),
+        "can_clear_blockers": bool(report.get("can_clear_blockers", False)),
+        "can_authorize_execution": bool(report.get("can_authorize_execution", False)),
+        "can_synthesize_strategy": bool(report.get("can_synthesize_strategy", False)),
+        "can_promote_candidate": bool(report.get("can_promote_candidate", False)),
+        "can_activate_deployment": bool(report.get("can_activate_deployment", False)),
+        "non_authoritative": bool(report.get("non_authoritative", NON_AUTHORITATIVE_FLAG)),
+        "evidence_authority": report.get("evidence_authority", EVIDENCE_AUTHORITY),
+    }
+
+
+def compute_runner_hash(report: Mapping[str, Any]) -> str:
+    payload = _canonical_runner_payload(report)
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
 def _reason_record(
     *,
     record_id: str,
@@ -85,6 +127,7 @@ def build_bounded_current_basket_generation_runner(
     request_payload: Mapping[str, Any] | None = None,
     *,
     repo_root: Path = Path("."),
+    controlled_validation_source: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     raw_request_payload = request_payload if isinstance(request_payload, Mapping) else None
     request_report = _request_snapshot(raw_request_payload)
@@ -111,6 +154,71 @@ def build_bounded_current_basket_generation_runner(
         blocking_reasons.append("forbidden_capabilities_present")
     if not safe_generation_command_found:
         blocking_reasons.append("safe_bounded_generation_command_not_found")
+    source_ref = (
+        str(controlled_validation_source.get("source_ref") or "")
+        if isinstance(controlled_validation_source, Mapping)
+        else ""
+    )
+    adapter_called = valid_request and bool(request.get("approval_ref")) and output_allowlisted and not forbidden_capabilities
+    if adapter_called:
+        adapter_result = validation_adapter.build_controlled_validation_adapter_result(
+            request,
+            controlled_validation_source=controlled_validation_source,
+        )
+    else:
+        adapter_result = {
+            "adapter_status": "blocked_invalid_bounded_request",
+            "request_ref": str(request.get("request_id") or ""),
+            "controlled_validation_source_ref": source_ref,
+            "lineage_candidate_refs": [],
+            "oos_candidate_refs": [],
+            "accepted_lineage_count": 0,
+            "accepted_oos_count": 0,
+            "rejected_reasons": list(blocking_reasons),
+            "can_clear_blockers": False,
+            "non_authoritative": True,
+            "evidence_authority": "adapter_not_called_preflight_failed",
+        }
+    adapter_status = str(adapter_result.get("adapter_status") or "")
+    accepted_lineage_count = int(adapter_result.get("accepted_lineage_count") or 0)
+    accepted_oos_count = int(adapter_result.get("accepted_oos_count") or 0)
+    adapter_rejected_reasons = list(adapter_result.get("rejected_reasons") or [])
+    adapter_has_required_counts = (
+        bool(adapter_result.get("can_clear_blockers"))
+        and accepted_lineage_count > 0
+        and accepted_oos_count > 0
+    )
+    can_clear_blockers = False
+    if adapter_has_required_counts:
+        adapter_rejected_reasons.append("verifier_acceptance_required_to_clear_blockers")
+    if not adapter_called:
+        runner_status = (
+            "blocked_missing_approval_ref"
+            if "missing_approval_ref" in blocking_reasons
+            else "blocked_output_path_not_allowlisted"
+            if "output_paths_not_allowlisted" in blocking_reasons
+            else "blocked_forbidden_capability"
+            if "forbidden_capabilities_present" in blocking_reasons
+            else "blocked_invalid_bounded_request"
+        )
+    elif adapter_status == "no_safe_controlled_validation_source":
+        runner_status = "no_safe_controlled_validation_source"
+    elif adapter_status == "accepted_structured_evidence":
+        runner_status = "adapter_accepted_structured_evidence"
+    elif adapter_status in {
+        "blocked_missing_candidate_id",
+        "blocked_missing_campaign_or_generation_id",
+        "blocked_missing_oos_window",
+        "blocked_missing_oos_metrics",
+        "blocked_missing_cost_slippage_refs",
+    }:
+        runner_status = "adapter_provisional_only"
+    elif adapter_status.startswith("rejected_") or adapter_status == "blocked_source_not_structured":
+        runner_status = "adapter_rejected_source"
+    else:
+        runner_status = "dry_run_only" if blocking_reasons else "runner_ready"
+    if adapter_rejected_reasons:
+        blocking_reasons.extend(adapter_rejected_reasons)
     generation_status = "not_executed"
     reason_records = [
         _reason_record(
@@ -144,7 +252,7 @@ def build_bounded_current_basket_generation_runner(
         if request_report.get("validation_status") == "valid"
         else "request_invalid_fails_closed"
     )
-    return {
+    report = {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
         "request": request,
@@ -170,11 +278,29 @@ def build_bounded_current_basket_generation_runner(
             "auto_run_allowed": False,
             "operator_decision_required": True,
             "safe_existing_generation_command_available": safe_generation_command_found,
+            "controlled_validation_adapter_called": adapter_called,
             "request_valid": valid_request,
             "approval_ref_present": bool(request.get("approval_ref")),
             "output_paths_allowlisted": output_allowlisted,
             "forbidden_capabilities_present": forbidden_capabilities,
         },
+        "runner_status": runner_status,
+        "request_ref": str(request.get("request_id") or ""),
+        "adapter_result_ref": "embedded:adapter_result",
+        "adapter_result": adapter_result,
+        "controlled_validation_source_ref": str(adapter_result.get("controlled_validation_source_ref") or source_ref),
+        "lineage_candidate_refs": list(adapter_result.get("lineage_candidate_refs") or []),
+        "oos_candidate_refs": list(adapter_result.get("oos_candidate_refs") or []),
+        "accepted_lineage_count": accepted_lineage_count,
+        "accepted_oos_count": accepted_oos_count,
+        "rejected_reasons": _unique_in_order([str(reason) for reason in blocking_reasons]),
+        "can_clear_blockers": can_clear_blockers,
+        "can_authorize_execution": False,
+        "can_synthesize_strategy": False,
+        "can_promote_candidate": False,
+        "can_activate_deployment": False,
+        "non_authoritative": NON_AUTHORITATIVE_FLAG,
+        "evidence_authority": EVIDENCE_AUTHORITY,
         "generation_manifest": {
             "generation_run_id": None,
             "generation_mode": "provisional_dry_run_only",
@@ -187,6 +313,11 @@ def build_bounded_current_basket_generation_runner(
             "approval_required": True,
             "auto_run_allowed": False,
             "final_recommendation": final_recommendation,
+            "controlled_validation_source_ref": str(adapter_result.get("controlled_validation_source_ref") or source_ref),
+            "adapter_status": adapter_status,
+            "accepted_lineage_count": accepted_lineage_count,
+            "accepted_oos_count": accepted_oos_count,
+            "can_clear_blockers": can_clear_blockers,
         },
         "command_manifest": {
             "runner_command": RUNNER_COMMAND,
@@ -223,8 +354,12 @@ def build_bounded_current_basket_generation_runner(
             "no_external_fetch": True,
             "no_runner_execution": True,
             "provisional_until_safe_command_exists": True,
+            "adapter_output_not_proof_by_itself": True,
+            "verifier_acceptance_required_to_clear_blockers": True,
         },
     }
+    report["hash"] = compute_runner_hash(report)
+    return report
 
 
 def render_operator_summary(report: Mapping[str, Any]) -> str:
@@ -294,11 +429,20 @@ def main(argv: list[str] | None = None) -> int:
         description="Build the provisional bounded current-basket generation runner report.",
     )
     parser.add_argument("--request-file", required=True)
+    parser.add_argument("--controlled-validation-source-file")
     parser.add_argument("--dry-run", action="store_true", default=True)
     parser.add_argument("--write", action="store_true")
     args = parser.parse_args(argv)
     request_payload = _request_from_file(Path(args.request_file))
-    report = build_bounded_current_basket_generation_runner(request_payload)
+    source_payload = _source_from_file(
+        Path(args.controlled_validation_source_file)
+        if args.controlled_validation_source_file
+        else None
+    )
+    report = build_bounded_current_basket_generation_runner(
+        request_payload,
+        controlled_validation_source=source_payload,
+    )
     if args.write:
         report["_artifact_paths"] = write_outputs(report)
     print(json.dumps(report, indent=2, sort_keys=True))

--- a/research/qre_controlled_validation_adapter.py
+++ b/research/qre_controlled_validation_adapter.py
@@ -400,6 +400,8 @@ def validate_adapter_result(result: Mapping[str, Any]) -> dict[str, Any]:
         rejection_reasons.append("can_authorize_execution_must_be_false")
     if canonical["can_promote_candidate"] is not False:
         rejection_reasons.append("can_promote_candidate_must_be_false")
+    if canonical["can_clear_blockers"] and canonical["adapter_status"] != "accepted_structured_evidence":
+        rejection_reasons.append("can_clear_blockers_requires_accepted_structured_evidence_status")
     computed_hash = compute_adapter_hash(result)
     if str(result.get("hash") or "") and str(result.get("hash")) != computed_hash:
         rejection_reasons.append("hash_mismatch")

--- a/tests/unit/test_qre_bounded_current_basket_generation_runner.py
+++ b/tests/unit/test_qre_bounded_current_basket_generation_runner.py
@@ -28,6 +28,33 @@ def _request_payload() -> dict[str, object]:
     }
 
 
+def _structured_source(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "source_type": "structured_controlled_validation",
+        "source_authority": "structured_source",
+        "source_ref": "artifacts/qre_controlled_validation/source-001.json",
+        "lineage_records": [
+            {
+                "candidate_id": "cand-001",
+                "campaign_id": "camp-001",
+                "generation_run_id": "gen-001",
+                "reason_record_refs": ["rr-lineage-001"],
+            }
+        ],
+        "oos_records": [
+            {
+                "candidate_id": "cand-001",
+                "oos_window": {"start": "2025-01-01", "end": "2025-06-30"},
+                "oos_metric_fields": {"oos_trade_count": 24, "oos_return_pct": 3.1},
+                "cost_slippage_assumption_refs": ["cost-model-001"],
+                "reason_record_refs": ["rr-oos-001"],
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
 def test_runner_is_deterministic_and_fail_closed() -> None:
     first = runner.build_bounded_current_basket_generation_runner(_request_payload())
     second = runner.build_bounded_current_basket_generation_runner(_request_payload())
@@ -39,6 +66,12 @@ def test_runner_is_deterministic_and_fail_closed() -> None:
     assert first["generation_manifest"]["auto_run_allowed"] is False
     assert first["preflight"]["approval_packet_ready"] is True
     assert first["preflight"]["safe_existing_generation_command_available"] is False
+    assert first["runner_status"] == "no_safe_controlled_validation_source"
+    assert first["adapter_result"]["adapter_status"] == "no_safe_controlled_validation_source"
+    assert first["accepted_lineage_count"] == 0
+    assert first["accepted_oos_count"] == 0
+    assert first["can_clear_blockers"] is False
+    assert first["hash"] == runner.compute_runner_hash(first)
 
 
 def test_runner_emits_reason_records_and_downstream_manifest() -> None:
@@ -73,6 +106,8 @@ def test_runner_rejects_invalid_request_payload_fail_closed() -> None:
     assert report["request_validation_status"] == "rejected"
     assert report["summary"]["final_recommendation"] == "request_invalid_fails_closed"
     assert report["preflight"]["approval_packet_ready"] is False
+    assert report["preflight"]["controlled_validation_adapter_called"] is False
+    assert report["runner_status"] == "blocked_missing_approval_ref"
 
 
 def test_runner_write_outputs_are_allowlisted(tmp_path: Path) -> None:
@@ -85,3 +120,138 @@ def test_runner_write_outputs_are_allowlisted(tmp_path: Path) -> None:
         (tmp_path / "logs" / "qre_bounded_current_basket_generation_runner" / "latest.json").read_text(encoding="utf-8")
     )
     assert payload["summary"]["final_recommendation"] == "NO_SAFE_BOUNDED_GENERATION_COMMAND_FOUND"
+
+
+def test_runner_does_not_call_adapter_when_approval_ref_missing() -> None:
+    payload = _request_payload()
+    payload["approval_ref"] = ""
+    report = runner.build_bounded_current_basket_generation_runner(
+        payload,
+        controlled_validation_source=_structured_source(),
+    )
+
+    assert report["preflight"]["controlled_validation_adapter_called"] is False
+    assert report["runner_status"] == "blocked_missing_approval_ref"
+    assert report["accepted_lineage_count"] == 0
+    assert report["accepted_oos_count"] == 0
+
+
+def test_runner_does_not_call_adapter_when_forbidden_capabilities_present() -> None:
+    payload = _request_payload()
+    payload["forbidden_capabilities"] = ["strategy_synthesis"]
+    report = runner.build_bounded_current_basket_generation_runner(
+        payload,
+        controlled_validation_source=_structured_source(),
+    )
+
+    assert report["preflight"]["controlled_validation_adapter_called"] is False
+    assert report["runner_status"] == "blocked_forbidden_capability"
+    assert report["can_clear_blockers"] is False
+
+
+def test_runner_returns_no_safe_controlled_validation_source_without_source() -> None:
+    report = runner.build_bounded_current_basket_generation_runner(_request_payload())
+
+    assert report["runner_status"] == "no_safe_controlled_validation_source"
+    assert report["adapter_result"]["adapter_status"] == "no_safe_controlled_validation_source"
+    assert report["accepted_lineage_count"] == 0
+    assert report["accepted_oos_count"] == 0
+    assert report["can_clear_blockers"] is False
+
+
+def test_runner_preserves_adapter_rejected_result_without_clearing_blockers() -> None:
+    report = runner.build_bounded_current_basket_generation_runner(
+        _request_payload(),
+        controlled_validation_source={"source_type": "context_only", "source_ref": "report"},
+    )
+
+    assert report["runner_status"] == "adapter_rejected_source"
+    assert report["adapter_result"]["adapter_status"] == "rejected_context_only_source"
+    assert report["can_clear_blockers"] is False
+    assert "context_only_source_rejected" in report["rejected_reasons"]
+
+
+def test_runner_preserves_adapter_provisional_result_without_clearing_blockers() -> None:
+    report = runner.build_bounded_current_basket_generation_runner(
+        _request_payload(),
+        controlled_validation_source=_structured_source(
+            lineage_records=[
+                {"candidate_id": "", "campaign_id": "", "generation_run_id": ""}
+            ],
+        ),
+    )
+
+    assert report["runner_status"] == "adapter_provisional_only"
+    assert report["adapter_result"]["adapter_status"] == "blocked_missing_candidate_id"
+    assert report["accepted_lineage_count"] == 0
+    assert report["can_clear_blockers"] is False
+
+
+def test_runner_surfaces_adapter_accepted_counts_when_structured_source_is_accepted() -> None:
+    report = runner.build_bounded_current_basket_generation_runner(
+        _request_payload(),
+        controlled_validation_source=_structured_source(),
+    )
+
+    assert report["runner_status"] == "adapter_accepted_structured_evidence"
+    assert report["adapter_result"]["adapter_status"] == "accepted_structured_evidence"
+    assert report["accepted_lineage_count"] == 1
+    assert report["accepted_oos_count"] == 1
+    assert report["lineage_candidate_refs"] == [
+        "artifacts/qre_controlled_validation/source-001.json#lineage:cand-001"
+    ]
+    assert report["oos_candidate_refs"] == [
+        "artifacts/qre_controlled_validation/source-001.json#oos:cand-001"
+    ]
+    assert report["can_clear_blockers"] is False
+    assert "verifier_acceptance_required_to_clear_blockers" in report["rejected_reasons"]
+
+
+def test_runner_can_clear_blockers_requires_lineage_and_oos_counts() -> None:
+    report = runner.build_bounded_current_basket_generation_runner(
+        _request_payload(),
+        controlled_validation_source=_structured_source(oos_records=[]),
+    )
+
+    assert report["accepted_lineage_count"] == 1
+    assert report["accepted_oos_count"] == 0
+    assert report["can_clear_blockers"] is False
+
+
+def test_runner_rejects_stdout_and_legacy_sources_as_non_authoritative() -> None:
+    stdout_report = runner.build_bounded_current_basket_generation_runner(
+        _request_payload(),
+        controlled_validation_source={"source_type": "stdout_only", "source_ref": "stdout"},
+    )
+    legacy_report = runner.build_bounded_current_basket_generation_runner(
+        _request_payload(),
+        controlled_validation_source={"source_type": "legacy_alias_only", "source_ref": "alias"},
+    )
+
+    assert stdout_report["runner_status"] == "adapter_rejected_source"
+    assert stdout_report["can_clear_blockers"] is False
+    assert legacy_report["runner_status"] == "adapter_rejected_source"
+    assert legacy_report["can_clear_blockers"] is False
+
+
+def test_runner_authority_and_core_path_safety() -> None:
+    report = runner.build_bounded_current_basket_generation_runner(
+        _request_payload(),
+        controlled_validation_source=_structured_source(),
+    )
+    source = Path("research/qre_bounded_current_basket_generation_runner.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert report["non_authoritative"] is True
+    assert report["evidence_authority"] == "runner_context_until_verifier_acceptance"
+    assert report["can_authorize_execution"] is False
+    assert report["can_synthesize_strategy"] is False
+    assert report["can_promote_candidate"] is False
+    assert report["can_activate_deployment"] is False
+    assert report["generation_manifest"]["auto_run_allowed"] is False
+    assert report["safety_invariants"]["no_trading_authority"] is True
+    assert report["safety_invariants"]["no_external_fetch"] is True
+    assert report["safety_invariants"]["adapter_output_not_proof_by_itself"] is True
+    assert "AAPL" not in source
+    assert "NVDA" not in source

--- a/tests/unit/test_qre_controlled_validation_adapter.py
+++ b/tests/unit/test_qre_controlled_validation_adapter.py
@@ -228,6 +228,20 @@ def test_adapter_cannot_authorize_strategy_candidate_or_deployment() -> None:
     assert validation["valid"] is True
 
 
+def test_adapter_rejects_clear_blocker_claim_without_accepted_status() -> None:
+    result = build_controlled_validation_adapter_result(
+        _request(),
+        controlled_validation_source=_structured_source(),
+    )
+    result["adapter_status"] = "adapter_ready"
+    validation = validate_adapter_result(result)
+    assert validation["valid"] is False
+    assert (
+        "can_clear_blockers_requires_accepted_structured_evidence_status"
+        in validation["rejection_reasons"]
+    )
+
+
 def test_core_adapter_logic_has_no_aapl_or_nvda_hardcoding() -> None:
     source = Path("research/qre_controlled_validation_adapter.py").read_text(encoding="utf-8")
     assert "AAPL" not in source


### PR DESCRIPTION
## Status
Track 2/E1 runner-to-adapter bridge; working-read-only evidence production plumbing.

## Scope
- Connects `qre_bounded_current_basket_generation_runner` to `qre_controlled_validation_adapter` after runner preflight passes.
- Embeds adapter result as the runner sidecar/result artifact.
- Surfaces structured lineage/OOS candidate refs and accepted counts from adapter results.
- Keeps blocker clearance false until verifier-accepted structured lineage and OOS artifacts exist.

## Safety
- no fake evidence
- no invented candidate/campaign/generation IDs
- no context-only proof
- no stdout-only proof
- no legacy alias-only proof
- no strategy synthesis
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution
- no external fetch
- no AAPL/NVDA core hardcoding
- frozen contracts unchanged
- protected paths untouched

## Tests run
- `python -m pytest tests/unit/test_qre_bounded_current_basket_generation_runner.py tests/unit/test_qre_controlled_validation_adapter.py -q`
- `python -m pytest tests/unit/test_qre_bounded_basket_request.py tests/unit/test_qre_bounded_current_basket_generation_discovery.py -q`
- `python -m pytest tests/unit/test_qre_structured_lineage_artifacts.py tests/unit/test_qre_structured_oos_artifacts.py -q`
- `python -m pytest tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py tests/unit/test_qre_evidence_complete_basket_closure.py -q`
- `python -m pytest tests/smoke -q`
- `python scripts/governance_lint.py`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`
- `git diff --name-only -- live paper shadow broker risk execution`

## Evidence impact
- accepted structured lineage artifacts: 0 -> 0
- accepted structured OOS artifacts: 0 -> 0
- evidence_complete_count: 0 -> 0
- blockers cleared: none

## Next recommended PR
`feat: materialize adapter result artifacts for acceptance verifier`