### PR TITLE
feat: add preregistered multi-window evidence workflow

### DIFF
--- a/research/operator_approvals/qre_preregistered_multiwindow_validation_approval.v1.json
+++ b/research/operator_approvals/qre_preregistered_multiwindow_validation_approval.v1.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "qre_bounded_validation_approval.v1",
+  "approval_id": "qre_preregistered_multiwindow_validation_001",
+  "approved_by": "operator:joery",
+  "approved_at_utc": "2026-06-19T14:15:00Z",
+  "expiry_utc": "2026-06-21T14:15:00Z",
+  "scope": {
+    "symbols": [
+      "AAPL",
+      "NVDA"
+    ],
+    "preset_id": "trend_pullback_continuation_daily_v1",
+    "timeframe": "daily_v1",
+    "source_data_ref": "data/cache/market/yfinance__{AAPL,NVDA}__1d__*.parquet",
+    "bounded_validation_range": {
+      "start": "2026-04-08",
+      "end": "2026-06-08",
+      "selection_rule": "shared_local_cache_intersection"
+    },
+    "window_definitions": [
+      {
+        "window_id": "window_01",
+        "bounded_input_window": {
+          "start": "2026-04-08",
+          "end": "2026-05-07"
+        },
+        "oos_window": {
+          "start": "2026-04-29",
+          "end": "2026-05-07"
+        },
+        "regime_label": "trend"
+      },
+      {
+        "window_id": "window_02",
+        "bounded_input_window": {
+          "start": "2026-05-08",
+          "end": "2026-06-08"
+        },
+        "oos_window": {
+          "start": "2026-05-29",
+          "end": "2026-06-08"
+        },
+        "regime_label": "high_volatility"
+      }
+    ]
+  },
+  "allowed_command_class": "bounded_controlled_validation",
+  "allowed_output_paths": [
+    "logs/qre_bounded_current_basket_generation_runner/",
+    "logs/qre_controlled_validation_adapter_results/",
+    "logs/qre_bounded_generation_artifact_acceptance_verifier/",
+    "logs/qre_evidence_complete_basket_closure/"
+  ],
+  "forbidden_capabilities": [
+    "strategy_synthesis",
+    "strategy_registration",
+    "candidate_promotion",
+    "shadow_activation",
+    "paper_activation",
+    "live_activation",
+    "broker_access",
+    "risk_runtime",
+    "execution_runtime",
+    "order_generation",
+    "capital_allocation",
+    "external_fetch",
+    "parameter_optimization",
+    "window_shopping",
+    "oos_window_relabeling"
+  ],
+  "dry_run_allowed": true,
+  "real_run_allowed": true,
+  "evidence_acceptance_allowed": true,
+  "external_fetch_allowed": false,
+  "operator_note": "Exact-scope preregistered multi-window local-only validation for the shared AAPL/NVDA daily cache intersection. Windows and regimes are locked before execution and were not selected on performance."
+}

--- a/research/operator_approvals/qre_preregistered_multiwindow_validation_approval.v1.json
+++ b/research/operator_approvals/qre_preregistered_multiwindow_validation_approval.v1.json
@@ -28,7 +28,9 @@
           "start": "2026-04-29",
           "end": "2026-05-07"
         },
-        "regime_label": "trend"
+        "regime_label": "trend",
+        "role": "oos",
+        "locked": true
       },
       {
         "window_id": "window_02",
@@ -40,7 +42,9 @@
           "start": "2026-05-29",
           "end": "2026-06-08"
         },
-        "regime_label": "high_volatility"
+        "regime_label": "high_volatility",
+        "role": "oos",
+        "locked": true
       }
     ]
   },

--- a/research/qre_failure_to_action_mapper.py
+++ b/research/qre_failure_to_action_mapper.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Final, Literal
+
+
+FailureClass = Literal[
+    "non_positive_oos_trade_count",
+    "missing_oos_trade_count",
+    "missing_oos_window",
+    "missing_oos_metrics",
+    "missing_cost_slippage_refs",
+    "campaign_lineage_missing",
+    "candidate_lineage_missing",
+    "scope_mismatch",
+    "no_safe_local_source",
+    "no_safe_local_bounded_command",
+    "operator_approval_required",
+    "external_fetch_approval_required",
+    "insufficient_window_length",
+    "insufficient_trades_across_windows",
+    "regime_specific_no_trade_result",
+    "all_preregistered_windows_failed",
+    "null_control_failed",
+    "evidence_acceptance_failed",
+    "hypothesis_not_supported",
+]
+
+ActionAuthority = Literal["report_only", "approval_required", "forbidden_without_approval"]
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_failure_to_action_mapper"
+FAILURE_CLASSES: Final[frozenset[str]] = frozenset(
+    {
+        "non_positive_oos_trade_count",
+        "missing_oos_trade_count",
+        "missing_oos_window",
+        "missing_oos_metrics",
+        "missing_cost_slippage_refs",
+        "campaign_lineage_missing",
+        "candidate_lineage_missing",
+        "scope_mismatch",
+        "no_safe_local_source",
+        "no_safe_local_bounded_command",
+        "operator_approval_required",
+        "external_fetch_approval_required",
+        "insufficient_window_length",
+        "insufficient_trades_across_windows",
+        "regime_specific_no_trade_result",
+        "all_preregistered_windows_failed",
+        "null_control_failed",
+        "evidence_acceptance_failed",
+        "hypothesis_not_supported",
+    }
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _unique_in_order(values: Sequence[Any]) -> list[str]:
+    return list(dict.fromkeys(_text(value) for value in values if _text(value)))
+
+
+def compute_failure_action_hash(payload: Mapping[str, Any]) -> str:
+    canonical = {
+        "schema_version": payload.get("schema_version", SCHEMA_VERSION),
+        "report_kind": payload.get("report_kind", REPORT_KIND),
+        "failure_class": payload.get("failure_class", ""),
+        "recommended_action": payload.get("recommended_action", ""),
+        "action_authority": payload.get("action_authority", ""),
+        "reason_codes": list(payload.get("reason_codes", [])),
+        "prerequisites": list(payload.get("prerequisites", [])),
+        "can_execute": bool(payload.get("can_execute", False)),
+        "can_mutate_queue": bool(payload.get("can_mutate_queue", False)),
+        "can_clear_blocker": bool(payload.get("can_clear_blocker", False)),
+        "can_redefine_window": bool(payload.get("can_redefine_window", False)),
+        "can_tune_strategy": bool(payload.get("can_tune_strategy", False)),
+    }
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _result(
+    *,
+    failure_class: str,
+    recommended_action: str,
+    action_authority: ActionAuthority,
+    reason_codes: Sequence[str],
+    prerequisites: Sequence[str],
+) -> dict[str, Any]:
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "failure_class": failure_class,
+        "recommended_action": recommended_action,
+        "action_authority": action_authority,
+        "reason_codes": _unique_in_order(reason_codes),
+        "prerequisites": _unique_in_order(prerequisites),
+        "can_execute": False,
+        "can_mutate_queue": False,
+        "can_clear_blocker": False,
+        "can_redefine_window": False,
+        "can_tune_strategy": False,
+    }
+    report["hash"] = compute_failure_action_hash(report)
+    return report
+
+
+def map_failure_to_action(
+    *,
+    failure_class: str,
+    remaining_preregistered_window_count: int = 0,
+    remaining_preregistered_regime_count: int = 0,
+) -> dict[str, Any]:
+    normalized = _text(failure_class)
+    if normalized not in FAILURE_CLASSES:
+        return _result(
+            failure_class=normalized or "unknown_failure",
+            recommended_action="route_to_operator_review",
+            action_authority="report_only",
+            reason_codes=["unknown_failure_fail_closed"],
+            prerequisites=["operator_review_required"],
+        )
+
+    if normalized == "non_positive_oos_trade_count":
+        if remaining_preregistered_window_count > 0:
+            return _result(
+                failure_class=normalized,
+                recommended_action="run_next_preregistered_window",
+                action_authority="approval_required",
+                reason_codes=["non_positive_oos_trade_count", "next_preregistered_window_available"],
+                prerequisites=["existing_preregistered_sampling_plan", "valid_exact_scope_approval"],
+            )
+        if remaining_preregistered_regime_count > 0:
+            return _result(
+                failure_class=normalized,
+                recommended_action="run_next_preregistered_regime",
+                action_authority="approval_required",
+                reason_codes=["non_positive_oos_trade_count", "next_preregistered_regime_available"],
+                prerequisites=["existing_preregistered_sampling_plan", "valid_exact_scope_approval"],
+            )
+        return _result(
+            failure_class=normalized,
+            recommended_action="reject_hypothesis",
+            action_authority="report_only",
+            reason_codes=["non_positive_oos_trade_count", "no_remaining_preregistered_windows"],
+            prerequisites=["all_preregistered_windows_exhausted"],
+        )
+
+    direct_map: dict[str, tuple[str, ActionAuthority, list[str], list[str]]] = {
+        "missing_oos_trade_count": (
+            "repair_metadata_mapping",
+            "report_only",
+            ["missing_oos_trade_count", "metadata_repair_required"],
+            ["structured_source_artifact_ref"],
+        ),
+        "missing_oos_window": (
+            "repair_metadata_mapping",
+            "report_only",
+            ["missing_oos_window", "metadata_repair_required"],
+            ["structured_source_artifact_ref"],
+        ),
+        "missing_oos_metrics": (
+            "repair_metadata_mapping",
+            "report_only",
+            ["missing_oos_metrics", "metadata_repair_required"],
+            ["structured_source_artifact_ref"],
+        ),
+        "missing_cost_slippage_refs": (
+            "repair_metadata_mapping",
+            "report_only",
+            ["missing_cost_slippage_refs", "metadata_repair_required"],
+            ["structured_source_artifact_ref"],
+        ),
+        "campaign_lineage_missing": (
+            "repair_scope_matching",
+            "report_only",
+            ["campaign_lineage_missing", "lineage_scope_repair_required"],
+            ["accepted_lineage_artifact_or_structured_source"],
+        ),
+        "candidate_lineage_missing": (
+            "repair_scope_matching",
+            "report_only",
+            ["candidate_lineage_missing", "lineage_scope_repair_required"],
+            ["accepted_lineage_artifact_or_structured_source"],
+        ),
+        "scope_mismatch": (
+            "repair_scope_matching",
+            "report_only",
+            ["scope_mismatch", "exact_scope_repair_required"],
+            ["exact_scope_reason_record"],
+        ),
+        "no_safe_local_source": (
+            "stop_no_safe_next_action",
+            "report_only",
+            ["no_safe_local_source"],
+            ["operator_review_required"],
+        ),
+        "no_safe_local_bounded_command": (
+            "stop_no_safe_next_action",
+            "report_only",
+            ["no_safe_local_bounded_command"],
+            ["operator_review_required"],
+        ),
+        "operator_approval_required": (
+            "request_exact_operator_approval",
+            "approval_required",
+            ["operator_approval_required"],
+            ["exact_scope_manifest"],
+        ),
+        "external_fetch_approval_required": (
+            "request_external_fetch_approval",
+            "approval_required",
+            ["external_fetch_approval_required"],
+            ["exact_scope_external_fetch_manifest"],
+        ),
+        "insufficient_window_length": (
+            "create_preregistered_sampling_plan",
+            "report_only",
+            ["insufficient_window_length"],
+            ["larger_preregistered_local_range"],
+        ),
+        "insufficient_trades_across_windows": (
+            "reject_hypothesis",
+            "report_only",
+            ["insufficient_trades_across_windows"],
+            ["all_preregistered_windows_completed"],
+        ),
+        "regime_specific_no_trade_result": (
+            "run_next_preregistered_regime",
+            "approval_required",
+            ["regime_specific_no_trade_result"],
+            ["remaining_preregistered_regime"],
+        ),
+        "all_preregistered_windows_failed": (
+            "reject_hypothesis",
+            "report_only",
+            ["all_preregistered_windows_failed"],
+            ["all_preregistered_windows_completed"],
+        ),
+        "null_control_failed": (
+            "reject_hypothesis",
+            "report_only",
+            ["null_control_failed"],
+            ["null_control_result_recorded"],
+        ),
+        "evidence_acceptance_failed": (
+            "keep_fail_closed",
+            "report_only",
+            ["evidence_acceptance_failed"],
+            ["verifier_rejection_reasons_preserved"],
+        ),
+        "hypothesis_not_supported": (
+            "reject_hypothesis",
+            "report_only",
+            ["hypothesis_not_supported"],
+            ["reason_record_preserved"],
+        ),
+    }
+    action, authority, reasons, prerequisites = direct_map[normalized]
+    return _result(
+        failure_class=normalized,
+        recommended_action=action,
+        action_authority=authority,
+        reason_codes=reasons,
+        prerequisites=prerequisites,
+    )
+
+
+def validate_failure_action_mapping(report: Mapping[str, Any]) -> dict[str, Any]:
+    rejection_reasons: list[str] = []
+    if report.get("can_execute") is not False:
+        rejection_reasons.append("can_execute_must_be_false")
+    if report.get("can_mutate_queue") is not False:
+        rejection_reasons.append("can_mutate_queue_must_be_false")
+    if report.get("can_clear_blocker") is not False:
+        rejection_reasons.append("can_clear_blocker_must_be_false")
+    if report.get("can_redefine_window") is not False:
+        rejection_reasons.append("can_redefine_window_must_be_false")
+    if report.get("can_tune_strategy") is not False:
+        rejection_reasons.append("can_tune_strategy_must_be_false")
+    recomputed_hash = compute_failure_action_hash(report)
+    if _text(report.get("hash")) and _text(report.get("hash")) != recomputed_hash:
+        rejection_reasons.append("hash_mismatch")
+    return {
+        "valid": not rejection_reasons,
+        "rejection_reasons": rejection_reasons,
+        "hash": recomputed_hash,
+        "schema_version": SCHEMA_VERSION,
+    }

