### PR TITLE
fix: align accepted lineage scope with closure blocker clearance

### DIFF
--- a/research/qre_evidence_complete_basket_closure.py
+++ b/research/qre_evidence_complete_basket_closure.py
@@ -47,6 +47,10 @@ ACCEPTED_OOS_BLOCKERS: Final[frozenset[str]] = frozenset(
         "insufficient_oos_evidence",
     }
 )
+TIMEFRAME_ALIASES: Final[dict[str, frozenset[str]]] = {
+    "daily_v1": frozenset({"daily_v1", "1d"}),
+    "1d": frozenset({"1d", "daily_v1"}),
+}
 
 
 def _index_by_candidate(rows: Sequence[Mapping[str, Any]], *, key: str = "candidate_id") -> dict[str, dict[str, Any]]:
@@ -170,7 +174,11 @@ def _accepted_records(
 
 
 def _timeframe_matches(record_timeframe: str, row_timeframes: Sequence[Any]) -> bool:
-    return not row_timeframes or record_timeframe in {str(value or "") for value in row_timeframes}
+    if not row_timeframes:
+        return True
+    record_aliases = TIMEFRAME_ALIASES.get(record_timeframe, frozenset({record_timeframe}))
+    row_aliases = {str(value or "") for value in row_timeframes}
+    return bool(record_aliases.intersection(row_aliases))
 
 
 def _find_lineage_acceptance(

--- a/tests/unit/test_qre_evidence_complete_basket_closure.py
+++ b/tests/unit/test_qre_evidence_complete_basket_closure.py
@@ -465,6 +465,65 @@ def test_accepted_lineage_only_clears_lineage_blocker_but_not_oos(monkeypatch, t
     assert any(item["blocker_code"] == "campaign_lineage_missing" for item in row["clearance_reason_records"])
 
 
+def test_accepted_lineage_clears_campaign_lineage_for_timeframe_alias_equivalent_scope(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        closure,
+        "_guarded_alias_bounded_generation_snapshot",
+        lambda *_: {"overall_result": "ALIAS_POLICY_CONTEXT_ONLY_BOUNDED_GENERATION_READY"},
+    )
+    monkeypatch.setattr(
+        closure.evidence_coverage,
+        "build_real_basket_evidence_coverage",
+        lambda **_: {
+            "rows": [
+                {
+                    "candidate_id": "c1",
+                    "symbol": "AAA",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "timeframes": ["1d"],
+                    "diagnosis_class": "diagnosable",
+                    "evidence_completeness_score_pct": 57,
+                    "evidence_completeness_status": "partial",
+                    "missing_evidence_taxonomy": ["campaign_lineage_missing", "no_oos_evidence"],
+                    "follow_up": "collect_more_evidence",
+                    "evidence_presence": {
+                        "source_identity_ready": True,
+                        "source_quality_ready": True,
+                        "cache_ready": True,
+                        "screening_evidence_present": True,
+                        "oos_evidence_known": False,
+                        "campaign_lineage_present": False,
+                        "candidate_lineage_present": True,
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        closure.reason_records,
+        "build_reason_records_snapshot",
+        lambda **_: {"records": []},
+    )
+    monkeypatch.setattr(
+        closure.failure_action,
+        "build_failure_action_from_basket",
+        lambda **_: {"rows": [{"candidate_id": "c1", "recommended_action": "collect_oos_evidence", "actionability": {"is_actionable": True, "status": "actionable"}}]},
+    )
+    verifier_report = _accepted_verifier_report(timeframe="daily_v1")
+    verifier_report["rows"][0]["accepted_for_oos_evidence"] = False
+    verifier_report["rows"][0]["accepted_oos_count"] = 0
+    verifier_report["rows"][0]["accepted_oos_records"] = []
+    verifier_report["summary"]["accepted_oos_candidate_count"] = 0
+    _write_json(tmp_path / "logs" / "qre_bounded_generation_artifact_acceptance_verifier" / "latest.json", verifier_report)
+
+    report = closure.build_evidence_complete_basket_closure(repo_root=tmp_path)
+    row = report["rows"][0]
+
+    assert "campaign_lineage_missing" not in row["exact_blockers"]
+    assert "no_oos_evidence" in row["exact_blockers"]
+    assert any(item["blocker_code"] == "campaign_lineage_missing" for item in row["clearance_reason_records"])
+
+
 def test_accepted_oos_only_clears_oos_blocker_but_not_lineage(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
         closure,


### PR DESCRIPTION
status: closure scope alignment for accepted lineage

reason: accepted verifier lineage existed for the approved bounded run, but closure missed it because verifier used timeframe daily_v1 while closure rows used 1d.

what changed:
- updated research/qre_evidence_complete_basket_closure.py
- added alias-equivalent timeframe matching for accepted lineage/OOS scope resolution
- added regression test proving daily_v1 accepted lineage clears campaign_lineage_missing for 1d closure rows without clearing no_oos_evidence

result:
- approved AAPL/NVDA closure rows now clear campaign_lineage_missing
- exact remaining blocker for the approved scope is no_oos_evidence
- evidence_complete_count remains 0
- no OOS blocker was cleared from lineage alone

safety:
- no fake evidence
- no blocker clearance beyond exact accepted lineage scope
- no OOS acceptance implied
- no strategy synthesis
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution
- frozen contracts unchanged
- protected paths untouched

tests run:
- python -m pytest tests/unit/test_qre_evidence_complete_basket_closure.py -q
- python -m pytest tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv
- git diff --name-only -- live paper shadow broker risk execution

post-fix verification:
- reran verifier and closure writers sequentially
- approved scope now shows campaign_lineage_present=true and exact_blockers=[no_oos_evidence]

next:
- approved source still has non_positive_oos_trade_count for both approved candidates; move to docs/status for no-OOS approved source unless a new approved bounded source/window is provided.
