### PR TITLE
feat: materialize adapter result artifacts for acceptance verifier

### DIFF
--- a/research/qre_bounded_current_basket_generation_runner.py
+++ b/research/qre_bounded_current_basket_generation_runner.py
@@ -11,6 +11,7 @@ from typing import Any, Final
 from research import qre_bounded_basket_request as basket_request
 from research import qre_bounded_current_basket_generation_discovery as discovery
 from research import qre_controlled_validation_adapter as validation_adapter
+from research import qre_controlled_validation_adapter_result_materialization as adapter_materialization
 
 
 REPORT_KIND: Final[str] = "qre_bounded_current_basket_generation_runner"
@@ -358,6 +359,13 @@ def build_bounded_current_basket_generation_runner(
             "verifier_acceptance_required_to_clear_blockers": True,
         },
     }
+    report["controlled_validation_adapter_result_materialization"] = adapter_materialization.build_controlled_validation_adapter_result_materialization(
+        report
+    )
+    report["controlled_validation_adapter_result_materialization_ref"] = "embedded:controlled_validation_adapter_result_materialization"
+    report["controlled_validation_adapter_result_materialization_status"] = str(
+        (report.get("controlled_validation_adapter_result_materialization") or {}).get("materialization_status") or ""
+    )
     report["hash"] = compute_runner_hash(report)
     return report
 