--- a/research/qre_multiwindow_evidence_closure.py
+++ b/research/qre_multiwindow_evidence_closure.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_failure_to_action_mapper as failure_mapper
+from research import qre_preregistered_multiwindow_evidence_run as campaign_run
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_multiwindow_evidence_closure"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_multiwindow_evidence_closure")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_multiwindow_evidence_closure/"
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _unique_in_order(values: Sequence[Any]) -> list[str]:
+    return list(dict.fromkeys(_text(value) for value in values if _text(value)))
+
+
+def compute_multiwindow_closure_hash(report: Mapping[str, Any]) -> str:
+    canonical = {
+        "schema_version": report.get("schema_version", SCHEMA_VERSION),
+        "report_kind": report.get("report_kind", REPORT_KIND),
+        "closure_status": report.get("closure_status", ""),
+        "campaign_ref": report.get("campaign_ref", ""),
+        "sampling_plan_ref": report.get("sampling_plan_ref", ""),
+        "accepted_lineage_count": int(report.get("accepted_lineage_count", 0) or 0),
+        "accepted_oos_count": int(report.get("accepted_oos_count", 0) or 0),
+        "evidence_complete_count": int(report.get("evidence_complete_count", 0) or 0),
+        "hypothesis_disposition": report.get("hypothesis_disposition", ""),
+        "blockers_cleared": list(report.get("blockers_cleared", [])),
+        "blockers_remaining": list(report.get("blockers_remaining", [])),
+        "reason_records": list(report.get("reason_records", [])),
+        "recommended_next_action": report.get("recommended_next_action", ""),
+        "authority": dict(report.get("authority", {})),
+    }
+    raw = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _reason_record(*, record_id: str, reason_code: str, evidence_refs: Sequence[str], message: str) -> dict[str, Any]:
+    return {
+        "record_id": record_id,
+        "record_family": "multiwindow_evidence_closure",
+        "reason_codes": [reason_code],
+        "evidence_refs": list(evidence_refs),
+        "message": message,
+    }
+
+
+def build_multiwindow_evidence_closure(campaign_report: Mapping[str, Any]) -> dict[str, Any]:
+    window_results = list(campaign_report.get("window_results") or [])
+    accepted_lineage_count = int(campaign_report.get("accepted_lineage_count") or 0)
+    accepted_oos_count = int(campaign_report.get("accepted_oos_count") or 0)
+    campaign_outcome = _text(campaign_report.get("campaign_outcome"))
+    positive_oos_trade_count_total = int(campaign_report.get("positive_oos_trade_count_total") or 0)
+    null_control_status = _text((campaign_report.get("null_control_results") or {}).get("status"))
+    reason_records: list[dict[str, Any]] = []
+    blockers_cleared: list[str] = []
+    blockers_remaining: list[str] = []
+
+    if accepted_lineage_count > 0:
+        blockers_cleared.append("campaign_lineage_missing")
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_lineage_present",
+                reason_code="accepted_lineage_present",
+                evidence_refs=[_text(campaign_report.get("campaign_id"))],
+                message="Verifier-acceptable structured lineage exists for the preregistered campaign scope.",
+            )
+        )
+    else:
+        blockers_remaining.append("campaign_lineage_missing")
+
+    if accepted_oos_count > 0:
+        blockers_cleared.append("no_oos_evidence")
+    else:
+        blockers_remaining.append("no_oos_evidence")
+
+    if not window_results:
+        closure_status = "blocked_incomplete_campaign"
+        hypothesis_disposition = "not_evaluated"
+        recommended_next_action = "route_to_operator_review"
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_missing_windows",
+                reason_code="missing_window_results",
+                evidence_refs=[],
+                message="The preregistered campaign did not execute any windows.",
+            )
+        )
+    elif null_control_status == "failed":
+        closure_status = "null_control_failed"
+        hypothesis_disposition = "fail_closed_rejected"
+        recommended_next_action = "reject_hypothesis"
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_null_control_failed",
+                reason_code="null_control_failed",
+                evidence_refs=[],
+                message="Null/control requirements failed, so completion is blocked fail-closed.",
+            )
+        )
+    elif campaign_outcome == "accepted_multiwindow_oos_evidence" and accepted_lineage_count > 0 and accepted_oos_count > 0:
+        closure_status = "evidence_complete"
+        hypothesis_disposition = "supported_for_evidence_review"
+        recommended_next_action = "route_to_operator_review"
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_evidence_complete",
+                reason_code="evidence_complete",
+                evidence_refs=[_text(campaign_report.get("campaign_id"))],
+                message="Accepted lineage and OOS evidence satisfied the preregistered multi-window criteria.",
+            )
+        )
+    elif campaign_outcome in {"partial_oos_evidence", "regime_specific_evidence_only"} or accepted_oos_count > 0:
+        closure_status = "evidence_partial"
+        hypothesis_disposition = "insufficient_for_completion"
+        recommended_next_action = "route_to_operator_review"
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_partial",
+                reason_code="evidence_partial",
+                evidence_refs=[_text(campaign_report.get("campaign_id"))],
+                message="Some accepted OOS evidence exists, but the preregistered completion criteria were not met.",
+            )
+        )
+    elif campaign_outcome == "all_windows_non_positive_trade_count":
+        closure_status = "all_windows_no_oos_trades"
+        hypothesis_disposition = "fail_closed_rejected"
+        recommended_next_action = failure_mapper.map_failure_to_action(
+            failure_class="all_preregistered_windows_failed"
+        )["recommended_action"]
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_all_zero",
+                reason_code="all_windows_non_positive_trade_count",
+                evidence_refs=[_text(campaign_report.get("campaign_id"))],
+                message="Every preregistered window completed with non-positive OOS trade count.",
+            )
+        )
+    elif campaign_outcome == "insufficient_total_oos_trades":
+        closure_status = "insufficient_total_oos_trades"
+        hypothesis_disposition = "fail_closed_rejected"
+        recommended_next_action = failure_mapper.map_failure_to_action(
+            failure_class="insufficient_trades_across_windows"
+        )["recommended_action"]
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_insufficient_trades",
+                reason_code="insufficient_trades_across_windows",
+                evidence_refs=[_text(campaign_report.get("campaign_id"))],
+                message="Preregistered windows ran, but total OOS trades remained below the minimum requirement.",
+            )
+        )
+    elif campaign_outcome in {"hypothesis_not_supported", "blocked_safety_check", "blocked_source", "blocked_approval"}:
+        closure_status = "hypothesis_not_supported" if campaign_outcome == "hypothesis_not_supported" else "operator_review_required"
+        hypothesis_disposition = "fail_closed_rejected" if campaign_outcome == "hypothesis_not_supported" else "operator_review_required"
+        recommended_next_action = "route_to_operator_review" if campaign_outcome != "hypothesis_not_supported" else "reject_hypothesis"
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_campaign_blocked",
+                reason_code=campaign_outcome or "campaign_blocked",
+                evidence_refs=[_text(campaign_report.get("campaign_id"))],
+                message="The multi-window campaign did not produce acceptable OOS evidence for the preregistered scope.",
+            )
+        )
+    else:
+        closure_status = "operator_review_required"
+        hypothesis_disposition = "operator_review_required"
+        recommended_next_action = "route_to_operator_review"
+
+    if accepted_oos_count == 0 and "no_oos_evidence" not in blockers_remaining:
+        blockers_remaining.append("no_oos_evidence")
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "closure_status": closure_status,
+        "campaign_ref": _text(campaign_report.get("campaign_id")),
+        "sampling_plan_ref": _text(campaign_report.get("sampling_plan_id")),
+        "accepted_lineage_count": accepted_lineage_count,
+        "accepted_oos_count": accepted_oos_count,
+        "evidence_complete_count": 1 if closure_status == "evidence_complete" else 0,
+        "hypothesis_disposition": hypothesis_disposition,
+        "blockers_cleared": _unique_in_order(blockers_cleared),
+        "blockers_remaining": _unique_in_order(blockers_remaining),
+        "reason_records": reason_records,
+        "recommended_next_action": recommended_next_action,
+        "authority": {
+            "non_authoritative": False,
+            "can_promote_candidate": False,
+            "can_activate_deployment": False,
+            "evidence_authority": "closure_summary_only",
+        },
+        "campaign_outcome": campaign_outcome,
+        "positive_oos_trade_count_total": positive_oos_trade_count_total,
+    }
+    report["hash"] = compute_multiwindow_closure_hash(report)
+    return report
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path.as_posix()}")
+    return payload
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(
+        "\n".join(
+            [
+                "# QRE Multi-Window Evidence Closure",
+                "",
+                f"- closure_status: {report.get('closure_status', '')}",
+                f"- accepted_lineage_count: {report.get('accepted_lineage_count', 0)}",
+                f"- accepted_oos_count: {report.get('accepted_oos_count', 0)}",
+                f"- evidence_complete_count: {report.get('evidence_complete_count', 0)}",
+                f"- hypothesis_disposition: {report.get('hypothesis_disposition', '')}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_multiwindow_evidence_closure",
+        description="Finalize the preregistered multi-window evidence campaign.",
+    )
+    parser.add_argument(
+        "--campaign-file",
+        default="logs/qre_preregistered_multiwindow_evidence_run/latest.json",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_multiwindow_evidence_closure(_read_json(Path(args.campaign_file)))
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/qre_preregistered_multiwindow_evidence_run.py
+++ b/research/qre_preregistered_multiwindow_evidence_run.py
@@ -118,6 +118,16 @@ def build_sampling_plan_for_multiwindow_approval(
             minimum_warmup_period=10,
             regime_labels=["trend", "high_volatility"],
         )
+    else:
+        window_definitions = [
+            {
+                **dict(window),
+                "role": _text((window or {}).get("role")) or "oos",
+                "locked": True if window.get("locked") is None else bool(window.get("locked")),
+            }
+            for window in window_definitions
+            if isinstance(window, Mapping)
+        ]
     return sampling.build_preregistered_sampling_plan(
         hypothesis_ref=hypothesis_id,
         behavior_id="trend_pullback",
@@ -489,7 +499,14 @@ def build_preregistered_multiwindow_evidence_run(
         campaign_outcome = "insufficient_total_oos_trades"
     elif accepted_oos_count > 0:
         campaign_outcome = "partial_oos_evidence"
-    elif failed_window_count == len(window_results) and rejection_reasons and set(rejection_reasons) == {"non_positive_oos_trade_count"}:
+    elif (
+        failed_window_count == len(window_results)
+        and all(
+            int(item.get("oos_trade_count") or 0) <= 0
+            for window in window_results
+            for item in window.get("symbol_results", [])
+        )
+    ):
         campaign_outcome = "all_windows_non_positive_trade_count"
     else:
         campaign_outcome = "hypothesis_not_supported"

--- a/research/qre_preregistered_multiwindow_evidence_run.py
+++ b/research/qre_preregistered_multiwindow_evidence_run.py
@@ -1,0 +1,571 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_approved_bounded_evidence_materialization as approved
+from research import qre_bounded_generation_artifact_acceptance_verifier as verifier
+from research import qre_controlled_validation_adapter as adapter
+from research import qre_controlled_validation_adapter_result_materialization as materializer
+from research import qre_failure_to_action_mapper as failure_mapper
+from research import qre_preregistered_multiwindow_validation as campaign_builder
+from research import qre_sampling_plan as sampling
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_preregistered_multiwindow_evidence_run"
+DEFAULT_APPROVAL_PATH: Final[Path] = Path(
+    "research/operator_approvals/qre_preregistered_multiwindow_validation_approval.v1.json"
+)
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_preregistered_multiwindow_evidence_run")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_preregistered_multiwindow_evidence_run/"
+ALLOWED_OUTPUT_PATHS: Final[tuple[str, ...]] = (
+    "logs/qre_bounded_current_basket_generation_runner/",
+    "logs/qre_controlled_validation_adapter_results/",
+    "logs/qre_bounded_generation_artifact_acceptance_verifier/",
+    "logs/qre_evidence_complete_basket_closure/",
+)
+TIMEFRAME_TO_INTERVAL: Final[dict[str, str]] = {"daily_v1": "1d"}
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _unique_in_order(values: Sequence[Any]) -> list[str]:
+    return list(dict.fromkeys(_text(value) for value in values if _text(value)))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path.as_posix()}")
+    return payload
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _candidate_scope(repo_root: Path, *, symbols: Sequence[str], preset_id: str) -> tuple[str, list[str]]:
+    payload = _read_json(repo_root / "logs/qre_basket_next_action_queue/latest.json")
+    rows = payload.get("rows") if isinstance(payload.get("rows"), list) else []
+    candidate_ids: list[str] = []
+    hypothesis_id = ""
+    wanted = {symbol.upper() for symbol in symbols}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        if _text(row.get("symbol")).upper() not in wanted:
+            continue
+        if _text(row.get("preset_id")) != preset_id:
+            continue
+        candidate_id = _text(row.get("candidate_id"))
+        if candidate_id:
+            candidate_ids.append(candidate_id)
+        if not hypothesis_id:
+            hypothesis_id = _text(row.get("hypothesis_id"))
+    if not candidate_ids or not hypothesis_id:
+        raise ValueError("missing_queue_candidate_scope")
+    return hypothesis_id, sorted(set(candidate_ids))
+
+
+def _load_common_trading_dates(repo_root: Path, *, symbols: Sequence[str], timeframe: str) -> list[str]:
+    interval = TIMEFRAME_TO_INTERVAL[timeframe]
+    date_sets: list[set[str]] = []
+    for symbol in symbols:
+        frame = approved._load_stitched_local_cache_frame(repo_root=repo_root, symbol=symbol, interval=interval)
+        date_sets.append({index.strftime("%Y-%m-%d") for index in frame.index})
+    common = sorted(set.intersection(*date_sets)) if date_sets else []
+    if not common:
+        raise ValueError("missing_common_local_trading_dates")
+    return common
+
+
+def build_sampling_plan_for_multiwindow_approval(
+    *,
+    approval_manifest: Mapping[str, Any],
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    scope = approval_manifest.get("scope") if isinstance(approval_manifest.get("scope"), Mapping) else {}
+    symbols = list(scope.get("symbols") or [])
+    preset_id = _text(scope.get("preset_id"))
+    timeframe = _text(scope.get("timeframe"))
+    hypothesis_id, _ = _candidate_scope(repo_root, symbols=symbols, preset_id=preset_id)
+    common_dates = _load_common_trading_dates(repo_root, symbols=symbols, timeframe=timeframe)
+    window_definitions = list(scope.get("window_definitions") or [])
+    if not window_definitions:
+        window_definitions = sampling.derive_preregistered_windows(
+            trading_dates=common_dates,
+            window_count=2,
+            minimum_window_length=20,
+            minimum_warmup_period=10,
+            regime_labels=["trend", "high_volatility"],
+        )
+    return sampling.build_preregistered_sampling_plan(
+        hypothesis_ref=hypothesis_id,
+        behavior_id="trend_pullback",
+        preset_id=preset_id,
+        timeframe=timeframe,
+        bounded_source_data_availability={
+            "source_data_ref": _text(scope.get("source_data_ref")),
+            "local_only": True,
+        },
+        proposed_total_validation_range=dict(scope.get("bounded_validation_range") or {}),
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_lineage", "structured_oos"],
+        null_control_definitions=[
+            {
+                "control_id": "null_daily_holdout",
+                "required_for_evidence_complete": True,
+                "required_for_fail_closed_rejection": False,
+            }
+        ],
+        known_previous_failed_windows=[
+            {
+                "scope_ref": "qre_bounded_validation_next_oos_source_001",
+                "failure_class": "non_positive_oos_trade_count",
+            }
+        ],
+        regime_buckets=[
+            {"regime_label": "trend", "selection_basis": "preregistered_window_label"},
+            {"regime_label": "high_volatility", "selection_basis": "preregistered_window_label"},
+        ],
+        window_definitions=window_definitions,
+        preregistration_timestamp=_text(approval_manifest.get("approved_at_utc")),
+        minimum_trade_requirement=1,
+    )
+
+
+def build_campaign_for_multiwindow_approval(
+    *,
+    approval_manifest: Mapping[str, Any],
+    sampling_plan_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    scope = approval_manifest.get("scope") if isinstance(approval_manifest.get("scope"), Mapping) else {}
+    return campaign_builder.build_preregistered_multiwindow_validation(
+        sampling_plan_payload=sampling_plan_payload,
+        approval_manifest=approval_manifest,
+        local_source_ref=_text(scope.get("source_data_ref")),
+        minimum_required_windows=2,
+        minimum_total_oos_trades=1,
+        per_window_minimum_oos_trades=1,
+        null_control_requirements=[
+            {"control_id": "null_daily_holdout", "required_for_evidence_complete": True}
+        ],
+    )
+
+
+def _window_approval(
+    *,
+    approval_manifest: Mapping[str, Any],
+    symbol: str,
+    window_spec: Mapping[str, Any],
+) -> dict[str, Any]:
+    scope = approval_manifest.get("scope") if isinstance(approval_manifest.get("scope"), Mapping) else {}
+    approval_id = f"{_text(approval_manifest.get('approval_id'))}__{_text(window_spec.get('window_id'))}__{symbol}"
+    return {
+        "approval_id": approval_id,
+        "approved_by": _text(approval_manifest.get("approved_by")),
+        "approved_at_utc": _text(approval_manifest.get("approved_at_utc")),
+        "expiry_utc": _text(approval_manifest.get("expiry_utc") or approval_manifest.get("expires_at_utc")),
+        "scope": {
+            "symbols": [symbol],
+            "preset_id": _text(scope.get("preset_id")),
+            "timeframe": _text(scope.get("timeframe")),
+            "source_data_ref": _text(scope.get("source_data_ref")),
+            "bounded_input_window": dict(window_spec.get("bounded_input_window") or {}),
+            "oos_window": dict(window_spec.get("oos_window") or {}),
+        },
+        "allowed_command_class": _text(approval_manifest.get("allowed_command_class")),
+        "allowed_output_paths": list(approval_manifest.get("allowed_output_paths") or []),
+        "forbidden_capabilities": list(approval_manifest.get("forbidden_capabilities") or []),
+        "dry_run_allowed": bool(approval_manifest.get("dry_run_allowed", False)),
+        "real_run_allowed": bool(approval_manifest.get("real_run_allowed", False)),
+        "evidence_acceptance_allowed": bool(approval_manifest.get("evidence_acceptance_allowed", False)),
+        "external_fetch_allowed": bool(approval_manifest.get("external_fetch_allowed", False)),
+    }
+
+
+def _source_payload_for_window(
+    *,
+    approval_payload: Mapping[str, Any],
+    repo_root: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    normalized = approved._normalize_approval_payload(approval_payload)
+    request = approved._build_request_payload(
+        normalized,
+        created_at_utc=_utcnow(),
+    )
+    symbol = list(normalized["symbols"])[0]
+    timeframe = _text(normalized["timeframe"])
+    interval = TIMEFRAME_TO_INTERVAL[timeframe]
+    candidate_ids = approved._candidate_ids_from_queue(
+        repo_root=repo_root,
+        symbols=[symbol],
+        preset_id=_text(normalized["preset_id"]),
+        timeframe=timeframe,
+    )
+    frame = approved._load_stitched_local_cache_frame(repo_root=repo_root, symbol=symbol, interval=interval)
+    bounded_frame = approved._restrict_frame_to_approval_window(frame=frame, approval=normalized)
+    source_ref = (
+        "logs/qre_controlled_validation_adapter_results/source_artifacts/"
+        f"{approval_payload['approval_id']}.v1.json"
+    )
+    evaluation = approved._evaluate_symbol_with_local_cache(
+        symbol=symbol,
+        candidate_id=candidate_ids[symbol.upper()],
+        generation_run_id=f"{approval_payload['approval_id']}::generation",
+        frame=bounded_frame,
+        source_ref=source_ref,
+        approval=normalized,
+    )
+    source_payload = {
+        "schema_version": approved.SCHEMA_VERSION,
+        "report_kind": "qre_bounded_local_cache_controlled_validation_source",
+        "generated_at_utc": _utcnow(),
+        "approval_id": approval_payload["approval_id"],
+        "approval_manifest_ref": DEFAULT_APPROVAL_PATH.as_posix(),
+        "source_type": "structured_controlled_validation",
+        "source_authority": "structured_source",
+        "source_ref": source_ref,
+        "source_metadata_kind": "approved_local_cache_strategy_validation",
+        "no_external_fetch": True,
+        "lineage_records": [
+            {
+                "symbol": evaluation.symbol,
+                "candidate_id": evaluation.candidate_id,
+                "generation_run_id": evaluation.generation_run_id,
+                "validation_status": "accepted",
+                "reason_record_refs": evaluation.reason_record_refs,
+            }
+        ],
+        "oos_records": [
+            {
+                "symbol": evaluation.symbol,
+                "candidate_id": evaluation.candidate_id,
+                "oos_window": {
+                    "start": evaluation.oos_window_start,
+                    "end": evaluation.oos_window_end,
+                    "label": _text((approval_payload.get("scope") or {}).get("oos_window", {}).get("selection_rule"))
+                    or "preregistered_oos_window",
+                },
+                "oos_metric_fields": dict(evaluation.oos_metric_fields),
+                "cost_slippage_assumption_refs": list(evaluation.cost_slippage_assumption_refs),
+                "validation_status": "accepted",
+                "reason_record_refs": evaluation.reason_record_refs,
+            }
+        ],
+        "cost_slippage_assumptions": [
+            {
+                "ref": evaluation.cost_slippage_assumption_refs[0],
+                "fee_per_side_fraction": 0.0035,
+                "slippage_bps": 0.0,
+                "source": "agent.backtesting.engine default cost model",
+            }
+        ],
+        "reason_records": [
+            {
+                "ref": evaluation.reason_record_refs[0],
+                "subject": evaluation.candidate_id,
+                "reason_code": "approved_local_cache_generation_run",
+            },
+            {
+                "ref": evaluation.reason_record_refs[1],
+                "subject": evaluation.candidate_id,
+                "reason_code": "approved_local_cache_oos_metrics_materialized",
+            },
+        ],
+    }
+    source_payload["hash"] = hashlib.sha256(
+        json.dumps(source_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()
+    return request, source_payload
+
+
+def _classify_window_symbol(
+    *,
+    approval_manifest: Mapping[str, Any],
+    window_spec: Mapping[str, Any],
+    symbol: str,
+    repo_root: Path,
+) -> dict[str, Any]:
+    approval_payload = _window_approval(
+        approval_manifest=approval_manifest,
+        symbol=symbol,
+        window_spec=window_spec,
+    )
+    request, source_payload = _source_payload_for_window(
+        approval_payload=approval_payload,
+        repo_root=repo_root,
+    )
+    adapter_result = adapter.build_controlled_validation_adapter_result(
+        request,
+        controlled_validation_source=source_payload,
+    )
+    materialized = materializer.build_controlled_validation_adapter_result_materialization(adapter_result)
+    row = verifier._classify_materialized_record(
+        materialized,
+        relative_path=f"logs/qre_controlled_validation_adapter_results/{approval_payload['approval_id']}.json",
+        allowlisted_paths=list(ALLOWED_OUTPUT_PATHS),
+    )
+    oos_metrics = {}
+    if source_payload["oos_records"]:
+        oos_metrics = dict(source_payload["oos_records"][0].get("oos_metric_fields") or {})
+    positive_trades = int(oos_metrics.get("oos_trade_count") or 0) if row["accepted_for_oos_evidence"] else 0
+    return {
+        "window_id": _text(window_spec.get("window_id")),
+        "symbol": symbol,
+        "request_id": request["request_id"],
+        "approval_id": approval_payload["approval_id"],
+        "source_ref": source_payload["source_ref"],
+        "classification": row["classification"],
+        "accepted_lineage_count": int(row.get("accepted_lineage_count") or 0),
+        "accepted_oos_count": int(row.get("accepted_oos_count") or 0),
+        "positive_oos_trade_count": positive_trades,
+        "oos_trade_count": int(oos_metrics.get("oos_trade_count") or 0),
+        "rejection_reasons": list(dict.fromkeys([
+            *list(row.get("rejection_reasons") or []),
+            *list(row.get("oos_rejection_reasons") or []),
+        ])),
+        "lineage_records": list(row.get("accepted_lineage_records") or []),
+        "oos_records": list(row.get("accepted_oos_records") or []),
+        "adapter_result": adapter_result,
+        "materialized_result": materialized,
+    }
+
+
+def compute_campaign_run_hash(report: Mapping[str, Any]) -> str:
+    canonical = {
+        "schema_version": report.get("schema_version", SCHEMA_VERSION),
+        "report_kind": report.get("report_kind", REPORT_KIND),
+        "campaign_id": report.get("campaign_id", ""),
+        "sampling_plan_id": report.get("sampling_plan_id", ""),
+        "campaign_plan_hash": report.get("campaign_plan_hash", ""),
+        "accepted_lineage_count": int(report.get("accepted_lineage_count", 0) or 0),
+        "accepted_oos_count": int(report.get("accepted_oos_count", 0) or 0),
+        "positive_oos_trade_count_total": int(report.get("positive_oos_trade_count_total", 0) or 0),
+        "failed_window_count": int(report.get("failed_window_count", 0) or 0),
+        "accepted_window_count": int(report.get("accepted_window_count", 0) or 0),
+        "rejection_reasons": list(report.get("rejection_reasons", [])),
+        "campaign_outcome": report.get("campaign_outcome", ""),
+    }
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build_preregistered_multiwindow_evidence_run(
+    *,
+    approval_manifest: Mapping[str, Any],
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    sampling_plan_payload = build_sampling_plan_for_multiwindow_approval(
+        approval_manifest=approval_manifest,
+        repo_root=repo_root,
+    )
+    campaign_plan = build_campaign_for_multiwindow_approval(
+        approval_manifest=approval_manifest,
+        sampling_plan_payload=sampling_plan_payload,
+    )
+    if sampling_plan_payload["hash"] != campaign_plan["sampling_plan_hash"]:
+        raise ValueError("sampling_plan_hash_mismatch")
+    if campaign_plan["hash"] != campaign_builder.compute_campaign_hash(campaign_plan):
+        raise ValueError("campaign_plan_hash_mismatch")
+    if campaign_plan["status"] != "campaign_ready_preregistered_context":
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "report_kind": REPORT_KIND,
+            "campaign_id": campaign_plan["campaign_id"],
+            "sampling_plan_id": sampling_plan_payload["sampling_plan_id"],
+            "campaign_plan_hash": campaign_plan["hash"],
+            "window_results": [],
+            "regime_results": [],
+            "accepted_lineage_count": 0,
+            "accepted_oos_count": 0,
+            "positive_oos_trade_count_total": 0,
+            "failed_window_count": 0,
+            "accepted_window_count": 0,
+            "rejection_reasons": list(campaign_plan.get("blocked_reasons") or []),
+            "null_control_results": {"status": "not_run_due_to_blocked_campaign"},
+            "campaign_outcome": "blocked_approval",
+            "can_clear_blockers": False,
+            "can_promote_candidate": False,
+            "can_activate_deployment": False,
+            "hash": "",
+        }
+
+    window_results: list[dict[str, Any]] = []
+    remaining = len(campaign_plan["window_run_specs"])
+    for window_spec in campaign_plan["window_run_specs"]:
+        symbol_results = [
+            _classify_window_symbol(
+                approval_manifest=approval_manifest,
+                window_spec=window_spec,
+                symbol=symbol,
+                repo_root=repo_root,
+            )
+            for symbol in window_spec["symbols"]
+        ]
+        remaining -= 1
+        accepted_oos_count = sum(item["accepted_oos_count"] for item in symbol_results)
+        positive_trades = sum(max(0, item["positive_oos_trade_count"]) for item in symbol_results)
+        rejection_reasons = _unique_in_order(
+            [reason for item in symbol_results for reason in item["rejection_reasons"]]
+        )
+        window_failure = "window_accepted" if accepted_oos_count > 0 else "non_positive_oos_trade_count"
+        next_action = (
+            failure_mapper.map_failure_to_action(
+                failure_class="non_positive_oos_trade_count",
+                remaining_preregistered_window_count=remaining,
+            )
+            if window_failure != "window_accepted"
+            else None
+        )
+        window_results.append(
+            {
+                "window_id": _text(window_spec.get("window_id")),
+                "regime_label": _text(window_spec.get("regime_label")) or "unclassified",
+                "bounded_input_window": dict(window_spec.get("bounded_input_window") or {}),
+                "oos_window": dict(window_spec.get("oos_window") or {}),
+                "symbol_results": symbol_results,
+                "accepted_lineage_count": sum(item["accepted_lineage_count"] for item in symbol_results),
+                "accepted_oos_count": accepted_oos_count,
+                "positive_oos_trade_count_total": positive_trades,
+                "rejection_reasons": rejection_reasons,
+                "window_outcome": "accepted_oos_evidence" if accepted_oos_count > 0 else "non_positive_oos_trade_count",
+                "recommended_next_action": dict(next_action or {}),
+            }
+        )
+
+    regime_summary: dict[str, dict[str, Any]] = {}
+    for window in window_results:
+        regime = _text(window.get("regime_label")) or "unclassified"
+        bucket = regime_summary.setdefault(
+            regime,
+            {
+                "regime_label": regime,
+                "window_count": 0,
+                "accepted_window_count": 0,
+                "positive_oos_trade_count_total": 0,
+                "rejection_reasons": [],
+            },
+        )
+        bucket["window_count"] += 1
+        if int(window["accepted_oos_count"]) > 0:
+            bucket["accepted_window_count"] += 1
+        bucket["positive_oos_trade_count_total"] += int(window["positive_oos_trade_count_total"])
+        bucket["rejection_reasons"] = _unique_in_order(
+            [*bucket["rejection_reasons"], *list(window["rejection_reasons"] or [])]
+        )
+
+    accepted_lineage_count = sum(int(window["accepted_lineage_count"]) for window in window_results)
+    accepted_oos_count = sum(int(window["accepted_oos_count"]) for window in window_results)
+    positive_oos_trade_count_total = sum(int(window["positive_oos_trade_count_total"]) for window in window_results)
+    accepted_window_count = sum(1 for window in window_results if int(window["accepted_oos_count"]) > 0)
+    failed_window_count = len(window_results) - accepted_window_count
+    rejection_reasons = _unique_in_order(
+        [reason for window in window_results for reason in window.get("rejection_reasons", [])]
+    )
+    if accepted_oos_count > 0 and accepted_window_count >= int(campaign_plan["minimum_required_windows"]) and positive_oos_trade_count_total >= int(campaign_plan["minimum_total_oos_trades"]):
+        campaign_outcome = "accepted_multiwindow_oos_evidence"
+    elif accepted_oos_count > 0 and positive_oos_trade_count_total < int(campaign_plan["minimum_total_oos_trades"]):
+        campaign_outcome = "insufficient_total_oos_trades"
+    elif accepted_oos_count > 0:
+        campaign_outcome = "partial_oos_evidence"
+    elif failed_window_count == len(window_results) and rejection_reasons and set(rejection_reasons) == {"non_positive_oos_trade_count"}:
+        campaign_outcome = "all_windows_non_positive_trade_count"
+    else:
+        campaign_outcome = "hypothesis_not_supported"
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "campaign_id": campaign_plan["campaign_id"],
+        "sampling_plan_id": sampling_plan_payload["sampling_plan_id"],
+        "sampling_plan_hash": sampling_plan_payload["hash"],
+        "campaign_plan_hash": campaign_plan["hash"],
+        "window_results": window_results,
+        "regime_results": list(regime_summary.values()),
+        "accepted_lineage_count": accepted_lineage_count,
+        "accepted_oos_count": accepted_oos_count,
+        "positive_oos_trade_count_total": positive_oos_trade_count_total,
+        "failed_window_count": failed_window_count,
+        "accepted_window_count": accepted_window_count,
+        "rejection_reasons": rejection_reasons,
+        "null_control_results": {
+            "status": "not_run_due_to_no_accepted_oos" if accepted_oos_count == 0 else "pending_manual_null_control_review"
+        },
+        "campaign_outcome": campaign_outcome,
+        "can_clear_blockers": False,
+        "can_promote_candidate": False,
+        "can_activate_deployment": False,
+    }
+    report["hash"] = compute_campaign_run_hash(report)
+    return report
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    _write_json(latest, report)
+    summary = [
+        "# QRE Preregistered Multi-Window Evidence Run",
+        "",
+        f"- campaign_id: {report.get('campaign_id', '')}",
+        f"- accepted_lineage_count: {report.get('accepted_lineage_count', 0)}",
+        f"- accepted_oos_count: {report.get('accepted_oos_count', 0)}",
+        f"- positive_oos_trade_count_total: {report.get('positive_oos_trade_count_total', 0)}",
+        f"- campaign_outcome: {report.get('campaign_outcome', '')}",
+        "",
+    ]
+    summary_path.write_text("\n".join(summary), encoding="utf-8")
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_preregistered_multiwindow_evidence_run",
+        description="Execute the preregistered multi-window local-only evidence campaign.",
+    )
+    parser.add_argument("--approval-file", default=DEFAULT_APPROVAL_PATH.as_posix())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_preregistered_multiwindow_evidence_run(
+        approval_manifest=_read_json(Path(args.approval_file)),
+    )
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/qre_preregistered_multiwindow_validation.py
+++ b/research/qre_preregistered_multiwindow_validation.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any, Final, Literal
+
+from research import qre_bounded_validation_approval_gate as approval_gate
+from research import qre_sampling_plan as sampling_plan
+
+
+CampaignStatus = Literal[
+    "campaign_ready_preregistered_context",
+    "blocked_invalid_sampling_plan",
+    "blocked_invalid_approval",
+    "blocked_external_fetch_not_allowed",
+    "blocked_output_path_not_allowlisted",
+    "blocked_outcome_based_window_selection",
+]
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_preregistered_multiwindow_validation"
+NON_AUTHORITATIVE: Final[bool] = True
+CAN_AUTHORIZE_EXECUTION: Final[bool] = False
+CAN_CLEAR_EVIDENCE_BLOCKERS: Final[bool] = False
+CAN_PROMOTE_CANDIDATE: Final[bool] = False
+EVIDENCE_AUTHORITY: Final[str] = "context_only"
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _unique_in_order(values: Sequence[Any]) -> list[str]:
+    return list(dict.fromkeys(_text(value) for value in values if _text(value)))
+
+
+def _request_from_approval(approval_manifest: Mapping[str, Any]) -> dict[str, Any]:
+    scope = approval_manifest.get("scope") if isinstance(approval_manifest.get("scope"), Mapping) else {}
+    return {
+        "request_id": f"preregistered-multiwindow-{_text(approval_manifest.get('approval_id'))}",
+        "symbols": list(scope.get("symbols") or approval_manifest.get("symbols") or []),
+        "preset_id": _text(scope.get("preset_id") or approval_manifest.get("preset_id")),
+        "timeframe": _text(scope.get("timeframe") or approval_manifest.get("timeframe")),
+        "approval_ref": _text(approval_manifest.get("approval_id")),
+        "allowed_output_paths": list(approval_manifest.get("allowed_output_paths") or []),
+        "forbidden_capabilities": list(approval_manifest.get("forbidden_capabilities") or []),
+        "required_artifact_types": [
+            "structured_lineage_artifact",
+            "structured_oos_artifact",
+        ],
+    }
+
+
+def compute_campaign_hash(report: Mapping[str, Any]) -> str:
+    canonical = {
+        "schema_version": report.get("schema_version", SCHEMA_VERSION),
+        "report_kind": report.get("report_kind", REPORT_KIND),
+        "campaign_id": report.get("campaign_id", ""),
+        "sampling_plan_ref": report.get("sampling_plan_ref", ""),
+        "sampling_plan_hash": report.get("sampling_plan_hash", ""),
+        "approval_ref": report.get("approval_ref", ""),
+        "window_run_specs": list(report.get("window_run_specs", [])),
+        "regime_run_specs": list(report.get("regime_run_specs", [])),
+        "execution_order": list(report.get("execution_order", [])),
+        "stopping_rules": list(report.get("stopping_rules", [])),
+        "acceptance_rules": list(report.get("acceptance_rules", [])),
+        "rejection_rules": list(report.get("rejection_rules", [])),
+        "status": report.get("status", ""),
+        "authority": dict(report.get("authority", {})),
+    }
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build_preregistered_multiwindow_validation(
+    *,
+    sampling_plan_payload: Mapping[str, Any],
+    approval_manifest: Mapping[str, Any],
+    local_source_ref: str,
+    minimum_required_windows: int,
+    minimum_total_oos_trades: int,
+    per_window_minimum_oos_trades: int,
+    null_control_requirements: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    sampling_validation = sampling_plan.validate_sampling_plan(sampling_plan_payload)
+    request = _request_from_approval(approval_manifest)
+    gate = approval_gate.build_bounded_validation_approval_gate(
+        {
+            "approval_id": _text(approval_manifest.get("approval_id")),
+            "approved_by": _text(approval_manifest.get("approved_by")),
+            "approved_at_utc": _text(approval_manifest.get("approved_at_utc")),
+            "expires_at_utc": _text(approval_manifest.get("expiry_utc") or approval_manifest.get("expires_at_utc")),
+            "symbols": list((approval_manifest.get("scope") or {}).get("symbols") or approval_manifest.get("symbols") or []),
+            "preset_id": _text((approval_manifest.get("scope") or {}).get("preset_id") or approval_manifest.get("preset_id")),
+            "timeframe": _text((approval_manifest.get("scope") or {}).get("timeframe") or approval_manifest.get("timeframe")),
+            "allowed_command_class": _text(approval_manifest.get("allowed_command_class")),
+            "allowed_output_paths": list(approval_manifest.get("allowed_output_paths") or []),
+            "forbidden_capabilities": list(approval_manifest.get("forbidden_capabilities") or []),
+            "dry_run_allowed": bool(approval_manifest.get("dry_run_allowed", False)),
+            "real_run_allowed": bool(approval_manifest.get("real_run_allowed", False)),
+            "external_fetch_allowed": bool(approval_manifest.get("external_fetch_allowed", False)),
+            "evidence_acceptance_allowed": bool(approval_manifest.get("evidence_acceptance_allowed", False)),
+        },
+        request,
+        evaluated_at_utc=_text(approval_manifest.get("approved_at_utc")),
+        requested_external_fetch=False,
+        require_real_run=True,
+        require_evidence_acceptance=True,
+    )
+    blocked_reasons: list[str] = []
+    status: CampaignStatus = "campaign_ready_preregistered_context"
+    if sampling_validation["valid"] is not True or _text(sampling_plan_payload.get("status")) != "sampling_plan_ready_context_only":
+        status = "blocked_invalid_sampling_plan"
+        blocked_reasons.extend(list(sampling_validation.get("rejection_reasons") or []))
+        blocked_reasons.extend(_unique_in_order(sampling_plan_payload.get("blocked_reasons") or []))
+    elif gate["approval_gate_status"] != "approval_valid_for_bounded_validation":
+        status = "blocked_invalid_approval"
+        blocked_reasons.extend(list(gate.get("rejection_reasons") or []))
+    elif bool(approval_manifest.get("external_fetch_allowed", False)):
+        status = "blocked_external_fetch_not_allowed"
+        blocked_reasons.append("external_fetch_must_remain_false")
+    elif any("output_path_not_allowlisted" in reason for reason in gate.get("rejection_reasons") or []):
+        status = "blocked_output_path_not_allowlisted"
+        blocked_reasons.extend(list(gate.get("rejection_reasons") or []))
+    elif any(
+        "profit" in _text(rule).lower() or "sharpe" in _text(rule).lower()
+        for rule in sampling_plan_payload.get("selection_policy", "")
+    ):
+        status = "blocked_outcome_based_window_selection"
+        blocked_reasons.append("outcome_based_window_selection")
+
+    windows = list(sampling_plan_payload.get("window_definitions") or [])
+    symbols = list(request.get("symbols") or [])
+    window_run_specs = [
+        {
+            "window_id": _text(window.get("window_id")),
+            "bounded_input_window": dict(window.get("bounded_input_window") or {}),
+            "oos_window": dict(window.get("oos_window") or {}),
+            "regime_label": _text(window.get("regime_label")) or "unclassified",
+            "symbols": symbols,
+            "preset_id": request["preset_id"],
+            "timeframe": request["timeframe"],
+            "source_data_ref": local_source_ref,
+            "locked": bool(window.get("locked", False)),
+        }
+        for window in windows
+    ]
+    regime_counts = Counter(_text(window.get("regime_label")) or "unclassified" for window in windows)
+    regime_run_specs = [
+        {"regime_label": regime_label, "window_count": count}
+        for regime_label, count in sorted(regime_counts.items())
+    ]
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "campaign_id": "qmwv_"
+        + hashlib.sha256(
+            json.dumps(
+                {
+                    "sampling_plan_id": sampling_plan_payload.get("sampling_plan_id"),
+                    "approval_id": approval_manifest.get("approval_id"),
+                    "symbols": symbols,
+                    "window_ids": [_text(window.get("window_id")) for window in windows],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("utf-8")
+        ).hexdigest()[:16],
+        "sampling_plan_ref": _text(sampling_plan_payload.get("sampling_plan_id")),
+        "sampling_plan_hash": _text(sampling_plan_payload.get("hash")),
+        "approval_ref": _text(approval_manifest.get("approval_id")),
+        "approval_gate": gate,
+        "window_run_specs": window_run_specs,
+        "regime_run_specs": regime_run_specs,
+        "execution_order": [_text(window.get("window_id")) for window in windows],
+        "stopping_rules": [
+            "execute_all_preregistered_windows_in_order",
+            "do_not_stop_early_for_positive_results",
+            "do_not_add_windows_after_execution_starts",
+            "stop_on_approval_expiry_or_safety_failure",
+            "stop_if_external_fetch_becomes_required_without_approval",
+        ],
+        "acceptance_rules": [
+            f"minimum_required_windows:{int(minimum_required_windows)}",
+            f"minimum_total_oos_trades:{int(minimum_total_oos_trades)}",
+            f"per_window_minimum_oos_trades:{int(per_window_minimum_oos_trades)}",
+            "accepted_oos_requires_positive_trade_count_and_complete_structured_fields",
+            "null_control_must_pass_for_evidence_complete",
+        ],
+        "rejection_rules": [
+            "not_supported_across_preregistered_windows",
+            "insufficient_total_oos_trades",
+            "null_control_failed",
+            "blocked_incomplete_evidence",
+            "operator_review_required",
+        ],
+        "null_control_requirements": [dict(item) for item in null_control_requirements],
+        "minimum_required_windows": int(minimum_required_windows),
+        "minimum_total_oos_trades": int(minimum_total_oos_trades),
+        "per_window_minimum_oos_trades": int(per_window_minimum_oos_trades),
+        "local_source_ref": local_source_ref,
+        "authority": {
+            "non_authoritative": NON_AUTHORITATIVE,
+            "can_authorize_execution": CAN_AUTHORIZE_EXECUTION,
+            "can_clear_evidence_blockers": CAN_CLEAR_EVIDENCE_BLOCKERS,
+            "can_promote_candidate": CAN_PROMOTE_CANDIDATE,
+            "evidence_authority": EVIDENCE_AUTHORITY,
+        },
+        "status": status,
+        "blocked_reasons": _unique_in_order(blocked_reasons),
+    }
+    report["hash"] = compute_campaign_hash(report)
+    return report

--- a/research/qre_sampling_plan.py
+++ b/research/qre_sampling_plan.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, Final, Literal
+
+
+SamplingPlanStatus = Literal[
+    "sampling_plan_ready_context_only",
+    "blocked_missing_hypothesis",
+    "blocked_missing_preset",
+    "blocked_missing_timeframe",
+    "blocked_insufficient_range",
+    "blocked_invalid_window",
+    "blocked_overlapping_windows",
+    "blocked_missing_null_control",
+    "blocked_outcome_based_selection",
+    "blocked_not_preregistered",
+]
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_sampling_plan"
+NON_AUTHORITATIVE: Final[bool] = True
+CAN_AUTHORIZE_EXECUTION: Final[bool] = False
+CAN_CLEAR_EVIDENCE_BLOCKERS: Final[bool] = False
+CAN_PROMOTE_CANDIDATE: Final[bool] = False
+EVIDENCE_AUTHORITY: Final[str] = "context_only"
+DEFAULT_SELECTION_POLICY: Final[str] = "deterministic_preregistered_windows_only"
+DEFAULT_FORBIDDEN_ADAPTATIONS: Final[tuple[str, ...]] = (
+    "profitability_based_window_selection",
+    "return_based_window_selection",
+    "sharpe_based_window_selection",
+    "parameter_tuning_against_oos_window",
+    "post_hoc_window_redefinition",
+    "in_sample_to_oos_relabeling",
+)
+OUTCOME_KEYWORDS: Final[tuple[str, ...]] = (
+    "profit",
+    "pnl",
+    "return",
+    "sharpe",
+    "drawdown",
+    "win_rate",
+    "outcome",
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _unique_in_order(values: Sequence[Any]) -> list[str]:
+    return list(dict.fromkeys(_text(value) for value in values if _text(value)))
+
+
+def _normalize_date_text(value: Any) -> str:
+    text = _text(value)
+    if not text:
+        return ""
+    return text[:10]
+
+
+def _date_key(value: Any) -> tuple[int, int, int]:
+    text = _normalize_date_text(value)
+    if not text:
+        return (0, 0, 0)
+    year, month, day = text.split("-")
+    return (int(year), int(month), int(day))
+
+
+def _contains_outcome_language(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return any(
+            _contains_outcome_language(key) or _contains_outcome_language(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return any(_contains_outcome_language(item) for item in value)
+    lowered = _text(value).lower()
+    return any(keyword in lowered for keyword in OUTCOME_KEYWORDS)
+
+
+def _canonical_window(window: Mapping[str, Any], *, index: int) -> dict[str, Any]:
+    return {
+        "window_id": _text(window.get("window_id")) or f"window_{index:02d}",
+        "bounded_input_window": {
+            "start": _normalize_date_text((window.get("bounded_input_window") or {}).get("start")),
+            "end": _normalize_date_text((window.get("bounded_input_window") or {}).get("end")),
+        },
+        "oos_window": {
+            "start": _normalize_date_text((window.get("oos_window") or {}).get("start")),
+            "end": _normalize_date_text((window.get("oos_window") or {}).get("end")),
+        },
+        "role": _text(window.get("role")) or "oos",
+        "regime_label": _text(window.get("regime_label")) or "unclassified",
+        "locked": bool(window.get("locked", False)),
+        "justification": _text(window.get("justification")),
+    }
+
+
+def _validate_windows(window_definitions: Sequence[Mapping[str, Any]]) -> tuple[str | None, list[str], list[dict[str, Any]]]:
+    normalized = [_canonical_window(window, index=index + 1) for index, window in enumerate(window_definitions)]
+    seen_ids: set[str] = set()
+    errors: list[str] = []
+    spans: list[tuple[tuple[int, int, int], tuple[int, int, int], str]] = []
+    for window in normalized:
+        window_id = window["window_id"]
+        if window_id in seen_ids:
+            errors.append(f"duplicate_window_id:{window_id}")
+        seen_ids.add(window_id)
+        bounded_start = window["bounded_input_window"]["start"]
+        bounded_end = window["bounded_input_window"]["end"]
+        oos_start = window["oos_window"]["start"]
+        oos_end = window["oos_window"]["end"]
+        if not bounded_start or not bounded_end or not oos_start or not oos_end:
+            errors.append(f"invalid_window_bounds:{window_id}")
+            continue
+        if _date_key(bounded_start) >= _date_key(bounded_end):
+            errors.append(f"invalid_bounded_window:{window_id}")
+        if _date_key(oos_start) >= _date_key(oos_end):
+            errors.append(f"invalid_oos_window:{window_id}")
+        if _date_key(oos_start) < _date_key(bounded_start) or _date_key(oos_end) > _date_key(bounded_end):
+            errors.append(f"oos_window_outside_bounded_window:{window_id}")
+        if window["role"] != "oos":
+            errors.append(f"invalid_window_role:{window_id}")
+        if window["locked"] is not True:
+            errors.append(f"window_not_locked:{window_id}")
+        spans.append((_date_key(oos_start), _date_key(oos_end), window_id))
+    ordered_spans = sorted(spans, key=lambda item: (item[0], item[1], item[2]))
+    for left, right in zip(ordered_spans, ordered_spans[1:]):
+        if right[0] <= left[1]:
+            errors.append(f"overlapping_oos_windows:{left[2]}:{right[2]}")
+    if any(error.startswith("overlapping_oos_windows:") for error in errors):
+        return "blocked_overlapping_windows", errors, normalized
+    if errors:
+        return "blocked_invalid_window", errors, normalized
+    return None, [], normalized
+
+
+def derive_preregistered_windows(
+    *,
+    trading_dates: Sequence[Any],
+    window_count: int,
+    minimum_window_length: int,
+    minimum_warmup_period: int,
+    regime_labels: Sequence[str] | None = None,
+) -> list[dict[str, Any]]:
+    ordered_dates = sorted({_normalize_date_text(value) for value in trading_dates if _normalize_date_text(value)})
+    if window_count <= 0:
+        raise ValueError("window_count_must_be_positive")
+    if minimum_window_length <= 0:
+        raise ValueError("minimum_window_length_must_be_positive")
+    if minimum_warmup_period < 0:
+        raise ValueError("minimum_warmup_period_must_be_non_negative")
+    if len(ordered_dates) < minimum_window_length * window_count:
+        raise ValueError("insufficient_range_for_preregistered_windows")
+    base_length = len(ordered_dates) // window_count
+    remainder = len(ordered_dates) % window_count
+    cursor = 0
+    windows: list[dict[str, Any]] = []
+    labels = list(regime_labels or [])
+    for index in range(window_count):
+        current_length = base_length + (1 if index < remainder else 0)
+        slice_dates = ordered_dates[cursor : cursor + current_length]
+        cursor += current_length
+        if len(slice_dates) < minimum_window_length:
+            raise ValueError("insufficient_window_length")
+        split_index = max(minimum_warmup_period, int(len(slice_dates) * 0.7))
+        if split_index >= len(slice_dates):
+            raise ValueError("invalid_oos_split")
+        regime_label = _text(labels[index]) if index < len(labels) else "unclassified"
+        windows.append(
+            {
+                "window_id": f"window_{index + 1:02d}",
+                "bounded_input_window": {
+                    "start": slice_dates[0],
+                    "end": slice_dates[-1],
+                },
+                "oos_window": {
+                    "start": slice_dates[split_index],
+                    "end": slice_dates[-1],
+                },
+                "role": "oos",
+                "regime_label": regime_label or "unclassified",
+                "locked": True,
+                "justification": "deterministic_non_overlapping_partition",
+            }
+        )
+    return windows
+
+
+def compute_sampling_plan_hash(plan: Mapping[str, Any]) -> str:
+    canonical = {
+        "schema_version": plan.get("schema_version", SCHEMA_VERSION),
+        "report_kind": plan.get("report_kind", REPORT_KIND),
+        "sampling_plan_id": plan.get("sampling_plan_id", ""),
+        "hypothesis_ref": plan.get("hypothesis_ref", ""),
+        "behavior_id": plan.get("behavior_id", ""),
+        "preset_id": plan.get("preset_id", ""),
+        "timeframe": plan.get("timeframe", ""),
+        "window_definitions": list(plan.get("window_definitions", [])),
+        "regime_buckets": list(plan.get("regime_buckets", [])),
+        "null_control_definitions": list(plan.get("null_control_definitions", [])),
+        "minimum_trade_requirement": int(plan.get("minimum_trade_requirement", 0) or 0),
+        "minimum_window_length": int(plan.get("minimum_window_length", 0) or 0),
+        "known_previous_failed_windows": list(plan.get("known_previous_failed_windows", [])),
+        "preregistration_timestamp": plan.get("preregistration_timestamp", ""),
+        "selection_policy": plan.get("selection_policy", ""),
+        "forbidden_adaptations": list(plan.get("forbidden_adaptations", [])),
+        "authority": dict(plan.get("authority", {})),
+        "status": plan.get("status", ""),
+    }
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build_preregistered_sampling_plan(
+    *,
+    hypothesis_ref: str | None = None,
+    hypothesis: Mapping[str, Any] | None = None,
+    behavior_id: str,
+    preset_id: str | None,
+    timeframe: str | None,
+    bounded_source_data_availability: Mapping[str, Any] | None = None,
+    proposed_total_validation_range: Mapping[str, Any] | None = None,
+    minimum_window_length: int,
+    minimum_warmup_period: int,
+    required_oos_evidence_types: Sequence[str],
+    null_control_definitions: Sequence[Mapping[str, Any]] | None,
+    known_previous_failed_windows: Sequence[Mapping[str, Any]] | None = None,
+    regime_buckets: Sequence[Mapping[str, Any]] | None = None,
+    window_definitions: Sequence[Mapping[str, Any]] | None = None,
+    trading_dates: Sequence[Any] | None = None,
+    window_count: int | None = None,
+    preregistration_timestamp: str | None = None,
+    minimum_trade_requirement: int = 1,
+    selection_policy: str = DEFAULT_SELECTION_POLICY,
+    forbidden_adaptations: Sequence[str] = DEFAULT_FORBIDDEN_ADAPTATIONS,
+) -> dict[str, Any]:
+    hypothesis_id = _text((hypothesis or {}).get("hypothesis_id")) or _text(hypothesis_ref)
+    timestamp = _text(preregistration_timestamp) or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    if not hypothesis_id:
+        status: SamplingPlanStatus = "blocked_missing_hypothesis"
+        blocked_reasons = ["missing_hypothesis"]
+        normalized_windows: list[dict[str, Any]] = []
+    elif not _text(preset_id):
+        status = "blocked_missing_preset"
+        blocked_reasons = ["missing_preset_id"]
+        normalized_windows = []
+    elif not _text(timeframe):
+        status = "blocked_missing_timeframe"
+        blocked_reasons = ["missing_timeframe"]
+        normalized_windows = []
+    elif not null_control_definitions:
+        status = "blocked_missing_null_control"
+        blocked_reasons = ["missing_null_control_definition"]
+        normalized_windows = []
+    elif not timestamp:
+        status = "blocked_not_preregistered"
+        blocked_reasons = ["missing_preregistration_timestamp"]
+        normalized_windows = []
+    elif _contains_outcome_language(selection_policy):
+        status = "blocked_outcome_based_selection"
+        blocked_reasons = ["outcome_based_selection_detected"]
+        normalized_windows = []
+    else:
+        candidate_windows = list(window_definitions or [])
+        if not candidate_windows:
+            if not trading_dates or not window_count:
+                status = "blocked_insufficient_range"
+                blocked_reasons = ["insufficient_range_for_preregistered_windows"]
+                normalized_windows = []
+            else:
+                try:
+                    candidate_windows = derive_preregistered_windows(
+                        trading_dates=trading_dates,
+                        window_count=window_count,
+                        minimum_window_length=minimum_window_length,
+                        minimum_warmup_period=minimum_warmup_period,
+                        regime_labels=[
+                            _text(bucket.get("regime_label")) if isinstance(bucket, Mapping) else _text(bucket)
+                            for bucket in (regime_buckets or [])
+                        ],
+                    )
+                except ValueError as exc:
+                    status = "blocked_insufficient_range"
+                    blocked_reasons = [str(exc)]
+                    normalized_windows = []
+                else:
+                    status = "sampling_plan_ready_context_only"
+                    blocked_reasons = []
+                    _, blocked_reasons, normalized_windows = _validate_windows(candidate_windows)
+                    if blocked_reasons:
+                        status = "blocked_overlapping_windows" if any(
+                            reason.startswith("overlapping_oos_windows:") for reason in blocked_reasons
+                        ) else "blocked_invalid_window"
+        else:
+            derived_status, blocked_reasons, normalized_windows = _validate_windows(candidate_windows)
+            status = derived_status or "sampling_plan_ready_context_only"
+    authority = {
+        "non_authoritative": NON_AUTHORITATIVE,
+        "can_authorize_execution": CAN_AUTHORIZE_EXECUTION,
+        "can_clear_evidence_blockers": CAN_CLEAR_EVIDENCE_BLOCKERS,
+        "can_promote_candidate": CAN_PROMOTE_CANDIDATE,
+        "evidence_authority": EVIDENCE_AUTHORITY,
+    }
+    plan_seed = {
+        "hypothesis_ref": hypothesis_id,
+        "behavior_id": _text(behavior_id),
+        "preset_id": _text(preset_id),
+        "timeframe": _text(timeframe),
+        "window_definitions": normalized_windows,
+        "timestamp": timestamp,
+    }
+    sampling_plan_id = "qsp_" + hashlib.sha256(
+        json.dumps(plan_seed, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()[:16]
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "sampling_plan_id": sampling_plan_id,
+        "hypothesis_ref": hypothesis_id,
+        "behavior_id": _text(behavior_id),
+        "preset_id": _text(preset_id),
+        "timeframe": _text(timeframe),
+        "bounded_source_data_availability": dict(bounded_source_data_availability or {}),
+        "proposed_total_validation_range": dict(proposed_total_validation_range or {}),
+        "required_oos_evidence_types": _unique_in_order(required_oos_evidence_types),
+        "window_definitions": normalized_windows,
+        "regime_buckets": [
+            {
+                "regime_label": _text(bucket.get("regime_label")) if isinstance(bucket, Mapping) else _text(bucket),
+                "selection_basis": _text((bucket or {}).get("selection_basis")) if isinstance(bucket, Mapping) else "",
+            }
+            for bucket in (regime_buckets or [])
+        ],
+        "null_control_definitions": [dict(item) for item in (null_control_definitions or [])],
+        "minimum_trade_requirement": int(minimum_trade_requirement),
+        "minimum_window_length": int(minimum_window_length),
+        "minimum_warmup_period": int(minimum_warmup_period),
+        "known_previous_failed_windows": [dict(item) for item in (known_previous_failed_windows or [])],
+        "preregistration_timestamp": timestamp,
+        "selection_policy": selection_policy,
+        "forbidden_adaptations": _unique_in_order(forbidden_adaptations),
+        "authority": authority,
+        "status": status,
+        "blocked_reasons": blocked_reasons,
+    }
+    plan["hash"] = compute_sampling_plan_hash(plan)
+    return plan
+
+
+def validate_sampling_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    rejection_reasons: list[str] = []
+    if plan.get("authority", {}).get("non_authoritative") is not True:
+        rejection_reasons.append("non_authoritative_must_be_true")
+    if plan.get("authority", {}).get("can_authorize_execution") is not False:
+        rejection_reasons.append("can_authorize_execution_must_be_false")
+    if plan.get("authority", {}).get("can_clear_evidence_blockers") is not False:
+        rejection_reasons.append("can_clear_evidence_blockers_must_be_false")
+    if plan.get("authority", {}).get("can_promote_candidate") is not False:
+        rejection_reasons.append("can_promote_candidate_must_be_false")
+    if plan.get("authority", {}).get("evidence_authority") != EVIDENCE_AUTHORITY:
+        rejection_reasons.append("invalid_evidence_authority")
+    if _contains_outcome_language(plan.get("selection_policy")):
+        rejection_reasons.append("selection_policy_contains_outcome_language")
+    recomputed_hash = compute_sampling_plan_hash(plan)
+    if _text(plan.get("hash")) and _text(plan.get("hash")) != recomputed_hash:
+        rejection_reasons.append("hash_mismatch")
+    return {
+        "valid": not rejection_reasons,
+        "rejection_reasons": rejection_reasons,
+        "hash": recomputed_hash,
+        "schema_version": SCHEMA_VERSION,
+    }

--- a/tests/unit/test_qre_failure_to_action_mapper.py
+++ b/tests/unit/test_qre_failure_to_action_mapper.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_failure_to_action_mapper as mapper
+
+
+def test_non_positive_oos_trade_count_maps_to_next_window_when_available() -> None:
+    report = mapper.map_failure_to_action(
+        failure_class="non_positive_oos_trade_count",
+        remaining_preregistered_window_count=2,
+    )
+
+    assert report["recommended_action"] == "run_next_preregistered_window"
+    assert report["action_authority"] == "approval_required"
+    assert report["can_execute"] is False
+    assert mapper.validate_failure_action_mapping(report)["valid"] is True
+
+
+def test_final_failed_window_maps_to_hypothesis_rejection() -> None:
+    report = mapper.map_failure_to_action(
+        failure_class="non_positive_oos_trade_count",
+        remaining_preregistered_window_count=0,
+        remaining_preregistered_regime_count=0,
+    )
+
+    assert report["recommended_action"] == "reject_hypothesis"
+    assert "no_remaining_preregistered_windows" in report["reason_codes"]
+
+
+def test_no_action_clears_blockers_executes_or_tunes() -> None:
+    report = mapper.map_failure_to_action(failure_class="missing_oos_metrics")
+
+    assert report["can_execute"] is False
+    assert report["can_mutate_queue"] is False
+    assert report["can_clear_blocker"] is False
+    assert report["can_redefine_window"] is False
+    assert report["can_tune_strategy"] is False
+
+
+def test_unknown_failure_fails_closed() -> None:
+    report = mapper.map_failure_to_action(failure_class="mystery_failure")
+
+    assert report["recommended_action"] == "route_to_operator_review"
+    assert report["reason_codes"] == ["unknown_failure_fail_closed"]
+
+
+def test_mapping_is_deterministic() -> None:
+    first = mapper.map_failure_to_action(
+        failure_class="all_preregistered_windows_failed",
+    )
+    second = mapper.map_failure_to_action(
+        failure_class="all_preregistered_windows_failed",
+    )
+
+    assert first == second
+    assert first["hash"] == mapper.compute_failure_action_hash(first)
+
+
+def test_mapper_core_has_no_symbol_hardcoding() -> None:
+    source = Path("research/qre_failure_to_action_mapper.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source

--- a/tests/unit/test_qre_multiwindow_evidence_closure.py
+++ b/tests/unit/test_qre_multiwindow_evidence_closure.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_multiwindow_evidence_closure as closure
+
+
+def _campaign(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "campaign_id": "camp-001",
+        "sampling_plan_id": "plan-001",
+        "accepted_lineage_count": 2,
+        "accepted_oos_count": 0,
+        "positive_oos_trade_count_total": 0,
+        "campaign_outcome": "all_windows_non_positive_trade_count",
+        "window_results": [
+            {
+                "window_id": "window_01",
+                "accepted_oos_count": 0,
+                "rejection_reasons": ["non_positive_oos_trade_count"],
+            },
+            {
+                "window_id": "window_02",
+                "accepted_oos_count": 0,
+                "rejection_reasons": ["non_positive_oos_trade_count"],
+            },
+        ],
+        "null_control_results": {"status": "not_run_due_to_no_accepted_oos"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_complete_evidence_requires_all_criteria() -> None:
+    report = closure.build_multiwindow_evidence_closure(
+        _campaign(
+            accepted_oos_count=2,
+            positive_oos_trade_count_total=4,
+            campaign_outcome="accepted_multiwindow_oos_evidence",
+            null_control_results={"status": "passed"},
+        )
+    )
+
+    assert report["closure_status"] == "evidence_complete"
+    assert report["evidence_complete_count"] == 1
+
+
+def test_partial_accepted_windows_do_not_become_complete() -> None:
+    report = closure.build_multiwindow_evidence_closure(
+        _campaign(
+            accepted_oos_count=1,
+            positive_oos_trade_count_total=1,
+            campaign_outcome="partial_oos_evidence",
+        )
+    )
+
+    assert report["closure_status"] == "evidence_partial"
+    assert report["evidence_complete_count"] == 0
+
+
+def test_all_zero_windows_reject_hypothesis_fail_closed() -> None:
+    report = closure.build_multiwindow_evidence_closure(_campaign())
+
+    assert report["closure_status"] == "all_windows_no_oos_trades"
+    assert report["hypothesis_disposition"] == "fail_closed_rejected"
+    assert report["recommended_next_action"] == "reject_hypothesis"
+
+
+def test_missing_windows_block_closure() -> None:
+    report = closure.build_multiwindow_evidence_closure(
+        _campaign(window_results=[], campaign_outcome="blocked_approval")
+    )
+
+    assert report["closure_status"] == "blocked_incomplete_campaign"
+
+
+def test_null_control_failure_blocks_completion() -> None:
+    report = closure.build_multiwindow_evidence_closure(
+        _campaign(
+            accepted_oos_count=2,
+            positive_oos_trade_count_total=4,
+            campaign_outcome="accepted_multiwindow_oos_evidence",
+            null_control_results={"status": "failed"},
+        )
+    )
+
+    assert report["closure_status"] == "null_control_failed"
+    assert report["evidence_complete_count"] == 0
+
+
+def test_reason_records_and_authority_are_explicit() -> None:
+    report = closure.build_multiwindow_evidence_closure(_campaign())
+
+    assert report["reason_records"]
+    assert report["authority"]["can_promote_candidate"] is False
+    assert report["authority"]["can_activate_deployment"] is False
+
+
+def test_core_closure_has_no_symbol_hardcoding() -> None:
+    source = Path("research/qre_multiwindow_evidence_closure.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source

--- a/tests/unit/test_qre_preregistered_multiwindow_evidence_run.py
+++ b/tests/unit/test_qre_preregistered_multiwindow_evidence_run.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_failure_to_action_mapper as failure_mapper
+from research import qre_preregistered_multiwindow_evidence_run as run
+
+
+def _approval() -> dict[str, object]:
+    return {
+        "approval_id": "approval-multiwindow-001",
+        "approved_by": "operator:local",
+        "approved_at_utc": "2026-06-19T10:05:00Z",
+        "expiry_utc": "2026-06-21T10:05:00Z",
+        "scope": {
+            "symbols": ["AAA", "BBB"],
+            "preset_id": "trend_pullback_continuation_daily_v1",
+            "timeframe": "daily_v1",
+            "source_data_ref": "data/cache/market/local.parquet",
+            "window_definitions": [
+                {
+                    "window_id": "window_01",
+                    "bounded_input_window": {"start": "2026-04-08", "end": "2026-05-07"},
+                    "oos_window": {"start": "2026-04-29", "end": "2026-05-07"},
+                    "regime_label": "trend",
+                },
+                {
+                    "window_id": "window_02",
+                    "bounded_input_window": {"start": "2026-05-08", "end": "2026-06-08"},
+                    "oos_window": {"start": "2026-05-29", "end": "2026-06-08"},
+                    "regime_label": "high_volatility",
+                },
+            ],
+        },
+        "allowed_command_class": "bounded_controlled_validation",
+        "allowed_output_paths": list(run.ALLOWED_OUTPUT_PATHS),
+        "forbidden_capabilities": ["strategy_synthesis", "parameter_optimization", "external_fetch"],
+        "dry_run_allowed": True,
+        "real_run_allowed": True,
+        "evidence_acceptance_allowed": True,
+        "external_fetch_allowed": False,
+    }
+
+
+def test_all_preregistered_windows_execute_in_order_and_failures_remain_visible(monkeypatch) -> None:
+    monkeypatch.setattr(
+        run,
+        "build_sampling_plan_for_multiwindow_approval",
+        lambda **_: {
+            "sampling_plan_id": "plan-001",
+            "hash": "plan-hash",
+            "status": "sampling_plan_ready_context_only",
+            "window_definitions": [
+                {
+                    "window_id": "window_01",
+                    "bounded_input_window": {"start": "2026-04-08", "end": "2026-05-07"},
+                    "oos_window": {"start": "2026-04-29", "end": "2026-05-07"},
+                    "regime_label": "trend",
+                },
+                {
+                    "window_id": "window_02",
+                    "bounded_input_window": {"start": "2026-05-08", "end": "2026-06-08"},
+                    "oos_window": {"start": "2026-05-29", "end": "2026-06-08"},
+                    "regime_label": "high_volatility",
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        run,
+        "build_campaign_for_multiwindow_approval",
+        lambda **_: {
+            "campaign_id": "camp-001",
+            "hash": "camp-hash",
+            "sampling_plan_hash": "plan-hash",
+            "window_run_specs": [
+                {
+                    "window_id": "window_01",
+                    "bounded_input_window": {"start": "2026-04-08", "end": "2026-05-07"},
+                    "oos_window": {"start": "2026-04-29", "end": "2026-05-07"},
+                    "regime_label": "trend",
+                    "symbols": ["AAA"],
+                },
+                {
+                    "window_id": "window_02",
+                    "bounded_input_window": {"start": "2026-05-08", "end": "2026-06-08"},
+                    "oos_window": {"start": "2026-05-29", "end": "2026-06-08"},
+                    "regime_label": "high_volatility",
+                    "symbols": ["AAA"],
+                },
+            ],
+            "minimum_required_windows": 2,
+            "minimum_total_oos_trades": 1,
+            "status": "campaign_ready_preregistered_context",
+        },
+    )
+    monkeypatch.setattr(run.campaign_builder, "compute_campaign_hash", lambda _: "camp-hash")
+    calls: list[str] = []
+
+    def fake_classify_window_symbol(**kwargs):
+        calls.append(kwargs["window_spec"]["window_id"])
+        if kwargs["window_spec"]["window_id"] == "window_01":
+            return {
+                "window_id": "window_01",
+                "symbol": "AAA",
+                "accepted_lineage_count": 1,
+                "accepted_oos_count": 1,
+                "positive_oos_trade_count": 2,
+                "oos_trade_count": 2,
+                "classification": "accepted_for_campaign_lineage",
+                "rejection_reasons": [],
+                "lineage_records": [{"candidate_id": "cand-001"}],
+                "oos_records": [{"candidate_id": "cand-001"}],
+            }
+        return {
+            "window_id": "window_02",
+            "symbol": "AAA",
+            "accepted_lineage_count": 1,
+            "accepted_oos_count": 0,
+            "positive_oos_trade_count": 0,
+            "oos_trade_count": 0,
+            "classification": "accepted_for_campaign_lineage_only",
+            "rejection_reasons": ["non_positive_oos_trade_count"],
+            "lineage_records": [{"candidate_id": "cand-001"}],
+            "oos_records": [],
+        }
+
+    monkeypatch.setattr(run, "_classify_window_symbol", fake_classify_window_symbol)
+
+    report = run.build_preregistered_multiwindow_evidence_run(approval_manifest=_approval())
+
+    assert calls == ["window_01", "window_02"]
+    assert report["accepted_window_count"] == 1
+    assert report["failed_window_count"] == 1
+    assert report["window_results"][1]["rejection_reasons"] == ["non_positive_oos_trade_count"]
+    assert report["can_promote_candidate"] is False
+    assert report["can_activate_deployment"] is False
+
+
+def test_all_zero_windows_produce_fail_closed_outcome(monkeypatch) -> None:
+    monkeypatch.setattr(
+        run,
+        "build_sampling_plan_for_multiwindow_approval",
+        lambda **_: {"sampling_plan_id": "plan-001", "hash": "plan-hash", "status": "sampling_plan_ready_context_only"},
+    )
+    monkeypatch.setattr(
+        run,
+        "build_campaign_for_multiwindow_approval",
+        lambda **_: {
+            "campaign_id": "camp-001",
+            "hash": "camp-hash",
+            "sampling_plan_hash": "plan-hash",
+            "window_run_specs": [
+                {"window_id": "window_01", "regime_label": "trend", "symbols": ["AAA"]},
+                {"window_id": "window_02", "regime_label": "range", "symbols": ["AAA"]},
+            ],
+            "minimum_required_windows": 2,
+            "minimum_total_oos_trades": 1,
+            "status": "campaign_ready_preregistered_context",
+        },
+    )
+    monkeypatch.setattr(run.campaign_builder, "compute_campaign_hash", lambda _: "camp-hash")
+    monkeypatch.setattr(
+        run,
+        "_classify_window_symbol",
+        lambda **kwargs: {
+            "window_id": kwargs["window_spec"]["window_id"],
+            "symbol": "AAA",
+            "accepted_lineage_count": 1,
+            "accepted_oos_count": 0,
+            "positive_oos_trade_count": 0,
+            "oos_trade_count": 0,
+            "classification": "accepted_for_campaign_lineage_only",
+            "rejection_reasons": ["non_positive_oos_trade_count"],
+            "lineage_records": [],
+            "oos_records": [],
+        },
+    )
+
+    report = run.build_preregistered_multiwindow_evidence_run(approval_manifest=_approval())
+
+    assert report["campaign_outcome"] == "all_windows_non_positive_trade_count"
+    assert report["accepted_oos_count"] == 0
+    assert report["positive_oos_trade_count_total"] == 0
+
+
+def test_campaign_run_is_deterministic(monkeypatch) -> None:
+    monkeypatch.setattr(
+        run,
+        "build_sampling_plan_for_multiwindow_approval",
+        lambda **_: {"sampling_plan_id": "plan-001", "hash": "plan-hash", "status": "sampling_plan_ready_context_only"},
+    )
+    monkeypatch.setattr(
+        run,
+        "build_campaign_for_multiwindow_approval",
+        lambda **_: {
+            "campaign_id": "camp-001",
+            "hash": "camp-hash",
+            "sampling_plan_hash": "plan-hash",
+            "window_run_specs": [{"window_id": "window_01", "regime_label": "trend", "symbols": ["AAA"]}],
+            "minimum_required_windows": 1,
+            "minimum_total_oos_trades": 1,
+            "status": "campaign_ready_preregistered_context",
+        },
+    )
+    monkeypatch.setattr(run.campaign_builder, "compute_campaign_hash", lambda _: "camp-hash")
+    monkeypatch.setattr(
+        run,
+        "_classify_window_symbol",
+        lambda **kwargs: {
+            "window_id": "window_01",
+            "symbol": "AAA",
+            "accepted_lineage_count": 1,
+            "accepted_oos_count": 1,
+            "positive_oos_trade_count": 2,
+            "oos_trade_count": 2,
+            "classification": "accepted_for_campaign_lineage",
+            "rejection_reasons": [],
+            "lineage_records": [],
+            "oos_records": [],
+        },
+    )
+
+    first = run.build_preregistered_multiwindow_evidence_run(approval_manifest=_approval())
+    second = run.build_preregistered_multiwindow_evidence_run(approval_manifest=_approval())
+
+    assert first == second
+    assert first["hash"] == run.compute_campaign_run_hash(first)
+
+
+def test_core_run_has_no_symbol_hardcoding() -> None:
+    source = Path("research/qre_preregistered_multiwindow_evidence_run.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source

--- a/tests/unit/test_qre_preregistered_multiwindow_validation.py
+++ b/tests/unit/test_qre_preregistered_multiwindow_validation.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_preregistered_multiwindow_validation as campaign
+from research import qre_sampling_plan as sampling
+
+
+def _sampling_plan() -> dict[str, object]:
+    return sampling.build_preregistered_sampling_plan(
+        hypothesis_ref="trend_pullback_behavior_v1",
+        behavior_id="trend_pullback",
+        preset_id="trend_pullback_continuation_daily_v1",
+        timeframe="daily_v1",
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_lineage", "structured_oos"],
+        null_control_definitions=[{"control_id": "null_daily_holdout", "required": True}],
+        window_definitions=[
+            {
+                "window_id": "window_01",
+                "bounded_input_window": {"start": "2026-04-08", "end": "2026-05-07"},
+                "oos_window": {"start": "2026-04-29", "end": "2026-05-07"},
+                "role": "oos",
+                "regime_label": "trend",
+                "locked": True,
+            },
+            {
+                "window_id": "window_02",
+                "bounded_input_window": {"start": "2026-05-08", "end": "2026-06-08"},
+                "oos_window": {"start": "2026-05-29", "end": "2026-06-08"},
+                "role": "oos",
+                "regime_label": "high_volatility",
+                "locked": True,
+            },
+        ],
+        preregistration_timestamp="2026-06-19T10:00:00Z",
+    )
+
+
+def _approval(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "approval_id": "approval-multiwindow-001",
+        "approved_by": "operator:local",
+        "approved_at_utc": "2026-06-19T10:05:00Z",
+        "expiry_utc": "2026-06-21T10:05:00Z",
+        "scope": {
+            "symbols": ["AAA", "BBB"],
+            "preset_id": "trend_pullback_continuation_daily_v1",
+            "timeframe": "daily_v1",
+        },
+        "allowed_command_class": "bounded_controlled_validation",
+        "allowed_output_paths": [
+            "logs/qre_bounded_current_basket_generation_runner/",
+            "logs/qre_controlled_validation_adapter_results/",
+            "logs/qre_bounded_generation_artifact_acceptance_verifier/",
+            "logs/qre_evidence_complete_basket_closure/",
+        ],
+        "forbidden_capabilities": [
+            "strategy_synthesis",
+            "parameter_optimization",
+            "external_fetch",
+        ],
+        "dry_run_allowed": True,
+        "real_run_allowed": True,
+        "evidence_acceptance_allowed": True,
+        "external_fetch_allowed": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_campaign_is_deterministic_and_windows_stay_locked() -> None:
+    first = campaign.build_preregistered_multiwindow_validation(
+        sampling_plan_payload=_sampling_plan(),
+        approval_manifest=_approval(),
+        local_source_ref="data/cache/market/local.parquet",
+        minimum_required_windows=2,
+        minimum_total_oos_trades=1,
+        per_window_minimum_oos_trades=1,
+        null_control_requirements=[{"control_id": "null_daily_holdout", "required": True}],
+    )
+    second = campaign.build_preregistered_multiwindow_validation(
+        sampling_plan_payload=_sampling_plan(),
+        approval_manifest=_approval(),
+        local_source_ref="data/cache/market/local.parquet",
+        minimum_required_windows=2,
+        minimum_total_oos_trades=1,
+        per_window_minimum_oos_trades=1,
+        null_control_requirements=[{"control_id": "null_daily_holdout", "required": True}],
+    )
+
+    assert first == second
+    assert first["status"] == "campaign_ready_preregistered_context"
+    assert all(spec["locked"] is True for spec in first["window_run_specs"])
+    assert "do_not_stop_early_for_positive_results" in first["stopping_rules"]
+    assert campaign.compute_campaign_hash(first) == first["hash"]
+
+
+def test_invalid_approval_is_blocked() -> None:
+    report = campaign.build_preregistered_multiwindow_validation(
+        sampling_plan_payload=_sampling_plan(),
+        approval_manifest=_approval(real_run_allowed=False),
+        local_source_ref="data/cache/market/local.parquet",
+        minimum_required_windows=2,
+        minimum_total_oos_trades=1,
+        per_window_minimum_oos_trades=1,
+        null_control_requirements=[{"control_id": "null_daily_holdout", "required": True}],
+    )
+
+    assert report["status"] == "blocked_invalid_approval"
+    assert "real_run_not_allowed" in report["blocked_reasons"]
+
+
+def test_external_fetch_is_denied() -> None:
+    report = campaign.build_preregistered_multiwindow_validation(
+        sampling_plan_payload=_sampling_plan(),
+        approval_manifest=_approval(external_fetch_allowed=True),
+        local_source_ref="data/cache/market/local.parquet",
+        minimum_required_windows=2,
+        minimum_total_oos_trades=1,
+        per_window_minimum_oos_trades=1,
+        null_control_requirements=[{"control_id": "null_daily_holdout", "required": True}],
+    )
+
+    assert report["status"] == "blocked_external_fetch_not_allowed"
+
+
+def test_outcome_based_additions_and_strategy_tuning_are_not_present() -> None:
+    report = campaign.build_preregistered_multiwindow_validation(
+        sampling_plan_payload=_sampling_plan(),
+        approval_manifest=_approval(),
+        local_source_ref="data/cache/market/local.parquet",
+        minimum_required_windows=2,
+        minimum_total_oos_trades=1,
+        per_window_minimum_oos_trades=1,
+        null_control_requirements=[{"control_id": "null_daily_holdout", "required": True}],
+    )
+
+    serialized = json.dumps(report, sort_keys=True)
+    assert "sharpe" not in serialized.lower()
+    assert "profit" not in serialized.lower()
+    assert "parameter_tuning" not in "".join(report["acceptance_rules"]).lower()
+
+
+def test_core_campaign_has_no_symbol_hardcoding() -> None:
+    source = Path("research/qre_preregistered_multiwindow_validation.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source

--- a/tests/unit/test_qre_sampling_plan.py
+++ b/tests/unit/test_qre_sampling_plan.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_sampling_plan as sampling
+
+
+def _windows() -> list[dict[str, object]]:
+    return [
+        {
+            "window_id": "window_01",
+            "bounded_input_window": {"start": "2026-04-08", "end": "2026-05-08"},
+            "oos_window": {"start": "2026-04-30", "end": "2026-05-08"},
+            "role": "oos",
+            "regime_label": "trend",
+            "locked": True,
+        },
+        {
+            "window_id": "window_02",
+            "bounded_input_window": {"start": "2026-05-11", "end": "2026-06-08"},
+            "oos_window": {"start": "2026-05-31", "end": "2026-06-08"},
+            "role": "oos",
+            "regime_label": "high_volatility",
+            "locked": True,
+        },
+    ]
+
+
+def test_sampling_plan_is_deterministic_and_context_only() -> None:
+    first = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref="trend_pullback_behavior_v1",
+        behavior_id="trend_pullback",
+        preset_id="trend_pullback_continuation_daily_v1",
+        timeframe="daily_v1",
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_lineage", "structured_oos"],
+        null_control_definitions=[{"control_id": "null_daily_holdout", "required": True}],
+        window_definitions=_windows(),
+        preregistration_timestamp="2026-06-19T10:00:00Z",
+    )
+    second = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref="trend_pullback_behavior_v1",
+        behavior_id="trend_pullback",
+        preset_id="trend_pullback_continuation_daily_v1",
+        timeframe="daily_v1",
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_lineage", "structured_oos"],
+        null_control_definitions=[{"control_id": "null_daily_holdout", "required": True}],
+        window_definitions=_windows(),
+        preregistration_timestamp="2026-06-19T10:00:00Z",
+    )
+
+    assert first == second
+    assert first["status"] == "sampling_plan_ready_context_only"
+    assert first["authority"]["non_authoritative"] is True
+    assert first["authority"]["can_authorize_execution"] is False
+    assert first["authority"]["can_clear_evidence_blockers"] is False
+    assert first["authority"]["can_promote_candidate"] is False
+    assert sampling.validate_sampling_plan(first)["valid"] is True
+
+
+def test_sampling_plan_blocks_outcome_based_selection() -> None:
+    plan = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref="trend_pullback_behavior_v1",
+        behavior_id="trend_pullback",
+        preset_id="trend_pullback_continuation_daily_v1",
+        timeframe="daily_v1",
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_oos"],
+        null_control_definitions=[{"control_id": "null_daily_holdout", "required": True}],
+        window_definitions=_windows(),
+        preregistration_timestamp="2026-06-19T10:00:00Z",
+        selection_policy="choose highest sharpe windows",
+    )
+
+    assert plan["status"] == "blocked_outcome_based_selection"
+    assert "outcome_based_selection_detected" in plan["blocked_reasons"]
+
+
+def test_sampling_plan_blocks_invalid_and_overlapping_windows() -> None:
+    plan = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref="trend_pullback_behavior_v1",
+        behavior_id="trend_pullback",
+        preset_id="trend_pullback_continuation_daily_v1",
+        timeframe="daily_v1",
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_oos"],
+        null_control_definitions=[{"control_id": "null_daily_holdout", "required": True}],
+        window_definitions=[
+            {
+                "window_id": "window_01",
+                "bounded_input_window": {"start": "2026-04-08", "end": "2026-05-08"},
+                "oos_window": {"start": "2026-04-30", "end": "2026-05-08"},
+                "role": "oos",
+                "locked": True,
+            },
+            {
+                "window_id": "window_02",
+                "bounded_input_window": {"start": "2026-05-01", "end": "2026-06-08"},
+                "oos_window": {"start": "2026-05-07", "end": "2026-05-20"},
+                "role": "oos",
+                "locked": True,
+            },
+        ],
+        preregistration_timestamp="2026-06-19T10:00:00Z",
+    )
+
+    assert plan["status"] == "blocked_overlapping_windows"
+    assert any(reason.startswith("overlapping_oos_windows:") for reason in plan["blocked_reasons"])
+
+
+def test_sampling_plan_requires_null_control_and_preserves_failed_windows() -> None:
+    blocked = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref="trend_pullback_behavior_v1",
+        behavior_id="trend_pullback",
+        preset_id="trend_pullback_continuation_daily_v1",
+        timeframe="daily_v1",
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_oos"],
+        null_control_definitions=[],
+        window_definitions=_windows(),
+        preregistration_timestamp="2026-06-19T10:00:00Z",
+    )
+    assert blocked["status"] == "blocked_missing_null_control"
+
+    plan = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref="trend_pullback_behavior_v1",
+        behavior_id="trend_pullback",
+        preset_id="trend_pullback_continuation_daily_v1",
+        timeframe="daily_v1",
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_oos"],
+        null_control_definitions=[{"control_id": "null_daily_holdout", "required": True}],
+        known_previous_failed_windows=[{"window_id": "window_00", "failure_class": "non_positive_oos_trade_count"}],
+        window_definitions=_windows(),
+        preregistration_timestamp="2026-06-19T10:00:00Z",
+    )
+
+    assert plan["known_previous_failed_windows"][0]["window_id"] == "window_00"
+    assert plan["window_definitions"][0]["window_id"] == "window_01"
+
+
+def test_sampling_plan_can_derive_non_overlapping_windows() -> None:
+    windows = sampling.derive_preregistered_windows(
+        trading_dates=[
+            "2026-04-08",
+            "2026-04-09",
+            "2026-04-10",
+            "2026-04-13",
+            "2026-04-14",
+            "2026-04-15",
+            "2026-04-16",
+            "2026-04-17",
+            "2026-04-20",
+            "2026-04-21",
+            "2026-04-22",
+            "2026-04-23",
+            "2026-04-24",
+            "2026-04-27",
+            "2026-04-28",
+            "2026-04-29",
+            "2026-04-30",
+            "2026-05-01",
+            "2026-05-04",
+            "2026-05-05",
+        ],
+        window_count=2,
+        minimum_window_length=10,
+        minimum_warmup_period=5,
+        regime_labels=["trend", "range"],
+    )
+
+    assert windows[0]["window_id"] == "window_01"
+    assert windows[1]["regime_label"] == "range"
+    assert windows[0]["oos_window"]["end"] < windows[1]["oos_window"]["start"]
+
+
+def test_sampling_plan_core_has_no_symbol_hardcoding() -> None:
+    source = Path("research/qre_sampling_plan.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source


### PR DESCRIPTION
## Why One PR / Five Commits
This work package was intentionally delivered as one PR with five atomic commits for bounded operational efficiency. Governance was preserved through per-commit local gates, one final combined validation pass, and one final CI cycle before merge.

## Commit Summary
1. `feat: add preregistered sampling plan`
   - Added deterministic context-only preregistration for fixed windows, regime buckets, null/control requirements, and forbidden adaptations.
2. `feat: add evidence failure-to-action mapping`
   - Added fail-closed mapping from evidence failures to allowed next actions without execution, queue mutation, or tuning authority.
3. `feat: add preregistered multi-window validation plan`
   - Added the preregistered campaign spec and exact-scope local-only approval manifest for the shared AAPL/NVDA daily cache range.
4. `feat: run preregistered multi-window evidence campaign`
   - Added the local-only multi-window runner that evaluates each locked window in order, preserves all failed windows, and aggregates verifier-compatible lineage/OOS outcomes without post-hoc changes.
5. `feat: finalize multi-window evidence closure`
   - Added final multi-window closure plus a narrow manifest/interop fix so approval-carried windows are explicitly locked for sampling-plan validation.

## Local Gate Results Per Commit
- Commit 1:
  - `python -m pytest tests/unit/test_qre_sampling_plan.py -q`
  - `python -m pytest tests/unit/test_qre_routing_score.py tests/unit/test_qre_hypothesis_model.py tests/unit/test_qre_preset_feasibility_mapper.py -q`
  - `python scripts/governance_lint.py`
  - `git diff --check`
  - frozen/protected-path checks clean
- Commit 2:
  - `python -m pytest tests/unit/test_qre_failure_to_action_mapper.py -q`
  - `python -m pytest tests/unit/test_qre_sampling_plan.py -q`
  - `python scripts/governance_lint.py`
  - `git diff --check`
  - frozen/protected-path checks clean
- Commit 3:
  - `python -m pytest tests/unit/test_qre_preregistered_multiwindow_validation.py -q`
  - `python -m pytest tests/unit/test_qre_sampling_plan.py tests/unit/test_qre_failure_to_action_mapper.py -q`
  - `python -m pytest tests/unit/test_qre_bounded_validation_approval_gate.py -q`
  - `python scripts/governance_lint.py`
  - `git diff --check`
  - frozen/protected-path checks clean
- Commit 4:
  - `python -m pytest tests/unit/test_qre_preregistered_multiwindow_evidence_run.py -q`
  - `python -m pytest tests/unit/test_qre_preregistered_multiwindow_validation.py tests/unit/test_qre_sampling_plan.py tests/unit/test_qre_failure_to_action_mapper.py -q`
  - `python -m pytest tests/unit/test_qre_bounded_validation_approval_gate.py tests/unit/test_qre_bounded_current_basket_generation_runner.py tests/unit/test_qre_controlled_validation_adapter.py -q`
  - `python -m pytest tests/unit/test_qre_approved_bounded_evidence_materialization.py tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py -q`
  - `python scripts/governance_lint.py`
  - `git diff --check`
  - frozen/protected-path checks clean
- Commit 5:
  - `python -m pytest tests/unit/test_qre_multiwindow_evidence_closure.py -q`
  - `python -m pytest tests/unit/test_qre_evidence_complete_basket_closure.py -q`
  - `python -m pytest tests/unit/test_qre_basket_operator_action_plan.py tests/unit/test_qre_basket_next_action_queue.py tests/unit/test_qre_trusted_loop_review_packet.py -q`
  - `python -m pytest tests/unit/test_qre_failure_to_action_mapper.py tests/unit/test_qre_preregistered_multiwindow_evidence_run.py -q`
  - `python scripts/governance_lint.py`
  - `git diff --check`
  - frozen/protected-path checks clean

## Final Full Validation
- `python -m pytest tests/unit/test_qre_sampling_plan.py tests/unit/test_qre_failure_to_action_mapper.py tests/unit/test_qre_preregistered_multiwindow_validation.py tests/unit/test_qre_preregistered_multiwindow_evidence_run.py tests/unit/test_qre_multiwindow_evidence_closure.py tests/unit/test_qre_bounded_validation_approval_gate.py tests/unit/test_qre_bounded_current_basket_generation_runner.py tests/unit/test_qre_controlled_validation_adapter.py tests/unit/test_qre_approved_bounded_evidence_materialization.py tests/unit/test_qre_bounded_generation_artifact_acceptance_verifier.py tests/unit/test_qre_evidence_complete_basket_closure.py tests/unit/test_qre_basket_operator_action_plan.py tests/unit/test_qre_basket_next_action_queue.py tests/unit/test_qre_trusted_loop_review_packet.py -q`
- `python -m pytest tests/smoke -q`
- `python scripts/governance_lint.py`
- `git diff --check`
- frozen/protected-path checks clean

## Approved Scope
- approval: `research/operator_approvals/qre_preregistered_multiwindow_validation_approval.v1.json`
- symbols: `AAPL`, `NVDA`
- preset: `trend_pullback_continuation_daily_v1`
- timeframe: `daily_v1`
- local-only shared validation range: `2026-04-08` through `2026-06-08`
- external fetch: `false`

## Sampling Plan / Locked Windows
- sampling plan id: `qsp_f343a1e05e1abfc2`
- windows:
  - `window_01`: bounded `2026-04-08` -> `2026-05-07`, OOS `2026-04-29` -> `2026-05-07`, regime `trend`
  - `window_02`: bounded `2026-05-08` -> `2026-06-08`, OOS `2026-05-29` -> `2026-06-08`, regime `high_volatility`
- null/control:
  - `null_daily_holdout` preregistered as required for evidence-complete, not used to override fail-closed rejection
- forbidden adaptations:
  - profitability-based window selection
  - return/sharpe based selection
  - parameter tuning against OOS windows
  - post-hoc window redefinition
  - in-sample to OOS relabeling

## Campaign Result
- campaign id: `qmwv_817024aec3967516`
- windows executed: `2`
- accepted lineage count: `4`
- accepted OOS count: `0`
- total positive OOS trades: `0`
- accepted windows: `0`
- failed windows: `2`
- campaign outcome: `all_windows_non_positive_trade_count`
- evidence_complete_count: `0`
- hypothesis disposition: `fail_closed_rejected`

## Evidence Before / After
- before:
  - accepted structured lineage artifacts: `1` for the latest exact scope
  - accepted structured OOS artifacts: `0`
  - evidence_complete_count: `0`
- after:
  - accepted lineage count in this preregistered campaign: `4`
  - accepted OOS count in this preregistered campaign: `0`
  - evidence_complete_count: `0`

## Maturity Before / After
| Domain | Before | After | Change |
| --- | ---: | ---: | ---: |
| Governance/infrastructure | 77 | 78 | +1 |
| Evidence production | 38 | 39 | +1 |
| Research intelligence | 44 | 46 | +2 |
| Candidate quality | 7 | 7 | 0 |
| Deployment/live readiness | 0 | 0 | 0 |

## Exact Remaining Blocker
Every preregistered OOS window for the exact approved AAPL/NVDA scope completed with `oos_trade_count = 0`, so no verifier-accepted structured OOS evidence exists for this hypothesis/preset/timeframe scope even though lineage is present.

## Safety Confirmation
- no fake evidence
- no invented trades, metrics, IDs, costs, or windows
- no window shopping or outcome-based window selection
- no acceptance-threshold weakening
- no parameter tuning
- no in-sample to OOS relabeling
- no external fetch
- no strategy synthesis or registration
- no candidate promotion
- no paper/shadow/live activation
- no broker/risk/execution changes
- frozen contracts unchanged
- protected paths untouched
- no AAPL/NVDA special-case logic in core modules

## Recommended Next Action
`register hypothesis as not supported`