### PR TITLE
docs: add Track 2 E1 status after approved bounded run

### DIFF
--- a/docs/roadmap/qre_track2_e1_status_after_approved_bounded_run.md
+++ b/docs/roadmap/qre_track2_e1_status_after_approved_bounded_run.md
@@ -1,0 +1,68 @@
+# QRE Track 2/E1 Status After Approved Bounded Run
+
+## Overall Result
+
+`APPROVED_SOURCE_HAS_NO_OOS_TRADES`
+
+## PR Summary
+
+| PR | Title | Result | Merge SHA | Evidence Impact |
+| -- | ----- | ------ | --------- | --------------- |
+| #575 | feat: run approved bounded evidence materialization path | merged | `e0a31fb71b4f0545c178b80912c57b148285a119` | accepted structured lineage increased to 2; accepted OOS remained 0 |
+| #576 | diagnostics: explain approved OOS rejection and lineage closure scope | merged | `a20a09eda5921fbf752e7b8d38b7d20c5fe84378` | clarified exact OOS rejection reason and initial lineage scope mismatch |
+| #577 | fix: align accepted lineage scope with closure blocker clearance | merged | `5cdc183dee8fa410a2786e4851599274afb0994b` | accepted lineage now clears `campaign_lineage_missing` for the approved scope |
+| #578 | docs: report approved bounded source has no OOS trades | merged | `763a311b70f5e4d27950e89e697676a060add257` | documented the current hard bounded-source limitation without changing evidence |
+
+## Approved Scope
+
+- approval manifest: `research/operator_approvals/qre_bounded_validation_approval_first_batch.v1.json`
+- approval id: `qre_bounded_validation_first_batch_001`
+- symbols: `AAPL`, `NVDA`
+- preset: `trend_pullback_continuation_daily_v1`
+- timeframe: `daily_v1`
+- external fetch allowed: `false`
+
+## Current Evidence State
+
+- accepted structured lineage artifacts: `2`
+- accepted structured OOS artifacts: `0`
+- evidence_complete_count: `0`
+- blockers cleared: `campaign_lineage_missing` for the approved scope
+- blockers still present: `no_oos_evidence` for the approved scope
+- exact remaining blocker: `non_positive_oos_trade_count` on the approved bounded local OOS window
+
+## Current Maturity Estimate
+
+| Domain | Previous Estimate | Current Estimate | Change | Evidence | What Does Not Count Yet | Next Blocker |
+| --- | ---: | ---: | ---: | --- | --- | --- |
+| Governance/infrastructure | 75 | 76 | +1 | approved bounded run diagnostics and closure-scope integration are deterministic and fail-closed | docs and diagnostics are not authority uplift | preserve exact-scope acceptance while acquiring accepted OOS |
+| Evidence production | 36 | 37 | +1 | verifier-accepted structured lineage exists and is now reflected in closure for the exact scope | accepted OOS is still 0; evidence_complete_count is still 0 | a different bounded source/window that yields positive OOS trades |
+| Research intelligence | 44 | 44 | 0 | no new research-intelligence model was added | no new routing/sampling/memory capability | remains deferred behind Track 2 evidence needs |
+| Candidate quality | 7 | 7 | 0 | no evidence-complete candidates or lifecycle gates were added | accepted lineage alone is not candidate quality authority | accepted OOS plus evidence-complete closure |
+| Deployment/live readiness | 0 | 0 | 0 | no deployment work was started | none of this is deployment authority | explicit evidence-complete baskets and later deployment gates |
+
+## What Is Working Read-Only
+
+- bounded request schema
+- bounded command discovery
+- bounded runner to controlled-validation adapter bridge
+- controlled validation adapter
+- adapter-result materialization readable by the verifier
+- accepted lineage verification for explicit structured approved source artifacts
+- closure blocker clearance for exact accepted lineage scope
+
+## What Is Accepted Evidence
+
+- verifier-accepted structured lineage for:
+  - `seed::trend_pullback_continuation_daily_v1::AAPL`
+  - `seed::trend_pullback_continuation_daily_v1::NVDA`
+
+## What Is Still Provisional
+
+- approved bounded source OOS artifacts for the current local overlap window
+- structured lineage/OOS artifact logs outside verifier-accepted exact-scope records
+- all downstream report surfaces that remain blocked by missing accepted OOS
+
+## Recommended Next Step
+
+`approve different bounded validation source/window`


### PR DESCRIPTION
status: final Track 2/E1 approved-run status report

reason: close the autonomous sequence with a canonical docs/status artifact after the approved bounded run, accepted-lineage integration, and no-OOS finding.

what changed:
- added docs/roadmap/qre_track2_e1_status_after_approved_bounded_run.md

report contents:
- PR sequence summary
- approved scope
- accepted lineage / accepted OOS / evidence_complete_count
- blocker state
- updated conservative maturity estimate
- exact next recommended step

result recorded:
- APPROVED_SOURCE_HAS_NO_OOS_TRADES
- accepted structured lineage: 2
- accepted structured OOS: 0
- evidence_complete_count: 0
- next recommended step: approve different bounded validation source/window

safety:
- docs only
- no runtime change
- no evidence change
- no blocker clearance
- no strategy synthesis
- no candidate promotion
- no shadow/paper/live
- no broker/risk/execution
- frozen contracts unchanged
- protected paths untouched

tests run:
- python -m pytest tests/unit/test_qre_maturity_roadmap_to_100.py tests/unit/test_roadmap_task_catalog.py tests/unit/test_development_roadmap_progress.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv
- git diff --name-only -- live paper shadow broker risk execution
