### PR TITLE
feat: add bounded validation approval gate

### DIFF
--- a/research/qre_bounded_validation_approval_gate.py
+++ b/research/qre_bounded_validation_approval_gate.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Final, Literal
+
+
+ApprovalGateStatus = Literal[
+    "approval_valid_for_bounded_validation",
+    "blocked_missing_approval",
+    "blocked_expired_approval",
+    "blocked_scope_mismatch",
+    "blocked_forbidden_capability",
+    "blocked_output_path_not_allowlisted",
+    "blocked_real_run_not_allowed",
+    "blocked_external_fetch_not_allowed",
+    "blocked_evidence_acceptance_not_allowed",
+]
+
+REPORT_KIND: Final[str] = "qre_bounded_validation_approval_gate"
+SCHEMA_VERSION: Final[str] = "1.0"
+FORBIDDEN_CAPABILITY_MARKERS: Final[tuple[str, ...]] = (
+    "strategy_synthesis",
+    "strategy_registration",
+    "candidate_promotion",
+    "paper_shadow_live",
+    "broker_risk_execution",
+    "execution",
+    "order",
+    "capital_allocation",
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _sorted_unique_strings(values: Any, *, upper: bool = False) -> tuple[str, ...]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        return ()
+    normalized = []
+    seen: set[str] = set()
+    for value in values:
+        text = _text(value)
+        if upper:
+            text = text.upper()
+        if text and text not in seen:
+            seen.add(text)
+            normalized.append(text)
+    return tuple(sorted(normalized))
+
+
+def _has_forbidden_capability(values: Sequence[str]) -> bool:
+    return any(any(marker in item.lower() for marker in FORBIDDEN_CAPABILITY_MARKERS) for item in values)
+
+
+def compute_approval_gate_hash(payload: Mapping[str, Any]) -> str:
+    canonical = {
+        "schema_version": payload.get("schema_version", SCHEMA_VERSION),
+        "report_kind": payload.get("report_kind", REPORT_KIND),
+        "approval_gate_status": payload.get("approval_gate_status", ""),
+        "approval_id": payload.get("approval_id", ""),
+        "request_ref": payload.get("request_ref", ""),
+        "symbols": list(payload.get("symbols", [])),
+        "preset_id": payload.get("preset_id", ""),
+        "timeframe": payload.get("timeframe", ""),
+        "allowed_command_class": payload.get("allowed_command_class", ""),
+        "allowed_output_paths": list(payload.get("allowed_output_paths", [])),
+        "rejection_reasons": list(payload.get("rejection_reasons", [])),
+        "can_execute": bool(payload.get("can_execute", False)),
+    }
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build_bounded_validation_approval_gate(
+    approval: Mapping[str, Any] | None,
+    request: Mapping[str, Any] | None,
+    *,
+    evaluated_at_utc: str,
+    requested_external_fetch: bool = False,
+    require_real_run: bool = True,
+    require_evidence_acceptance: bool = True,
+) -> dict[str, Any]:
+    approval = dict(approval or {})
+    request = dict(request or {})
+    request_symbols = _sorted_unique_strings(request.get("symbols"), upper=True)
+    request_paths = _sorted_unique_strings(request.get("allowed_output_paths"))
+    request_forbidden = _sorted_unique_strings(request.get("forbidden_capabilities"))
+    rejection_reasons: list[str] = []
+
+    if not approval:
+        status: ApprovalGateStatus = "blocked_missing_approval"
+        rejection_reasons.append("missing_approval")
+    else:
+        approval_symbols = _sorted_unique_strings(approval.get("symbols"), upper=True)
+        approval_paths = _sorted_unique_strings(approval.get("allowed_output_paths"))
+        approval_forbidden = _sorted_unique_strings(approval.get("forbidden_capabilities"))
+        expires_at_utc = _text(approval.get("expires_at_utc"))
+
+        if not _text(approval.get("approval_id")) or not _text(approval.get("approved_by")) or not _text(approval.get("approved_at_utc")):
+            status = "blocked_missing_approval"
+            rejection_reasons.append("missing_approval_fields")
+        elif expires_at_utc and expires_at_utc < evaluated_at_utc:
+            status = "blocked_expired_approval"
+            rejection_reasons.append("approval_expired")
+        elif approval_symbols != request_symbols or _text(approval.get("preset_id")) != _text(request.get("preset_id")) or _text(approval.get("timeframe")) != _text(request.get("timeframe")):
+            status = "blocked_scope_mismatch"
+            rejection_reasons.append("scope_mismatch")
+        elif _has_forbidden_capability(approval_forbidden) or _has_forbidden_capability(request_forbidden):
+            status = "blocked_forbidden_capability"
+            rejection_reasons.append("forbidden_capability")
+        elif request_paths and not set(request_paths).issubset(set(approval_paths)):
+            status = "blocked_output_path_not_allowlisted"
+            rejection_reasons.append("output_path_not_allowlisted")
+        elif require_real_run and bool(approval.get("real_run_allowed")) is not True:
+            status = "blocked_real_run_not_allowed"
+            rejection_reasons.append("real_run_not_allowed")
+        elif requested_external_fetch and bool(approval.get("external_fetch_allowed")) is not True:
+            status = "blocked_external_fetch_not_allowed"
+            rejection_reasons.append("external_fetch_not_allowed")
+        elif require_evidence_acceptance and bool(approval.get("evidence_acceptance_allowed")) is not True:
+            status = "blocked_evidence_acceptance_not_allowed"
+            rejection_reasons.append("evidence_acceptance_not_allowed")
+        else:
+            status = "approval_valid_for_bounded_validation"
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "approval_gate_status": status,
+        "approval_id": _text(approval.get("approval_id")),
+        "request_ref": _text(request.get("request_id")),
+        "symbols": list(request_symbols),
+        "preset_id": _text(request.get("preset_id")),
+        "timeframe": _text(request.get("timeframe")),
+        "allowed_command_class": _text(approval.get("allowed_command_class")),
+        "allowed_output_paths": list(_sorted_unique_strings(approval.get("allowed_output_paths"))),
+        "rejection_reasons": rejection_reasons,
+        "real_run_allowed": bool(approval.get("real_run_allowed", False)),
+        "external_fetch_allowed": bool(approval.get("external_fetch_allowed", False)),
+        "evidence_acceptance_allowed": bool(approval.get("evidence_acceptance_allowed", False)),
+        "dry_run_allowed": bool(approval.get("dry_run_allowed", False)),
+        "can_execute": status == "approval_valid_for_bounded_validation",
+        "can_authorize_shadow": False,
+        "can_authorize_paper": False,
+        "can_authorize_live": False,
+        "can_authorize_broker_risk_execution": False,
+    }
+    report["hash"] = compute_approval_gate_hash(report)
+    return report
+
+
+def validate_approval_gate_result(report: Mapping[str, Any]) -> dict[str, Any]:
+    rejection_reasons: list[str] = []
+    if bool(report.get("can_authorize_shadow")):
+        rejection_reasons.append("shadow_authority_forbidden")
+    if bool(report.get("can_authorize_paper")):
+        rejection_reasons.append("paper_authority_forbidden")
+    if bool(report.get("can_authorize_live")):
+        rejection_reasons.append("live_authority_forbidden")
+    if bool(report.get("can_authorize_broker_risk_execution")):
+        rejection_reasons.append("broker_risk_execution_authority_forbidden")
+    computed_hash = compute_approval_gate_hash(report)
+    if _text(report.get("hash")) and _text(report.get("hash")) != computed_hash:
+        rejection_reasons.append("hash_mismatch")
+    return {
+        "valid": not rejection_reasons,
+        "rejection_reasons": rejection_reasons,
+        "hash": computed_hash,
+        "schema_version": SCHEMA_VERSION,
+    }

