### PR TITLE
feat: connect accepted adapter artifacts to closure reason records

### DIFF
--- a/research/qre_bounded_generation_artifact_acceptance_verifier.py
+++ b/research/qre_bounded_generation_artifact_acceptance_verifier.py
@@ -156,6 +156,37 @@ def _validate_oos_candidate(
     return reasons
 
 
+def _accepted_lineage_record(candidate: Mapping[str, Any], *, request_ref: str, verifier_ref: str) -> dict[str, Any]:
+    return {
+        "request_ref": request_ref,
+        "candidate_id": _text(candidate.get("candidate_id")),
+        "campaign_id": _text(candidate.get("campaign_id")),
+        "generation_id": _text(candidate.get("generation_id")),
+        "controlled_generation_id": _text(candidate.get("controlled_generation_id")),
+        "grid_run_id": _text(candidate.get("grid_run_id")),
+        "preset_id": _text(candidate.get("preset_id")),
+        "timeframe": _text(candidate.get("timeframe")),
+        "source_ref": _text(candidate.get("source_ref")),
+        "reason_record_refs": _text_list(candidate.get("reason_record_refs")),
+        "verifier_ref": verifier_ref,
+    }
+
+
+def _accepted_oos_record(candidate: Mapping[str, Any], *, request_ref: str, verifier_ref: str) -> dict[str, Any]:
+    return {
+        "request_ref": request_ref,
+        "candidate_id": _text(candidate.get("candidate_id")),
+        "preset_id": _text(candidate.get("preset_id")),
+        "timeframe": _text(candidate.get("timeframe")),
+        "source_ref": _text(candidate.get("source_ref")),
+        "oos_window": dict(candidate.get("oos_window")) if isinstance(candidate.get("oos_window"), Mapping) else {},
+        "oos_metric_fields": dict(candidate.get("oos_metric_fields")) if isinstance(candidate.get("oos_metric_fields"), Mapping) else {},
+        "cost_slippage_assumption_refs": _text_list(candidate.get("cost_slippage_assumption_refs")),
+        "reason_record_refs": _text_list(candidate.get("reason_record_refs")),
+        "verifier_ref": verifier_ref,
+    }
+
+
 def _classify_materialized_record(
     payload: Mapping[str, Any],
     *,
@@ -170,6 +201,8 @@ def _classify_materialized_record(
     authority_reasons = _validate_materialized_authority(authority)
     lineage_reasons: list[str] = []
     oos_reasons: list[str] = []
+    accepted_lineage_records: list[dict[str, Any]] = []
+    accepted_oos_records: list[dict[str, Any]] = []
 
     accepted_lineage_count = 0
     accepted_oos_count = 0
@@ -184,6 +217,13 @@ def _classify_materialized_record(
                 lineage_reasons.extend(candidate_reasons)
                 if not candidate_reasons:
                     accepted_lineage_count += 1
+                    accepted_lineage_records.append(
+                        _accepted_lineage_record(
+                            candidate,
+                            request_ref=request_ref,
+                            verifier_ref=f"{relative_path}#lineage:{_text(candidate.get('candidate_id'))}",
+                        )
+                    )
         for candidate in oos_candidates:
             if isinstance(candidate, Mapping):
                 candidate_reasons = _validate_oos_candidate(
@@ -194,6 +234,13 @@ def _classify_materialized_record(
                 oos_reasons.extend(candidate_reasons)
                 if not candidate_reasons:
                     accepted_oos_count += 1
+                    accepted_oos_records.append(
+                        _accepted_oos_record(
+                            candidate,
+                            request_ref=request_ref,
+                            verifier_ref=f"{relative_path}#oos:{_text(candidate.get('candidate_id'))}",
+                        )
+                    )
 
     payload_lineage_count = int(payload.get("accepted_lineage_count") or 0)
     payload_oos_count = int(payload.get("accepted_oos_count") or 0)
@@ -250,6 +297,8 @@ def _classify_materialized_record(
         "accepted_for_oos_evidence": oos_accepted,
         "accepted_lineage_count": accepted_lineage_count,
         "accepted_oos_count": accepted_oos_count,
+        "accepted_lineage_records": accepted_lineage_records,
+        "accepted_oos_records": accepted_oos_records,
         "accepted_for_screening_evidence": False,
         "materialization_status": materialization_status,
         "lineage_rejection_reasons": lineage_reasons,

--- a/research/qre_evidence_complete_basket_closure.py
+++ b/research/qre_evidence_complete_basket_closure.py
@@ -39,6 +39,14 @@ KNOWN_OOS_GAP_BLOCKERS: Final[frozenset[str]] = frozenset(
         "insufficient_oos_evidence",
     }
 )
+ACCEPTED_OOS_BLOCKERS: Final[frozenset[str]] = frozenset(
+    {
+        "no_oos_evidence",
+        "oos_evidence_missing",
+        "oos_evidence_unknown",
+        "insufficient_oos_evidence",
+    }
+)
 
 
 def _index_by_candidate(rows: Sequence[Mapping[str, Any]], *, key: str = "candidate_id") -> dict[str, dict[str, Any]]:
@@ -97,6 +105,24 @@ def _guarded_alias_bounded_generation_snapshot(repo_root: Path) -> dict[str, Any
     return {"overall_result": "guarded_alias_bounded_generation_cascade_unavailable"}
 
 
+def _verifier_snapshot(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(
+        repo_root / "logs" / "qre_bounded_generation_artifact_acceptance_verifier" / "latest.json"
+    )
+    if isinstance(payload, dict) and str(payload.get("report_kind") or "") == "qre_bounded_generation_artifact_acceptance_verifier":
+        return payload
+    return {
+        "report_kind": "qre_bounded_generation_artifact_acceptance_verifier_unavailable",
+        "summary": {
+            "accepted_lineage_artifact_count": 0,
+            "accepted_oos_artifact_count": 0,
+            "accepted_lineage_candidate_count": 0,
+            "accepted_oos_candidate_count": 0,
+        },
+        "rows": [],
+    }
+
+
 def _structured_artifact_snapshot(repo_root: Path, kind: str) -> dict[str, Any]:
     if kind == "lineage":
         payload = _read_json(repo_root / "logs" / "qre_structured_lineage_artifacts" / "latest.json")
@@ -115,6 +141,112 @@ def _structured_artifact_snapshot(repo_root: Path, kind: str) -> dict[str, Any]:
             "accepted_count": 0,
         },
     }
+
+
+def _accepted_records(
+    verifier_report: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    rows = verifier_report.get("rows")
+    if not isinstance(rows, list):
+        return [], []
+    lineage_records: list[dict[str, Any]] = []
+    oos_records: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        if bool(row.get("accepted_for_campaign_lineage")):
+            lineage_records.extend(
+                dict(record)
+                for record in row.get("accepted_lineage_records") or []
+                if isinstance(record, Mapping)
+            )
+        if bool(row.get("accepted_for_oos_evidence")):
+            oos_records.extend(
+                dict(record)
+                for record in row.get("accepted_oos_records") or []
+                if isinstance(record, Mapping)
+            )
+    return lineage_records, oos_records
+
+
+def _timeframe_matches(record_timeframe: str, row_timeframes: Sequence[Any]) -> bool:
+    return not row_timeframes or record_timeframe in {str(value or "") for value in row_timeframes}
+
+
+def _find_lineage_acceptance(
+    row: Mapping[str, Any],
+    lineage_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    candidate_id = str(row.get("candidate_id") or "")
+    preset_id = str(row.get("preset_id") or "")
+    timeframes = row.get("timeframes")
+    if not isinstance(timeframes, Sequence) or isinstance(timeframes, (str, bytes)):
+        timeframes = []
+    for record in lineage_records:
+        if str(record.get("candidate_id") or "") != candidate_id:
+            continue
+        if str(record.get("preset_id") or "") != preset_id:
+            continue
+        if not _timeframe_matches(str(record.get("timeframe") or ""), timeframes):
+            continue
+        return dict(record)
+    return None
+
+
+def _find_oos_acceptance(
+    row: Mapping[str, Any],
+    oos_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    candidate_id = str(row.get("candidate_id") or "")
+    preset_id = str(row.get("preset_id") or "")
+    timeframes = row.get("timeframes")
+    if not isinstance(timeframes, Sequence) or isinstance(timeframes, (str, bytes)):
+        timeframes = []
+    for record in oos_records:
+        if str(record.get("candidate_id") or "") != candidate_id:
+            continue
+        if str(record.get("preset_id") or "") != preset_id:
+            continue
+        if not _timeframe_matches(str(record.get("timeframe") or ""), timeframes):
+            continue
+        return dict(record)
+    return None
+
+
+def _clearance_reason_record(
+    *,
+    blocker_code: str,
+    accepted_record: Mapping[str, Any],
+    candidate_id: str,
+) -> dict[str, Any]:
+    return {
+        "record_family": "accepted_structured_evidence_clearance",
+        "subject_id": candidate_id,
+        "blocker_code": blocker_code,
+        "reason_codes": [f"{blocker_code}_cleared_by_accepted_structured_evidence"],
+        "evidence_refs": [
+            str(accepted_record.get("verifier_ref") or ""),
+            str(accepted_record.get("source_ref") or ""),
+        ],
+        "request_ref": str(accepted_record.get("request_ref") or ""),
+        "preset_id": str(accepted_record.get("preset_id") or ""),
+        "timeframe": str(accepted_record.get("timeframe") or ""),
+    }
+
+
+def _recomputed_completeness(flags: Mapping[str, Any]) -> tuple[int, str]:
+    score = round(
+        100
+        * sum(bool(flags.get(flag_key)) for _, flag_key in CHECKLIST_ORDER)
+        / len(CHECKLIST_ORDER)
+    )
+    if score >= 85:
+        return score, "complete"
+    if score >= 55:
+        return score, "partial"
+    if score > 0:
+        return score, "thin"
+    return score, "missing"
 
 
 def _row_closure(row: Mapping[str, Any]) -> dict[str, Any]:
@@ -181,6 +313,7 @@ def _row_closure(row: Mapping[str, Any]) -> dict[str, Any]:
         "reason_record_ids": reason_record_ids,
         "reason_record_families": list(reason_record_refs.get("record_families") or []),
         "reason_record_evidence_refs": list(reason_record_refs.get("evidence_refs") or []),
+        "clearance_reason_records": list(row.get("clearance_reason_records") or []),
         "failure_action": dict(failure_action),
         "follow_up": row.get("follow_up"),
         "exact_next_action": exact_next_action,
@@ -217,6 +350,8 @@ def build_evidence_complete_basket_closure(
     reason_index = _index_reason_records([row for row in reason_rows if isinstance(row, Mapping)])
     failure_index = _index_by_candidate([row for row in failure_rows if isinstance(row, Mapping)])
     guarded_report = _guarded_alias_bounded_generation_snapshot(repo_root)
+    verifier_report = _verifier_snapshot(repo_root)
+    accepted_lineage_records, accepted_oos_records = _accepted_records(verifier_report)
     structured_lineage_report = _structured_artifact_snapshot(repo_root, "lineage")
     structured_oos_report = _structured_artifact_snapshot(repo_root, "oos")
     structured_lineage_summary = (
@@ -233,6 +368,42 @@ def build_evidence_complete_basket_closure(
         enriched_row = dict(row)
         enriched_row["reason_record_refs"] = dict(reason_index.get(subject_id) or {})
         enriched_row["failure_action"] = dict(failure_index.get(subject_id) or {})
+        flags = (
+            dict(enriched_row.get("evidence_presence"))
+            if isinstance(enriched_row.get("evidence_presence"), Mapping)
+            else {}
+        )
+        missing = list(enriched_row.get("missing_evidence_taxonomy") or [])
+        clearance_reason_records: list[dict[str, Any]] = []
+        lineage_acceptance = _find_lineage_acceptance(enriched_row, accepted_lineage_records)
+        oos_acceptance = _find_oos_acceptance(enriched_row, accepted_oos_records)
+        if lineage_acceptance is not None:
+            flags["candidate_lineage_present"] = True
+            flags["campaign_lineage_present"] = True
+            missing = [item for item in missing if item != "campaign_lineage_missing"]
+            clearance_reason_records.append(
+                _clearance_reason_record(
+                    blocker_code="campaign_lineage_missing",
+                    accepted_record=lineage_acceptance,
+                    candidate_id=subject_id,
+                )
+            )
+        if oos_acceptance is not None:
+            flags["oos_evidence_known"] = True
+            missing = [item for item in missing if item not in ACCEPTED_OOS_BLOCKERS]
+            clearance_reason_records.append(
+                _clearance_reason_record(
+                    blocker_code="no_oos_evidence",
+                    accepted_record=oos_acceptance,
+                    candidate_id=subject_id,
+                )
+            )
+        score, completeness_status = _recomputed_completeness(flags)
+        enriched_row["evidence_presence"] = flags
+        enriched_row["missing_evidence_taxonomy"] = missing
+        enriched_row["evidence_completeness_score_pct"] = score
+        enriched_row["evidence_completeness_status"] = completeness_status
+        enriched_row["clearance_reason_records"] = clearance_reason_records
         closure_rows.append(_row_closure(enriched_row))
     closure_rows.sort(
         key=lambda row: (
@@ -290,10 +461,16 @@ def build_evidence_complete_basket_closure(
             "structured_lineage_artifact_count": int(structured_lineage_summary.get("artifact_count") or 0),
             "structured_lineage_artifact_provisional_count": int(structured_lineage_summary.get("provisional_count") or 0),
             "structured_lineage_artifact_accepted_count": int(structured_lineage_summary.get("accepted_count") or 0),
+            "verifier_accepted_lineage_count": int(
+                (verifier_report.get("summary") or {}).get("accepted_lineage_candidate_count") or 0
+            ),
             "structured_oos_artifact_status": str(structured_oos_summary.get("final_recommendation") or ""),
             "structured_oos_artifact_count": int(structured_oos_summary.get("artifact_count") or 0),
             "structured_oos_artifact_provisional_count": int(structured_oos_summary.get("provisional_count") or 0),
             "structured_oos_artifact_accepted_count": int(structured_oos_summary.get("accepted_count") or 0),
+            "verifier_accepted_oos_count": int(
+                (verifier_report.get("summary") or {}).get("accepted_oos_candidate_count") or 0
+            ),
             "final_recommendation": (
                 "evidence_complete_reason_records_ready"
                 if complete_count > 0

--- a/tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py
+++ b/tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py
@@ -98,6 +98,7 @@ def test_accepts_valid_structured_lineage_artifact_from_materialized_adapter_rec
     assert row["classification"] == "accepted_for_campaign_lineage"
     assert row["accepted_for_campaign_lineage"] is True
     assert row["accepted_lineage_count"] == 1
+    assert row["accepted_lineage_records"][0]["candidate_id"] == "cand-001"
     assert report["summary"]["accepted_lineage_candidate_count"] == 1
 
 
@@ -112,6 +113,7 @@ def test_accepts_valid_structured_oos_artifact_from_materialized_adapter_record(
 
     assert row["accepted_for_oos_evidence"] is True
     assert row["accepted_oos_count"] == 1
+    assert row["accepted_oos_records"][0]["cost_slippage_assumption_refs"] == ["cost-model-001"]
     assert report["summary"]["accepted_oos_candidate_count"] == 1
 
 

--- a/tests/unit/test_qre_evidence_complete_basket_closure.py
+++ b/tests/unit/test_qre_evidence_complete_basket_closure.py
@@ -11,6 +11,53 @@ def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
+def _accepted_verifier_report(*, candidate_id: str = "c1", preset_id: str = "trend_pullback_continuation_daily_v1", timeframe: str = "1d") -> dict:
+    return {
+        "report_kind": "qre_bounded_generation_artifact_acceptance_verifier",
+        "summary": {
+            "accepted_lineage_candidate_count": 1,
+            "accepted_oos_candidate_count": 1,
+        },
+        "rows": [
+            {
+                "relative_path": "logs/qre_controlled_validation_adapter_results/latest.json",
+                "classification": "accepted_for_campaign_lineage",
+                "accepted_for_campaign_lineage": True,
+                "accepted_for_oos_evidence": True,
+                "accepted_lineage_count": 1,
+                "accepted_oos_count": 1,
+                "accepted_lineage_records": [
+                    {
+                        "request_ref": "req-001",
+                        "candidate_id": candidate_id,
+                        "campaign_id": "camp-001",
+                        "generation_id": "gen-001",
+                        "preset_id": preset_id,
+                        "timeframe": timeframe,
+                        "source_ref": "artifacts/qre_controlled_validation/source-001.json",
+                        "reason_record_refs": ["rr-lineage-001"],
+                        "verifier_ref": "logs/qre_bounded_generation_artifact_acceptance_verifier/latest.json#lineage",
+                    }
+                ],
+                "accepted_oos_records": [
+                    {
+                        "request_ref": "req-001",
+                        "candidate_id": candidate_id,
+                        "preset_id": preset_id,
+                        "timeframe": timeframe,
+                        "source_ref": "artifacts/qre_controlled_validation/source-001.json",
+                        "oos_window": {"start": "2025-01-01", "end": "2025-06-30"},
+                        "oos_metric_fields": {"oos_trade_count": 12, "oos_return_pct": 2.1},
+                        "cost_slippage_assumption_refs": ["cost-001"],
+                        "reason_record_refs": ["rr-oos-001"],
+                        "verifier_ref": "logs/qre_bounded_generation_artifact_acceptance_verifier/latest.json#oos",
+                    }
+                ],
+            }
+        ],
+    }
+
+
 def _seed_complete_repo(tmp_path: Path) -> None:
     _write_json(
         tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
@@ -356,3 +403,296 @@ def test_closure_writes_outputs(tmp_path: Path, monkeypatch) -> None:
     markdown = (tmp_path / paths["operator_summary"]).read_text(encoding="utf-8")
     assert paths["latest"] == "logs/qre_evidence_complete_basket_closure/latest.json"
     assert "# QRE Evidence Complete Basket Closure" in markdown
+
+
+def test_accepted_lineage_only_clears_lineage_blocker_but_not_oos(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        closure,
+        "_guarded_alias_bounded_generation_snapshot",
+        lambda *_: {"overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"},
+    )
+    monkeypatch.setattr(
+        closure.evidence_coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "c1",
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "timeframes": ["1d"],
+                    "diagnosis_class": "diagnosable",
+                    "evidence_completeness_score_pct": 57,
+                    "evidence_completeness_status": "partial",
+                    "missing_evidence_taxonomy": ["campaign_lineage_missing", "no_oos_evidence"],
+                    "follow_up": "collect_more_evidence",
+                    "evidence_presence": {
+                        "source_identity_ready": True,
+                        "source_quality_ready": True,
+                        "cache_ready": True,
+                        "screening_evidence_present": True,
+                        "oos_evidence_known": False,
+                        "campaign_lineage_present": False,
+                        "candidate_lineage_present": True,
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        closure.reason_records,
+        "build_reason_records_snapshot",
+        lambda **_: {"records": [{"subject_id": "c1", "record_ids": ["qrr-1"], "record_families": ["basket_diagnosis"], "reason_codes": ["campaign_lineage_missing"], "evidence_refs": ["research/production_discovery_catalog.py"]}]},
+    )
+    monkeypatch.setattr(
+        closure.failure_action,
+        "build_failure_action_from_basket",
+        lambda **_: {"rows": [{"candidate_id": "c1", "recommended_action": "collect_oos_evidence", "actionability": {"is_actionable": True, "status": "actionable"}}]},
+    )
+    verifier_report = _accepted_verifier_report()
+    verifier_report["rows"][0]["accepted_for_oos_evidence"] = False
+    verifier_report["rows"][0]["accepted_oos_count"] = 0
+    verifier_report["rows"][0]["accepted_oos_records"] = []
+    verifier_report["summary"]["accepted_oos_candidate_count"] = 0
+    _write_json(tmp_path / "logs" / "qre_bounded_generation_artifact_acceptance_verifier" / "latest.json", verifier_report)
+
+    report = closure.build_evidence_complete_basket_closure(repo_root=tmp_path)
+    row = report["rows"][0]
+
+    assert "campaign_lineage_missing" not in row["exact_blockers"]
+    assert "no_oos_evidence" in row["exact_blockers"]
+    assert row["closure_status"] == "blocked_not_evidence_complete"
+    assert any(item["blocker_code"] == "campaign_lineage_missing" for item in row["clearance_reason_records"])
+
+
+def test_accepted_oos_only_clears_oos_blocker_but_not_lineage(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        closure,
+        "_guarded_alias_bounded_generation_snapshot",
+        lambda *_: {"overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"},
+    )
+    monkeypatch.setattr(
+        closure.evidence_coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "c1",
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "timeframes": ["1d"],
+                    "diagnosis_class": "diagnosable",
+                    "evidence_completeness_score_pct": 57,
+                    "evidence_completeness_status": "partial",
+                    "missing_evidence_taxonomy": ["campaign_lineage_missing", "no_oos_evidence"],
+                    "follow_up": "collect_more_evidence",
+                    "evidence_presence": {
+                        "source_identity_ready": True,
+                        "source_quality_ready": True,
+                        "cache_ready": True,
+                        "screening_evidence_present": True,
+                        "oos_evidence_known": False,
+                        "campaign_lineage_present": False,
+                        "candidate_lineage_present": True,
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        closure.reason_records,
+        "build_reason_records_snapshot",
+        lambda **_: {"records": [{"subject_id": "c1", "record_ids": ["qrr-1"], "record_families": ["basket_diagnosis"], "reason_codes": ["no_oos_evidence"], "evidence_refs": ["research/screening_evidence_latest.v1.json"]}]},
+    )
+    monkeypatch.setattr(
+        closure.failure_action,
+        "build_failure_action_from_basket",
+        lambda **_: {"rows": [{"candidate_id": "c1", "recommended_action": "materialize_lineage_from_existing_artifacts", "actionability": {"is_actionable": True, "status": "actionable"}}]},
+    )
+    verifier_report = _accepted_verifier_report()
+    verifier_report["rows"][0]["accepted_for_campaign_lineage"] = False
+    verifier_report["rows"][0]["accepted_lineage_count"] = 0
+    verifier_report["rows"][0]["accepted_lineage_records"] = []
+    verifier_report["summary"]["accepted_lineage_candidate_count"] = 0
+    _write_json(tmp_path / "logs" / "qre_bounded_generation_artifact_acceptance_verifier" / "latest.json", verifier_report)
+
+    report = closure.build_evidence_complete_basket_closure(repo_root=tmp_path)
+    row = report["rows"][0]
+
+    assert "campaign_lineage_missing" in row["exact_blockers"]
+    assert "no_oos_evidence" not in row["exact_blockers"]
+    assert row["closure_status"] == "blocked_not_evidence_complete"
+    assert any(item["blocker_code"] == "no_oos_evidence" for item in row["clearance_reason_records"])
+
+
+def test_accepted_lineage_and_oos_for_same_scope_can_complete_basket(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        closure,
+        "_guarded_alias_bounded_generation_snapshot",
+        lambda *_: {"overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"},
+    )
+    monkeypatch.setattr(
+        closure.evidence_coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "c1",
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "timeframes": ["1d"],
+                    "diagnosis_class": "diagnosable",
+                    "evidence_completeness_score_pct": 57,
+                    "evidence_completeness_status": "partial",
+                    "missing_evidence_taxonomy": ["campaign_lineage_missing", "no_oos_evidence"],
+                    "follow_up": "collect_more_evidence",
+                    "evidence_presence": {
+                        "source_identity_ready": True,
+                        "source_quality_ready": True,
+                        "cache_ready": True,
+                        "screening_evidence_present": True,
+                        "oos_evidence_known": False,
+                        "campaign_lineage_present": False,
+                        "candidate_lineage_present": True,
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        closure.reason_records,
+        "build_reason_records_snapshot",
+        lambda **_: {"records": [{"subject_id": "c1", "record_ids": ["qrr-1"], "record_families": ["basket_diagnosis"], "reason_codes": ["campaign_lineage_missing"], "evidence_refs": ["research/production_discovery_catalog.py"]}]},
+    )
+    monkeypatch.setattr(
+        closure.failure_action,
+        "build_failure_action_from_basket",
+        lambda **_: {"rows": [{"candidate_id": "c1", "recommended_action": "keep_fail_closed", "actionability": {"is_actionable": True, "status": "actionable"}}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_bounded_generation_artifact_acceptance_verifier" / "latest.json",
+        _accepted_verifier_report(),
+    )
+
+    report = closure.build_evidence_complete_basket_closure(repo_root=tmp_path)
+    row = report["rows"][0]
+
+    assert row["closure_status"] == "evidence_complete"
+    assert row["exact_blockers"] == []
+    assert report["summary"]["evidence_complete_count"] == 1
+
+
+def test_mismatched_scope_does_not_clear_blockers(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        closure,
+        "_guarded_alias_bounded_generation_snapshot",
+        lambda *_: {"overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"},
+    )
+    monkeypatch.setattr(
+        closure.evidence_coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "c1",
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "timeframes": ["1d"],
+                    "diagnosis_class": "diagnosable",
+                    "evidence_completeness_score_pct": 57,
+                    "evidence_completeness_status": "partial",
+                    "missing_evidence_taxonomy": ["campaign_lineage_missing", "no_oos_evidence"],
+                    "follow_up": "collect_more_evidence",
+                    "evidence_presence": {
+                        "source_identity_ready": True,
+                        "source_quality_ready": True,
+                        "cache_ready": True,
+                        "screening_evidence_present": True,
+                        "oos_evidence_known": False,
+                        "campaign_lineage_present": False,
+                        "candidate_lineage_present": True,
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(closure.reason_records, "build_reason_records_snapshot", lambda **_: {"records": []})
+    monkeypatch.setattr(
+        closure.failure_action,
+        "build_failure_action_from_basket",
+        lambda **_: {"rows": [{"candidate_id": "c1", "recommended_action": "keep_fail_closed", "actionability": {"is_actionable": False, "status": "non_actionable"}}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_bounded_generation_artifact_acceptance_verifier" / "latest.json",
+        _accepted_verifier_report(candidate_id="other-candidate"),
+    )
+
+    report = closure.build_evidence_complete_basket_closure(repo_root=tmp_path)
+    row = report["rows"][0]
+
+    assert "campaign_lineage_missing" in row["exact_blockers"]
+    assert "no_oos_evidence" in row["exact_blockers"]
+    assert row["clearance_reason_records"] == []
+
+
+def test_provisional_or_context_only_records_do_not_clear_blockers(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        closure,
+        "_guarded_alias_bounded_generation_snapshot",
+        lambda *_: {"overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"},
+    )
+    monkeypatch.setattr(
+        closure.evidence_coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "c1",
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "timeframes": ["1d"],
+                    "diagnosis_class": "diagnosable",
+                    "evidence_completeness_score_pct": 57,
+                    "evidence_completeness_status": "partial",
+                    "missing_evidence_taxonomy": ["campaign_lineage_missing", "no_oos_evidence"],
+                    "follow_up": "collect_more_evidence",
+                    "evidence_presence": {
+                        "source_identity_ready": True,
+                        "source_quality_ready": True,
+                        "cache_ready": True,
+                        "screening_evidence_present": True,
+                        "oos_evidence_known": False,
+                        "campaign_lineage_present": False,
+                        "candidate_lineage_present": True,
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(closure.reason_records, "build_reason_records_snapshot", lambda **_: {"records": []})
+    monkeypatch.setattr(
+        closure.failure_action,
+        "build_failure_action_from_basket",
+        lambda **_: {"rows": [{"candidate_id": "c1", "recommended_action": "keep_fail_closed", "actionability": {"is_actionable": False, "status": "non_actionable"}}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_bounded_generation_artifact_acceptance_verifier" / "latest.json",
+        {
+            "report_kind": "qre_bounded_generation_artifact_acceptance_verifier",
+            "summary": {"accepted_lineage_candidate_count": 0, "accepted_oos_candidate_count": 0},
+            "rows": [
+                {
+                    "classification": "rejected_materialized_provisional_only",
+                    "accepted_for_campaign_lineage": False,
+                    "accepted_for_oos_evidence": False,
+                }
+            ],
+        },
+    )
+
+    report = closure.build_evidence_complete_basket_closure(repo_root=tmp_path)
+    row = report["rows"][0]
+
+    assert "campaign_lineage_missing" in row["exact_blockers"]
+    assert "no_oos_evidence" in row["exact_blockers"]
+    assert row["clearance_reason_records"] == []


### PR DESCRIPTION
## Phase
Track 2 / E1 - closure reason-record integration

## Goal
Connect verifier-accepted structured lineage and OOS evidence to basket closure so blocker clearance is exact, scope-matched, and fail-closed.

## What Changed
- verifier now emits accepted lineage/OOS scope records
- closure reads verifier outputs and clears only exact accepted lineage/OOS blockers
- closure emits deterministic clearance reason records
- tests cover lineage-only, OOS-only, same-scope completion, mismatch, and provisional fail-closed behavior

## Safety
- no fake evidence
- no invented IDs, metrics, or refs
- no context-only/materialization-only proof
- no strategy synthesis
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution
- no frozen contract changes
- no protected path changes

## Tests Run
- python -m pytest tests/unit/test_qre_evidence_complete_basket_closure.py -q
- python -m pytest tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py -q
- python -m pytest tests/unit/test_qre_reason_records_v1.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv
- git diff --name-only -- live paper shadow broker risk execution