@@ -417,9 +425,15 @@ def write_outputs(
     tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
     tmp_md.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
     os.replace(tmp_md, summary_path)
+    materialization = report.get("controlled_validation_adapter_result_materialization")
+    if isinstance(materialization, Mapping):
+        materialization_paths = adapter_materialization.write_outputs(materialization, repo_root=repo_root)
+    else:
+        materialization_paths = {}
     return {
         "latest": latest.relative_to(repo_root).as_posix(),
         "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+        **({"controlled_validation_adapter_result_materialization": materialization_paths.get("latest")} if materialization_paths else {}),
     }
 
 

--- a/research/qre_bounded_generation_artifact_acceptance_verifier.py
+++ b/research/qre_bounded_generation_artifact_acceptance_verifier.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from research import qre_bounded_first_batch_generation_decision as decision
+from research import qre_controlled_validation_adapter_result_materialization as adapter_materialization
 
 
 REPORT_KIND: Final[str] = "qre_bounded_generation_artifact_acceptance_verifier"
@@ -59,6 +60,72 @@ def classify_artifact(
     payload = _read_json(path)
     relative_path = path.relative_to(repo_root).as_posix()
     text = json.dumps(payload, sort_keys=True, default=str).lower() if payload is not None else ""
+    report_kind = str(payload.get("report_kind") or "") if isinstance(payload, Mapping) else ""
+    if report_kind == adapter_materialization.REPORT_KIND:
+        materialization_status = str(payload.get("materialization_status") or "")
+        authority = payload.get("authority") if isinstance(payload.get("authority"), Mapping) else {}
+        lineage_candidates = payload.get("lineage_candidates") if isinstance(payload.get("lineage_candidates"), list) else []
+        oos_candidates = payload.get("oos_candidates") if isinstance(payload.get("oos_candidates"), list) else []
+        accepted_lineage_count = int(payload.get("accepted_lineage_count") or 0)
+        accepted_oos_count = int(payload.get("accepted_oos_count") or 0)
+        lineage_accepted = any(
+            isinstance(candidate, Mapping)
+            and str(candidate.get("candidate_id") or "").strip()
+            and (
+                str(candidate.get("campaign_id") or "").strip()
+                or str(candidate.get("generation_id") or "").strip()
+                or str(candidate.get("controlled_generation_id") or "").strip()
+                or str(candidate.get("grid_run_id") or "").strip()
+            )
+            and bool(candidate.get("accepted_by_adapter", False))
+            for candidate in lineage_candidates
+        )
+        oos_accepted = any(
+            isinstance(candidate, Mapping)
+            and str(candidate.get("candidate_id") or "").strip()
+            and bool(candidate.get("oos_metric_fields"))
+            and bool(candidate.get("cost_slippage_assumption_refs"))
+            and bool(candidate.get("accepted_by_adapter", False))
+            for candidate in oos_candidates
+        )
+        has_authority = (
+            bool(authority.get("non_authoritative")) is True
+            and bool(authority.get("can_authorize_execution")) is False
+            and bool(authority.get("can_promote_candidate")) is False
+            and bool(authority.get("can_clear_blockers")) is False
+        )
+        if (
+            materialization_status == "materialized_accepted_structured_evidence"
+            and accepted_lineage_count > 0
+            and accepted_oos_count > 0
+            and lineage_accepted
+            and oos_accepted
+            and has_authority
+        ):
+            classification = "accepted_for_campaign_lineage"
+        elif materialization_status == "materialized_no_safe_source":
+            classification = "rejected_materialized_no_safe_source"
+        elif materialization_status == "materialized_rejected_source":
+            classification = "rejected_materialized_rejected_source"
+        elif materialization_status == "materialized_provisional_only":
+            classification = "rejected_materialized_provisional_only"
+        elif materialization_status in {
+            "blocked_invalid_runner_payload",
+            "blocked_invalid_adapter_payload",
+            "blocked_missing_required_fields",
+        }:
+            classification = "rejected_materialized_missing_required_fields"
+        else:
+            classification = "rejected_context_only"
+        return {
+            "path": str(path),
+            "relative_path": relative_path,
+            "classification": classification,
+            "accepted_for_campaign_lineage": classification == "accepted_for_campaign_lineage",
+            "accepted_for_oos_evidence": classification == "accepted_for_campaign_lineage",
+            "accepted_for_screening_evidence": False,
+            "materialization_status": materialization_status,
+        }
     target_symbols = {"aapl", "nvda"}
     has_target_symbol = any(symbol in text for symbol in target_symbols)
     has_target_preset = "trend_pullback_continuation_daily_v1" in text
@@ -75,7 +142,6 @@ def classify_artifact(
     has_reason_record_refs = _mapping_has_key(payload, "reason_record_refs")
     has_policy_version = _mapping_has_key(payload, "policy_version")
     has_operator_approval = _mapping_has_key(payload, "operator_approval_id") or _mapping_has_key(payload, "approval_manifest_ref")
-    report_kind = str(payload.get("report_kind") or "") if isinstance(payload, Mapping) else ""
     if report_kind.startswith("qre_"):
         classification = "rejected_context_only"
     elif relative_path.startswith(".tmp/") or "stdout_tail" in text:

--- a/research/qre_controlled_validation_adapter_result_materialization.py
+++ b/research/qre_controlled_validation_adapter_result_materialization.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, Literal
+
+
+REPORT_KIND: Final[str] = "qre_controlled_validation_adapter_result_materialization"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_controlled_validation_adapter_results")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_controlled_validation_adapter_results/"
+RUNNER_REPORT_KIND: Final[str] = "qre_bounded_current_basket_generation_runner"
+ADAPTER_REPORT_KIND: Final[str] = "qre_controlled_validation_adapter"
+NON_AUTHORITATIVE_FLAG: Final[bool] = True
+EVIDENCE_AUTHORITY: Final[str] = "materializer_context_until_verifier_acceptance"
+
+MaterializationStatus = Literal[
+    "materialized_accepted_structured_evidence",
+    "materialized_provisional_only",
+    "materialized_rejected_source",
+    "materialized_no_safe_source",
+    "blocked_invalid_runner_payload",
+    "blocked_invalid_adapter_payload",
+    "blocked_missing_required_fields",
+]
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> list[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return list(value)
+    return []
+
+
+def _unique_in_order(values: Sequence[Any]) -> list[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _default_input_path(repo_root: Path) -> Path | None:
+    candidates = (
+        repo_root / "logs" / "qre_bounded_current_basket_generation_runner" / "latest.json",
+        repo_root / "logs" / "qre_controlled_validation_adapter" / "latest.json",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _is_runner_payload(payload: Mapping[str, Any]) -> bool:
+    return str(payload.get("report_kind") or "") == RUNNER_REPORT_KIND or "adapter_result" in payload
+
+
+def _is_adapter_payload(payload: Mapping[str, Any]) -> bool:
+    return str(payload.get("report_kind") or "") == ADAPTER_REPORT_KIND or "adapter_status" in payload
+
+
+def _source_refs(source: Mapping[str, Any], adapter_payload: Mapping[str, Any], source_kind: str) -> tuple[str, str]:
+    if source_kind == "runner":
+        return (
+            str(source.get("report_kind") or RUNNER_REPORT_KIND),
+            str(source.get("adapter_result_ref") or adapter_payload.get("report_kind") or ADAPTER_REPORT_KIND),
+        )
+    return ("", str(source.get("report_kind") or ADAPTER_REPORT_KIND))
+
+
+def _materialization_status(
+    *,
+    adapter_status: str,
+    required_fields_missing: bool,
+) -> MaterializationStatus:
+    if required_fields_missing:
+        return "blocked_missing_required_fields"
+    if adapter_status == "accepted_structured_evidence":
+        return "materialized_accepted_structured_evidence"
+    if adapter_status == "no_safe_controlled_validation_source":
+        return "materialized_no_safe_source"
+    if adapter_status.startswith("rejected_") or adapter_status == "blocked_source_not_structured":
+        return "materialized_rejected_source"
+    return "materialized_provisional_only"
+
+
+def _canonical_payload(report: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": report.get("schema_version", SCHEMA_VERSION),
+        "report_kind": report.get("report_kind", REPORT_KIND),
+        "generated_at_utc": report.get("generated_at_utc", ""),
+        "source_runner_ref": report.get("source_runner_ref", ""),
+        "source_adapter_ref": report.get("source_adapter_ref", ""),
+        "request_ref": report.get("request_ref", ""),
+        "adapter_status": report.get("adapter_status", ""),
+        "request_symbols": list(report.get("request_symbols", [])),
+        "preset_id": report.get("preset_id", ""),
+        "timeframe": report.get("timeframe", ""),
+        "lineage_candidates": list(report.get("lineage_candidates", [])),
+        "oos_candidates": list(report.get("oos_candidates", [])),
+        "accepted_lineage_count": int(report.get("accepted_lineage_count", 0) or 0),
+        "accepted_oos_count": int(report.get("accepted_oos_count", 0) or 0),
+        "rejected_reasons": list(report.get("rejected_reasons", [])),
+        "materialization_status": report.get("materialization_status", ""),
+        "authority": dict(report.get("authority", {})),
+    }
+
+
+def compute_materialization_hash(report: Mapping[str, Any]) -> str:
+    payload = _canonical_payload(report)
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _materialize_from_source(source: Mapping[str, Any]) -> dict[str, Any]:
+    source = _mapping(source)
+    request_payload = _mapping(source.get("request"))
+    source_kind = "runner" if _is_runner_payload(source) else "adapter" if _is_adapter_payload(source) else "runner"
+    adapter_payload = _mapping(source.get("adapter_result")) if source_kind == "runner" else source
+    request_ref = str(source.get("request_ref") or adapter_payload.get("request_ref") or request_payload.get("request_id") or "").strip()
+    adapter_status = str(adapter_payload.get("adapter_status") or "").strip()
+    source_runner_ref, source_adapter_ref = _source_refs(source, adapter_payload, source_kind)
+    generated_at_utc = str(
+        source.get("generated_at_utc")
+        or source.get("generated_at")
+        or adapter_payload.get("generated_at_utc")
+        or adapter_payload.get("generated_at")
+        or ""
+    ).strip()
+    lineage_candidates = list(adapter_payload.get("lineage_candidates") or [])
+    oos_candidates = list(adapter_payload.get("oos_candidates") or [])
+    lineage_candidate_refs = _unique_in_order(adapter_payload.get("lineage_candidate_refs") or [])
+    oos_candidate_refs = _unique_in_order(adapter_payload.get("oos_candidate_refs") or [])
+    rejected_reasons = _unique_in_order(adapter_payload.get("rejected_reasons") or [])
+    request_symbols = _unique_in_order(request_payload.get("symbols") or source.get("symbols") or [])
+    preset_id = str(request_payload.get("preset_id") or source.get("preset_id") or adapter_payload.get("preset_id") or "").strip()
+    timeframe = str(request_payload.get("timeframe") or source.get("timeframe") or adapter_payload.get("timeframe") or "").strip()
+
+    source_missing_required_fields = not request_ref or not adapter_status
+    if source_kind == "runner" and not source.get("adapter_result"):
+        status = "blocked_invalid_runner_payload"
+    elif source_kind == "adapter" and source_missing_required_fields:
+        status = "blocked_invalid_adapter_payload"
+    elif not request_ref or not adapter_status:
+        status = "blocked_missing_required_fields"
+    else:
+        accepted_lineage_count = int(adapter_payload.get("accepted_lineage_count", 0) or 0)
+        accepted_oos_count = int(adapter_payload.get("accepted_oos_count", 0) or 0)
+        authority = {
+            "non_authoritative": bool(adapter_payload.get("non_authoritative", NON_AUTHORITATIVE_FLAG)),
+            "evidence_authority": str(adapter_payload.get("evidence_authority") or EVIDENCE_AUTHORITY),
+            "can_clear_blockers": False,
+            "can_authorize_execution": False,
+            "can_promote_candidate": False,
+        }
+        required_fields_missing = False
+        required_fields_missing = required_fields_missing or not lineage_candidate_refs and accepted_lineage_count > 0
+        required_fields_missing = required_fields_missing or not oos_candidate_refs and accepted_oos_count > 0
+        required_fields_missing = required_fields_missing or not rejected_reasons and adapter_status != "accepted_structured_evidence"
+        required_fields_missing = required_fields_missing or not authority["non_authoritative"]
+        required_fields_missing = required_fields_missing or authority["can_clear_blockers"] is not False
+        required_fields_missing = required_fields_missing or authority["can_authorize_execution"] is not False
+        required_fields_missing = required_fields_missing or authority["can_promote_candidate"] is not False
+        status = _materialization_status(
+            adapter_status=adapter_status,
+            required_fields_missing=required_fields_missing,
+        )
+        if status == "materialized_accepted_structured_evidence":
+            if accepted_lineage_count <= 0 or accepted_oos_count <= 0:
+                status = "blocked_missing_required_fields"
+            elif not lineage_candidate_refs or not oos_candidate_refs:
+                status = "blocked_missing_required_fields"
+        if status != "materialized_accepted_structured_evidence":
+            accepted_lineage_count = 0
+            accepted_oos_count = 0
+            lineage_candidates = []
+            oos_candidates = []
+            lineage_candidate_refs = []
+            oos_candidate_refs = []
+        report = {
+            "schema_version": SCHEMA_VERSION,
+            "report_kind": REPORT_KIND,
+            "generated_at_utc": generated_at_utc,
+            "source_runner_ref": source_runner_ref,
+            "source_adapter_ref": source_adapter_ref,
+            "request_ref": request_ref,
+            "adapter_status": adapter_status,
+            "request_symbols": request_symbols,
+            "preset_id": preset_id,
+            "timeframe": timeframe,
+            "lineage_candidates": lineage_candidates,
+            "oos_candidates": oos_candidates,
+            "accepted_lineage_count": accepted_lineage_count,
+            "accepted_oos_count": accepted_oos_count,
+            "rejected_reasons": rejected_reasons,
+            "materialization_status": status,
+            "authority": {
+                "non_authoritative": True,
+                "evidence_authority": EVIDENCE_AUTHORITY,
+                "can_clear_blockers": False,
+                "can_authorize_execution": False,
+                "can_promote_candidate": False,
+            },
+        }
+        report["hash"] = compute_materialization_hash(report)
+        return report
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "source_runner_ref": source_runner_ref,
+        "source_adapter_ref": source_adapter_ref,
+        "request_ref": request_ref,
+        "adapter_status": adapter_status,
+        "request_symbols": request_symbols,
+        "preset_id": preset_id,
+        "timeframe": timeframe,
+        "lineage_candidates": [],
+        "oos_candidates": [],
+        "accepted_lineage_count": 0,
+        "accepted_oos_count": 0,
+        "rejected_reasons": rejected_reasons or [status],
+        "materialization_status": status,
+        "authority": {
+            "non_authoritative": True,
+            "evidence_authority": EVIDENCE_AUTHORITY,
+            "can_clear_blockers": False,
+            "can_authorize_execution": False,
+            "can_promote_candidate": False,
+        },
+    }
+    report["hash"] = compute_materialization_hash(report)
+    return report
+
+
+def build_controlled_validation_adapter_result_materialization(
+    source: Mapping[str, Any] | None = None,
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    if source is None:
+        path = _default_input_path(repo_root)
+        source = _read_json(path) if path is not None else {}
+    return _materialize_from_source(source or {})
+
+
+def validate_materialization_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    rejection_reasons: list[str] = []
+    canonical = _canonical_payload(result)
+    if canonical["authority"].get("non_authoritative") is not True:
+        rejection_reasons.append("non_authoritative_must_be_true")
+    if canonical["authority"].get("can_clear_blockers") is not False:
+        rejection_reasons.append("can_clear_blockers_must_be_false")
+    if canonical["authority"].get("can_authorize_execution") is not False:
+        rejection_reasons.append("can_authorize_execution_must_be_false")
+    if canonical["authority"].get("can_promote_candidate") is not False:
+        rejection_reasons.append("can_promote_candidate_must_be_false")
+    if canonical["materialization_status"] == "materialized_accepted_structured_evidence":
+        if canonical["accepted_lineage_count"] <= 0 or canonical["accepted_oos_count"] <= 0:
+            rejection_reasons.append("accepted_materialization_requires_lineage_and_oos_counts")
+        if not canonical["lineage_candidates"] or not canonical["oos_candidates"]:
+            rejection_reasons.append("accepted_materialization_requires_candidate_records")
+    computed_hash = compute_materialization_hash(result)
+    if str(result.get("hash") or "") and str(result.get("hash")) != computed_hash:
+        rejection_reasons.append("hash_mismatch")
+    return {
+        "valid": not rejection_reasons,
+        "rejection_reasons": list(_unique_in_order(rejection_reasons)),
+        "hash": computed_hash,
+        "schema_version": SCHEMA_VERSION,
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    authority = report.get("authority") if isinstance(report.get("authority"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE Controlled Validation Adapter Result Materialization",
+            "",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["request_ref", str(report.get("request_ref") or "")],
+                    ["adapter_status", str(report.get("adapter_status") or "")],
+                    ["materialization_status", str(report.get("materialization_status") or "")],
+                    ["accepted_lineage_count", str(int(report.get("accepted_lineage_count") or 0))],
+                    ["accepted_oos_count", str(int(report.get("accepted_oos_count") or 0))],
+                    ["non_authoritative", str(bool(authority.get("non_authoritative"))).lower()],
+                    ["can_clear_blockers", str(bool(authority.get("can_clear_blockers"))).lower()],
+                ],
+            ),
+            "",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["source_runner_ref", str(report.get("source_runner_ref") or "")],
+                    ["source_adapter_ref", str(report.get("source_adapter_ref") or "")],
+                    ["preset_id", str(report.get("preset_id") or "")],
+                    ["timeframe", str(report.get("timeframe") or "")],
+                    ["generated_at_utc", str(report.get("generated_at_utc") or "")],
+                ],
+            ),
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_controlled_validation_adapter_result_materialization: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_controlled_validation_adapter_result_materialization",
+        description="Build the controlled validation adapter result materialization report.",
+    )
+    parser.add_argument("--input-file")
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    input_payload = _read_json(Path(args.input_file)) if args.input_file else None
+    report = build_controlled_validation_adapter_result_materialization(input_payload, repo_root=Path("."))
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_bounded_current_basket_generation_runner.py
+++ b/tests/unit/test_qre_bounded_current_basket_generation_runner.py
@@ -71,6 +71,7 @@ def test_runner_is_deterministic_and_fail_closed() -> None:
     assert first["accepted_lineage_count"] == 0
     assert first["accepted_oos_count"] == 0
     assert first["can_clear_blockers"] is False
+    assert first["controlled_validation_adapter_result_materialization_status"] == "materialized_no_safe_source"
     assert first["hash"] == runner.compute_runner_hash(first)
 
 
@@ -116,6 +117,7 @@ def test_runner_write_outputs_are_allowlisted(tmp_path: Path) -> None:
 
     assert paths["latest"] == "logs/qre_bounded_current_basket_generation_runner/latest.json"
     assert paths["operator_summary"] == "logs/qre_bounded_current_basket_generation_runner/operator_summary.md"
+    assert paths["controlled_validation_adapter_result_materialization"] == "logs/qre_controlled_validation_adapter_results/latest.json"
     payload = json.loads(
         (tmp_path / "logs" / "qre_bounded_current_basket_generation_runner" / "latest.json").read_text(encoding="utf-8")
     )
@@ -195,6 +197,7 @@ def test_runner_surfaces_adapter_accepted_counts_when_structured_source_is_accep
 
     assert report["runner_status"] == "adapter_accepted_structured_evidence"
     assert report["adapter_result"]["adapter_status"] == "accepted_structured_evidence"
+    assert report["controlled_validation_adapter_result_materialization"]["materialization_status"] == "materialized_accepted_structured_evidence"
     assert report["accepted_lineage_count"] == 1
     assert report["accepted_oos_count"] == 1
     assert report["lineage_candidate_refs"] == [

--- a/tests/unit/test_qre_controlled_validation_adapter_result_materialization.py
+++ b/tests/unit/test_qre_controlled_validation_adapter_result_materialization.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_controlled_validation_adapter as adapter
+from research import qre_controlled_validation_adapter_result_materialization as materializer
+from research import qre_bounded_generation_artifact_acceptance_verifier as verifier
+from research import qre_evidence_complete_basket_closure as closure
+
+
+def _request_payload() -> dict[str, object]:
+    return {
+        "request_id": "req-materialize-001",
+        "symbols": ["AAPL", "NVDA"],
+        "preset_id": "trend_pullback_continuation_daily_v1",
+        "timeframe": "daily_v1",
+        "approval_ref": "approval-001",
+        "required_artifact_types": [
+            "generation_manifest",
+            "structured_lineage_artifact",
+            "structured_oos_artifact",
+        ],
+        "allowed_output_paths": ["logs/qre_controlled_validation_adapter_results/"],
+        "forbidden_capabilities": [],
+        "created_at_utc": "2026-06-17T16:10:00Z",
+        "source": "operator_approval_manifest",
+    }
+
+
+def _structured_source(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "source_type": "structured_controlled_validation",
+        "source_authority": "structured_source",
+        "source_ref": "artifacts/qre_controlled_validation/source-001.json",
+        "lineage_records": [
+            {
+                "candidate_id": "cand-001",
+                "campaign_id": "camp-001",
+                "generation_run_id": "gen-001",
+                "reason_record_refs": ["rr-lineage-001"],
+            }
+        ],
+        "oos_records": [
+            {
+                "candidate_id": "cand-001",
+                "oos_window": {"start": "2025-01-01", "end": "2025-06-30"},
+                "oos_metric_fields": {"oos_trade_count": 24, "oos_return_pct": 3.1},
+                "cost_slippage_assumption_refs": ["cost-model-001"],
+                "reason_record_refs": ["rr-oos-001"],
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_materializer_rejects_invalid_runner_payload() -> None:
+    report = materializer.build_controlled_validation_adapter_result_materialization(
+        {"report_kind": "qre_bounded_current_basket_generation_runner"}
+    )
+
+    assert report["materialization_status"] == "blocked_invalid_runner_payload"
+    assert report["authority"]["non_authoritative"] is True
+    assert report["authority"]["can_clear_blockers"] is False
+
+
+def test_materializer_rejects_invalid_adapter_payload() -> None:
+    report = materializer.build_controlled_validation_adapter_result_materialization(
+        {"report_kind": adapter.REPORT_KIND, "adapter_status": "accepted_structured_evidence"}
+    )
+
+    assert report["materialization_status"] == "blocked_invalid_adapter_payload"
+
+
+def test_no_safe_source_materializes_but_remains_non_authoritative() -> None:
+    adapter_result = adapter.build_controlled_validation_adapter_result(
+        _request_payload(),
+        controlled_validation_source=None,
+    )
+    report = materializer.build_controlled_validation_adapter_result_materialization(adapter_result)
+
+    assert report["materialization_status"] == "materialized_no_safe_source"
+    assert report["authority"]["non_authoritative"] is True
+    assert report["authority"]["can_clear_blockers"] is False
+
+
+def test_provisional_adapter_state_materializes_but_cannot_clear_blockers() -> None:
+    adapter_result = adapter.build_controlled_validation_adapter_result(
+        _request_payload(),
+        controlled_validation_source=_structured_source(
+            lineage_records=[{"candidate_id": "", "campaign_id": "", "generation_run_id": ""}]
+        ),
+    )
+    report = materializer.build_controlled_validation_adapter_result_materialization(adapter_result)
+
+    assert report["materialization_status"] == "materialized_provisional_only"
+    assert report["accepted_lineage_count"] == 0
+    assert report["authority"]["can_clear_blockers"] is False
+
+
+def test_rejected_source_materializes_with_reason_codes() -> None:
+    adapter_result = adapter.build_controlled_validation_adapter_result(
+        _request_payload(),
+        controlled_validation_source={"source_type": "context_only", "source_ref": "report"},
+    )
+    report = materializer.build_controlled_validation_adapter_result_materialization(adapter_result)
+
+    assert report["materialization_status"] == "materialized_rejected_source"
+    assert report["rejected_reasons"] == ["context_only_source_rejected"]
+
+
+def test_accepted_structured_evidence_materializes_only_when_required_fields_exist() -> None:
+    adapter_result = adapter.build_controlled_validation_adapter_result(
+        _request_payload(),
+        controlled_validation_source=_structured_source(),
+    )
+    report = materializer.build_controlled_validation_adapter_result_materialization(adapter_result)
+
+    assert report["materialization_status"] == "materialized_accepted_structured_evidence"
+    assert report["accepted_lineage_count"] == 1
+    assert report["accepted_oos_count"] == 1
+    assert report["lineage_candidates"]
+    assert report["oos_candidates"]
+    assert report["authority"]["non_authoritative"] is True
+    assert report["authority"]["can_authorize_execution"] is False
+    assert report["authority"]["can_promote_candidate"] is False
+
+
+def test_materialized_hash_is_deterministic() -> None:
+    adapter_result = adapter.build_controlled_validation_adapter_result(
+        _request_payload(),
+        controlled_validation_source=_structured_source(),
+    )
+    first = materializer.build_controlled_validation_adapter_result_materialization(adapter_result)
+    second = materializer.build_controlled_validation_adapter_result_materialization(adapter_result)
+
+    assert first == second
+    assert first["hash"] == materializer.compute_materialization_hash(first)
+
+
+def test_materializer_does_not_invent_candidate_ids() -> None:
+    report = materializer.build_controlled_validation_adapter_result_materialization(
+        adapter.build_controlled_validation_adapter_result(
+            _request_payload(),
+            controlled_validation_source=_structured_source(),
+        )
+    )
+
+    assert report["lineage_candidates"][0]["candidate_id"] == "cand-001"
+    assert report["oos_candidates"][0]["candidate_id"] == "cand-001"
+
+
+def test_core_materializer_logic_has_no_aapl_or_nvda_hardcoding() -> None:
+    source = Path("research/qre_controlled_validation_adapter_result_materialization.py").read_text(
+        encoding="utf-8"
+    )
+    assert "AAPL" not in source
+    assert "NVDA" not in source
+
+
+def test_verifier_can_read_materialized_records(tmp_path: Path) -> None:
+    report = materializer.build_controlled_validation_adapter_result_materialization(
+        adapter.build_controlled_validation_adapter_result(
+            _request_payload(),
+            controlled_validation_source=_structured_source(),
+        )
+    )
+    _write_json(tmp_path / "logs" / "qre_controlled_validation_adapter_results" / "latest.json", report)
+
+    verifier_report = verifier.build_bounded_generation_artifact_acceptance_verifier(repo_root=tmp_path)
+    rows = {row["relative_path"]: row for row in verifier_report["rows"]}
+
+    assert rows["logs/qre_controlled_validation_adapter_results/latest.json"]["classification"] == "accepted_for_campaign_lineage"
+    assert rows["logs/qre_controlled_validation_adapter_results/latest.json"]["accepted_for_oos_evidence"] is True
+
+
+def test_verifier_does_not_accept_provisional_or_no_safe_materialized_records(tmp_path: Path) -> None:
+    provisional = materializer.build_controlled_validation_adapter_result_materialization(
+        adapter.build_controlled_validation_adapter_result(
+            _request_payload(),
+            controlled_validation_source=_structured_source(
+                lineage_records=[{"candidate_id": "", "campaign_id": "", "generation_run_id": ""}]
+            ),
+        )
+    )
+    no_safe = materializer.build_controlled_validation_adapter_result_materialization(
+        adapter.build_controlled_validation_adapter_result(_request_payload())
+    )
+    _write_json(tmp_path / "logs" / "qre_controlled_validation_adapter_results" / "provisional.json", provisional)
+    _write_json(tmp_path / "logs" / "qre_controlled_validation_adapter_results" / "no_safe.json", no_safe)
+
+    verifier_report = verifier.build_bounded_generation_artifact_acceptance_verifier(repo_root=tmp_path)
+    rows = {row["relative_path"]: row for row in verifier_report["rows"]}
+
+    assert rows["logs/qre_controlled_validation_adapter_results/provisional.json"]["classification"] == "rejected_materialized_provisional_only"
+    assert rows["logs/qre_controlled_validation_adapter_results/no_safe.json"]["classification"] == "rejected_materialized_no_safe_source"
+
+
+def test_closure_remains_zero_when_only_provisional_or_no_safe_materialized_records_exist(tmp_path: Path, monkeypatch) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_controlled_validation_adapter_results" / "latest.json",
+        materializer.build_controlled_validation_adapter_result_materialization(
+            adapter.build_controlled_validation_adapter_result(
+                _request_payload(),
+                controlled_validation_source=None,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        closure,
+        "_guarded_alias_bounded_generation_snapshot",
+        lambda *_: {"overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"},
+    )
+    report = closure.build_evidence_complete_basket_closure(repo_root=tmp_path)
+
+    assert report["summary"]["evidence_complete_count"] == 0


### PR DESCRIPTION
## Phase
Track 2 / E1 Evidence Production

## Scope
- Persist controlled-validation adapter results as deterministic sidecar artifacts.
- Keep runner -> adapter -> materialization -> verifier readable, but fail closed.
- Preserve provisional/rejected/no-safe-source states without clearing blockers.

## Safety
- no fake evidence
- no invented candidate/campaign/generation IDs
- no context-only proof
- no stdout-only proof
- no legacy alias-only proof
- no generated report treated as source evidence
- no materialization-only proof
- no strategy synthesis
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution
- no external fetch
- no AAPL/NVDA hardcoding in core paths
- frozen contracts unchanged
- protected paths untouched

## Tests run
- `python -m pytest tests/unit/test_qre_controlled_validation_adapter_result_materialization.py -q`
- `python -m pytest tests/unit/test_qre_bounded_current_basket_generation_runner.py tests/unit/test_qre_controlled_validation_adapter.py -q`
- `python -m pytest tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py tests/unit/test_qre_controlled_validation_adapter_result_materialization.py -q`
- `python -m pytest tests/unit/test_qre_bounded_current_basket_generation_runner.py tests/unit/test_qre_controlled_validation_adapter_result_materialization.py tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py tests/unit/test_qre_evidence_complete_basket_closure.py -q`
- `python -m pytest tests/unit/test_qre_structured_lineage_artifacts.py tests/unit/test_qre_structured_oos_artifacts.py -q`
- `python -m pytest tests/smoke -q`
- `python scripts/governance_lint.py`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`
- `git diff --name-only -- live paper shadow broker risk execution`

## Evidence impact
- accepted structured lineage artifacts: 0 -> 0
- accepted structured OOS artifacts: 0 -> 0
- evidence_complete_count: 0 -> 0
- blockers cleared: none

## Next recommended PR
`feat: accept structured lineage/OOS evidence from controlled validation adapter`