--- a/tests/unit/test_qre_bounded_validation_approval_gate.py
+++ b/tests/unit/test_qre_bounded_validation_approval_gate.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_bounded_validation_approval_gate as gate
+
+
+def _request(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "request_id": "req-approval-001",
+        "symbols": ["AAPL", "NVDA"],
+        "preset_id": "trend_pullback_continuation_daily_v1",
+        "timeframe": "daily_v1",
+        "allowed_output_paths": ["logs/qre_controlled_validation_adapter_results/"],
+        "forbidden_capabilities": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _approval(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "approval_id": "approval-001",
+        "approved_by": "operator-001",
+        "approved_at_utc": "2026-06-18T18:00:00Z",
+        "expires_at_utc": "2026-06-19T18:00:00Z",
+        "symbols": ["AAPL", "NVDA"],
+        "preset_id": "trend_pullback_continuation_daily_v1",
+        "timeframe": "daily_v1",
+        "allowed_command_class": "bounded_validation",
+        "allowed_output_paths": ["logs/qre_controlled_validation_adapter_results/"],
+        "forbidden_capabilities": [],
+        "dry_run_allowed": True,
+        "real_run_allowed": True,
+        "external_fetch_allowed": False,
+        "evidence_acceptance_allowed": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_missing_approval_blocks() -> None:
+    report = gate.build_bounded_validation_approval_gate(None, _request(), evaluated_at_utc="2026-06-18T18:30:00Z")
+    assert report["approval_gate_status"] == "blocked_missing_approval"
+
+
+def test_expired_approval_blocks() -> None:
+    report = gate.build_bounded_validation_approval_gate(
+        _approval(expires_at_utc="2026-06-18T17:00:00Z"),
+        _request(),
+        evaluated_at_utc="2026-06-18T18:30:00Z",
+    )
+    assert report["approval_gate_status"] == "blocked_expired_approval"
+
+
+def test_scope_mismatch_blocks() -> None:
+    report = gate.build_bounded_validation_approval_gate(
+        _approval(symbols=["AAPL"]),
+        _request(),
+        evaluated_at_utc="2026-06-18T18:30:00Z",
+    )
+    assert report["approval_gate_status"] == "blocked_scope_mismatch"
+
+
+def test_forbidden_capability_blocks() -> None:
+    report = gate.build_bounded_validation_approval_gate(
+        _approval(forbidden_capabilities=["strategy_synthesis"]),
+        _request(),
+        evaluated_at_utc="2026-06-18T18:30:00Z",
+    )
+    assert report["approval_gate_status"] == "blocked_forbidden_capability"
+
+
+def test_real_run_blocked_by_default() -> None:
+    report = gate.build_bounded_validation_approval_gate(
+        _approval(real_run_allowed=False),
+        _request(),
+        evaluated_at_utc="2026-06-18T18:30:00Z",
+    )
+    assert report["approval_gate_status"] == "blocked_real_run_not_allowed"
+
+
+def test_external_fetch_blocked_by_default() -> None:
+    report = gate.build_bounded_validation_approval_gate(
+        _approval(external_fetch_allowed=False),
+        _request(),
+        evaluated_at_utc="2026-06-18T18:30:00Z",
+        requested_external_fetch=True,
+    )
+    assert report["approval_gate_status"] == "blocked_external_fetch_not_allowed"
+
+
+def test_exact_approval_can_pass() -> None:
+    report = gate.build_bounded_validation_approval_gate(
+        _approval(),
+        _request(),
+        evaluated_at_utc="2026-06-18T18:30:00Z",
+    )
+    validation = gate.validate_approval_gate_result(report)
+
+    assert report["approval_gate_status"] == "approval_valid_for_bounded_validation"
+    assert report["can_execute"] is True
+    assert validation["valid"] is True
+
+
+def test_no_shadow_paper_live_or_broker_risk_execution_authority() -> None:
+    report = gate.build_bounded_validation_approval_gate(
+        _approval(),
+        _request(),
+        evaluated_at_utc="2026-06-18T18:30:00Z",
+    )
+    assert report["can_authorize_shadow"] is False
+    assert report["can_authorize_paper"] is False
+    assert report["can_authorize_live"] is False
+    assert report["can_authorize_broker_risk_execution"] is False
+
+
+def test_output_is_deterministic() -> None:
+    first = gate.build_bounded_validation_approval_gate(_approval(), _request(), evaluated_at_utc="2026-06-18T18:30:00Z")
+    second = gate.build_bounded_validation_approval_gate(_approval(), _request(), evaluated_at_utc="2026-06-18T18:30:00Z")
+    assert first == second
+    assert first["hash"] == gate.compute_approval_gate_hash(first)
+
+
+def test_core_gate_has_no_aapl_or_nvda_hardcoding() -> None:
+    source = Path("research/qre_bounded_validation_approval_gate.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source


### PR DESCRIPTION
## Phase
Track 2 / E1 - bounded validation approval gate

## Goal
Add an explicit fail-closed approval gate for any real bounded validation run.

## What Changed
- added deterministic approval gate module
- validates approval scope, expiry, output allowlist, forbidden capabilities, real-run permission, external-fetch permission, and evidence-acceptance permission
- defaults remain blocked unless explicit approval is present and exact

## Safety
- no runtime validation execution
- no fake evidence
- no strategy synthesis
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution
- no frozen contract changes
- no protected path changes

## Tests Run
- python -m pytest tests/unit/test_qre_bounded_validation_approval_gate.py -q
- python -m pytest tests/unit/test_qre_bounded_basket_request.py tests/unit/test_qre_controlled_validation_adapter.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv
- git diff --name-only -- live paper shadow broker risk execution