### PR TITLE
feat: add null-control and falsification suite

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -33,6 +33,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_research_cycle_router/latest.json"),
     Path("logs/qre_evidence_breadth_framework/latest.json"),
     Path("logs/qre_research_memory_retrieval/latest.json"),
+    Path("logs/qre_null_control_falsification_suite/latest.json"),
 )
 _TOKEN_RE: Final[re.Pattern[str]] = re.compile(r"[a-z0-9_./:-]+")
 _PREVIEW_LIMIT: Final[int] = 280

--- a/research/qre_multiwindow_evidence_closure.py
+++ b/research/qre_multiwindow_evidence_closure.py
@@ -65,7 +65,8 @@ def build_multiwindow_evidence_closure(campaign_report: Mapping[str, Any]) -> di
     accepted_oos_count = int(campaign_report.get("accepted_oos_count") or 0)
     campaign_outcome = _text(campaign_report.get("campaign_outcome"))
     positive_oos_trade_count_total = int(campaign_report.get("positive_oos_trade_count_total") or 0)
-    null_control_status = _text((campaign_report.get("null_control_results") or {}).get("status"))
+    null_control_payload = campaign_report.get("null_control_results") if isinstance(campaign_report.get("null_control_results"), Mapping) else {}
+    null_control_status = _text(null_control_payload.get("status"))
     reason_records: list[dict[str, Any]] = []
     blockers_cleared: list[str] = []
     blockers_remaining: list[str] = []
@@ -100,7 +101,7 @@ def build_multiwindow_evidence_closure(campaign_report: Mapping[str, Any]) -> di
                 message="The preregistered campaign did not execute any windows.",
             )
         )
-    elif null_control_status == "failed":
+    elif null_control_status == "controls_failed":
         closure_status = "null_control_failed"
         hypothesis_disposition = "fail_closed_rejected"
         recommended_next_action = "reject_hypothesis"
@@ -110,6 +111,19 @@ def build_multiwindow_evidence_closure(campaign_report: Mapping[str, Any]) -> di
                 reason_code="null_control_failed",
                 evidence_refs=[],
                 message="Null/control requirements failed, so completion is blocked fail-closed.",
+            )
+        )
+    elif null_control_status in {"controls_not_run", "controls_incomplete", ""}:
+        closure_status = "blocked_missing_null_controls"
+        hypothesis_disposition = "insufficient_for_completion"
+        recommended_next_action = _text(null_control_payload.get("recommended_next_action")) or "materialize_missing_preregistered_controls"
+        blockers_remaining.append("null_controls_incomplete")
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_null_control_incomplete",
+                reason_code="null_controls_incomplete",
+                evidence_refs=[_text(campaign_report.get("campaign_id"))],
+                message="Preregistered null/control requirements are still incomplete, so evidence completion remains blocked.",
             )
         )
     elif campaign_outcome == "accepted_multiwindow_oos_evidence" and accepted_lineage_count > 0 and accepted_oos_count > 0:

--- a/research/qre_null_control_falsification_suite.py
+++ b/research/qre_null_control_falsification_suite.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, Literal
+
+from research import qre_sampling_plan as sampling_plan
+
+
+SuiteStatus = Literal[
+    "suite_ready_preregistered_context",
+    "blocked_invalid_sampling_plan",
+    "blocked_missing_control_definition",
+    "blocked_unlocked_control_definition",
+    "blocked_post_hoc_control_selection",
+]
+EvaluationStatus = Literal[
+    "controls_not_run",
+    "controls_incomplete",
+    "controls_failed",
+    "controls_passed_context_only",
+]
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_null_control_falsification_suite"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_null_control_falsification_suite")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_null_control_falsification_suite/"
+DEFAULT_CONTROL_FAMILIES: Final[tuple[dict[str, str], ...]] = (
+    {"control_id": "buy_and_hold_baseline", "control_family": "buy_and_hold"},
+    {"control_id": "random_entry_matched_holding", "control_family": "random_entry"},
+    {"control_id": "shuffled_signal_surrogate", "control_family": "shuffled_signal"},
+    {"control_id": "simple_momentum_baseline", "control_family": "simple_momentum"},
+    {"control_id": "simple_mean_reversion_baseline", "control_family": "simple_mean_reversion"},
+    {"control_id": "regime_matched_null", "control_family": "regime_matched_null"},
+    {"control_id": "turnover_matched_null", "control_family": "turnover_matched_null"},
+    {"control_id": "cost_free_vs_cost_adjusted", "control_family": "cost_sensitivity"},
+)
+FORBIDDEN_SELECTION_TERMS: Final[tuple[str, ...]] = (
+    "best_control",
+    "best-performing control",
+    "choose after results",
+    "post_hoc",
+    "profit",
+    "sharpe",
+    "return",
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _unique_in_order(values: Sequence[Any]) -> list[str]:
+    return list(dict.fromkeys(_text(value) for value in values if _text(value)))
+
+
+def _contains_forbidden_selection(value: Any) -> bool:
+    lowered = _text(value).lower()
+    return any(term in lowered for term in FORBIDDEN_SELECTION_TERMS)
+
+
+def _canonical_control_definition(
+    definition: Mapping[str, Any],
+    *,
+    fallback_family: str,
+) -> dict[str, Any]:
+    control_id = _text(definition.get("control_id"))
+    control_family = _text(definition.get("control_family")) or fallback_family
+    locked = bool(definition.get("locked", True))
+    required_for_evidence_complete = bool(definition.get("required_for_evidence_complete", True))
+    required_for_fail_closed_rejection = bool(definition.get("required_for_fail_closed_rejection", False))
+    return {
+        "control_id": control_id or control_family,
+        "control_family": control_family,
+        "locked": locked,
+        "required_for_evidence_complete": required_for_evidence_complete,
+        "required_for_fail_closed_rejection": required_for_fail_closed_rejection,
+        "selection_policy": _text(definition.get("selection_policy")) or "preregistered_control_family",
+        "justification": _text(definition.get("justification")) or "deterministic_preregistered_null_control",
+    }
+
+
+def compute_suite_hash(report: Mapping[str, Any]) -> str:
+    canonical = {
+        "schema_version": report.get("schema_version", SCHEMA_VERSION),
+        "report_kind": report.get("report_kind", REPORT_KIND),
+        "suite_id": report.get("suite_id", ""),
+        "sampling_plan_ref": report.get("sampling_plan_ref", ""),
+        "sampling_plan_hash": report.get("sampling_plan_hash", ""),
+        "status": report.get("status", ""),
+        "blocked_reasons": list(report.get("blocked_reasons", [])),
+        "control_definitions": list(report.get("control_definitions", [])),
+        "evaluation": dict(report.get("evaluation", {})),
+        "authority": dict(report.get("authority", {})),
+    }
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build_preregistered_null_control_suite(
+    *,
+    sampling_plan_payload: Mapping[str, Any],
+    control_families: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    sampling_validation = sampling_plan.validate_sampling_plan(sampling_plan_payload)
+    blocked_reasons: list[str] = []
+    status: SuiteStatus = "suite_ready_preregistered_context"
+
+    if sampling_validation["valid"] is not True or _text(sampling_plan_payload.get("status")) != "sampling_plan_ready_context_only":
+        status = "blocked_invalid_sampling_plan"
+        blocked_reasons.extend(list(sampling_validation.get("rejection_reasons") or []))
+        blocked_reasons.extend(_unique_in_order(sampling_plan_payload.get("blocked_reasons") or []))
+
+    supplied = list(sampling_plan_payload.get("null_control_definitions") or [])
+    if not supplied:
+        status = "blocked_missing_control_definition"
+        blocked_reasons.append("missing_null_control_definition")
+
+    controls_by_family = {
+        _text(item.get("control_family") or item.get("control_id")): item
+        for item in (control_families or DEFAULT_CONTROL_FAMILIES)
+        if isinstance(item, Mapping)
+    }
+    control_definitions: list[dict[str, Any]] = []
+    for definition in supplied:
+        if not isinstance(definition, Mapping):
+            continue
+        supplied_family = _text(definition.get("control_family") or definition.get("control_id"))
+        fallback_family = supplied_family or "unknown"
+        merged = dict(controls_by_family.get(supplied_family, {}))
+        merged.update(dict(definition))
+        canonical = _canonical_control_definition(merged, fallback_family=fallback_family)
+        if canonical["locked"] is not True:
+            status = "blocked_unlocked_control_definition"
+            blocked_reasons.append(f"control_not_locked:{canonical['control_id']}")
+        if _contains_forbidden_selection(canonical.get("selection_policy")) or _contains_forbidden_selection(
+            canonical.get("justification")
+        ):
+            status = "blocked_post_hoc_control_selection"
+            blocked_reasons.append(f"post_hoc_control_selection:{canonical['control_id']}")
+        control_definitions.append(canonical)
+
+    suite_seed = {
+        "sampling_plan_id": _text(sampling_plan_payload.get("sampling_plan_id")),
+        "sampling_plan_hash": _text(sampling_plan_payload.get("hash")),
+        "control_definitions": control_definitions,
+    }
+    suite_id = "qnc_" + hashlib.sha256(
+        json.dumps(suite_seed, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()[:16]
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "suite_id": suite_id,
+        "sampling_plan_ref": _text(sampling_plan_payload.get("sampling_plan_id")),
+        "sampling_plan_hash": _text(sampling_plan_payload.get("hash")),
+        "status": status,
+        "blocked_reasons": _unique_in_order(blocked_reasons),
+        "control_definitions": control_definitions,
+        "evaluation": {
+            "status": "controls_not_run",
+            "required_control_count": sum(
+                1 for item in control_definitions if bool(item.get("required_for_evidence_complete"))
+            ),
+            "completed_control_count": 0,
+            "passed_control_count": 0,
+            "failed_control_count": 0,
+            "missing_control_ids": [
+                str(item["control_id"])
+                for item in control_definitions
+                if bool(item.get("required_for_evidence_complete"))
+            ],
+            "failed_control_ids": [],
+            "recommended_next_action": "materialize_preregistered_controls_before_evidence_complete",
+            "blockers": [
+                "null_controls_not_materialized_for_preregistered_scope"
+            ]
+            if control_definitions
+            else ["missing_preregistered_null_control_definitions"],
+            "candidate_context_refs": [],
+            "control_result_rows": [],
+        },
+        "authority": {
+            "non_authoritative": True,
+            "can_authorize_execution": False,
+            "can_clear_evidence_blockers": False,
+            "can_promote_candidate": False,
+            "evidence_authority": "context_only",
+        },
+    }
+    report["hash"] = compute_suite_hash(report)
+    return report
+
+
+def evaluate_null_control_suite(
+    suite_report: Mapping[str, Any],
+    *,
+    candidate_context: Mapping[str, Any] | None = None,
+    control_results: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    control_rows = [dict(item) for item in suite_report.get("control_definitions", []) if isinstance(item, Mapping)]
+    results_index = {
+        _text(item.get("control_id")): dict(item)
+        for item in (control_results or [])
+        if isinstance(item, Mapping) and _text(item.get("control_id"))
+    }
+    completed_control_count = 0
+    passed_control_count = 0
+    failed_control_count = 0
+    missing_control_ids: list[str] = []
+    failed_control_ids: list[str] = []
+    result_rows: list[dict[str, Any]] = []
+
+    for row in control_rows:
+        control_id = _text(row.get("control_id"))
+        result = results_index.get(control_id, {})
+        result_status = _text(result.get("result_status")) or "missing"
+        passed = bool(result.get("passed", False)) if result_status != "missing" else False
+        if result_status != "missing":
+            completed_control_count += 1
+        if passed:
+            passed_control_count += 1
+        elif result_status != "missing":
+            failed_control_count += 1
+            failed_control_ids.append(control_id)
+        if bool(row.get("required_for_evidence_complete")) and result_status == "missing":
+            missing_control_ids.append(control_id)
+        result_rows.append(
+            {
+                "control_id": control_id,
+                "control_family": _text(row.get("control_family")),
+                "required_for_evidence_complete": bool(row.get("required_for_evidence_complete")),
+                "result_status": result_status,
+                "passed": passed,
+                "evidence_refs": _unique_in_order(result.get("evidence_refs") or []),
+                "failure_reason": _text(result.get("failure_reason")),
+            }
+        )
+
+    evaluation_status: EvaluationStatus
+    blockers: list[str]
+    recommended_next_action: str
+    if failed_control_ids:
+        evaluation_status = "controls_failed"
+        blockers = ["null_control_failure_detected"]
+        recommended_next_action = "reject_hypothesis_or_expand_falsification_review"
+    elif missing_control_ids:
+        evaluation_status = "controls_incomplete"
+        blockers = ["null_controls_incomplete"]
+        recommended_next_action = "materialize_missing_preregistered_controls"
+    elif control_rows:
+        evaluation_status = "controls_passed_context_only"
+        blockers = []
+        recommended_next_action = "route_to_operator_review_with_control_context"
+    else:
+        evaluation_status = "controls_not_run"
+        blockers = ["missing_preregistered_null_control_definitions"]
+        recommended_next_action = "define_preregistered_controls"
+
+    updated = dict(suite_report)
+    updated["evaluation"] = {
+        "status": evaluation_status,
+        "required_control_count": sum(
+            1 for item in control_rows if bool(item.get("required_for_evidence_complete"))
+        ),
+        "completed_control_count": completed_control_count,
+        "passed_control_count": passed_control_count,
+        "failed_control_count": failed_control_count,
+        "missing_control_ids": missing_control_ids,
+        "failed_control_ids": _unique_in_order(failed_control_ids),
+        "recommended_next_action": recommended_next_action,
+        "blockers": blockers,
+        "candidate_context_refs": _unique_in_order(
+            [
+                _text((candidate_context or {}).get("campaign_id")),
+                _text((candidate_context or {}).get("sampling_plan_id")),
+            ]
+        ),
+        "control_result_rows": result_rows,
+    }
+    updated["hash"] = compute_suite_hash(updated)
+    return updated
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    evaluation = report.get("evaluation") if isinstance(report.get("evaluation"), Mapping) else {}
+    controls = report.get("control_definitions") if isinstance(report.get("control_definitions"), list) else []
+    return "\n".join(
+        [
+            "# QRE Null-Control Falsification Suite",
+            "",
+            "- Preregistered control families are read-only context and never promote candidates or authorize execution.",
+            "",
+            "## Summary",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["suite_id", _text(report.get("suite_id"))],
+                    ["status", _text(report.get("status"))],
+                    ["evaluation_status", _text(evaluation.get("status"))],
+                    ["required_control_count", str(evaluation.get("required_control_count") or 0)],
+                    ["completed_control_count", str(evaluation.get("completed_control_count") or 0)],
+                    ["failed_control_count", str(evaluation.get("failed_control_count") or 0)],
+                    ["recommended_next_action", _text(evaluation.get("recommended_next_action"))],
+                ],
+            ),
+            "",
+            "## Controls",
+            _table(
+                ["Control", "Family", "Locked", "Required", "Result"],
+                [
+                    [
+                        _text(item.get("control_id")),
+                        _text(item.get("control_family")),
+                        str(bool(item.get("locked"))).lower(),
+                        str(bool(item.get("required_for_evidence_complete"))).lower(),
+                        _text(
+                            next(
+                                (
+                                    row.get("result_status")
+                                    for row in evaluation.get("control_result_rows", [])
+                                    if _text((row or {}).get("control_id")) == _text(item.get("control_id"))
+                                ),
+                                "missing",
+                            )
+                        ),
+                    ]
+                    for item in controls
+                ],
+            ),
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_null_control_falsification_suite",
+        description="Build deterministic preregistered null/control suite context.",
+    )
+    parser.add_argument("--sampling-plan-file", required=True)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    sampling_payload = json.loads(Path(args.sampling_plan_file).read_text(encoding="utf-8"))
+    report = build_preregistered_null_control_suite(sampling_plan_payload=sampling_payload)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+__all__ = [
+    "DEFAULT_CONTROL_FAMILIES",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "build_preregistered_null_control_suite",
+    "compute_suite_hash",
+    "evaluate_null_control_suite",
+    "render_operator_summary",
+    "write_outputs",
+]

--- a/research/qre_preregistered_multiwindow_evidence_run.py
+++ b/research/qre_preregistered_multiwindow_evidence_run.py
@@ -15,6 +15,7 @@ from research import qre_bounded_generation_artifact_acceptance_verifier as veri
 from research import qre_controlled_validation_adapter as adapter
 from research import qre_controlled_validation_adapter_result_materialization as materializer
 from research import qre_failure_to_action_mapper as failure_mapper
+from research import qre_null_control_falsification_suite as null_suite
 from research import qre_preregistered_multiwindow_validation as campaign_builder
 from research import qre_sampling_plan as sampling
 
@@ -170,6 +171,9 @@ def build_campaign_for_multiwindow_approval(
     sampling_plan_payload: Mapping[str, Any],
 ) -> dict[str, Any]:
     scope = approval_manifest.get("scope") if isinstance(approval_manifest.get("scope"), Mapping) else {}
+    suite = null_suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=sampling_plan_payload
+    )
     return campaign_builder.build_preregistered_multiwindow_validation(
         sampling_plan_payload=sampling_plan_payload,
         approval_manifest=approval_manifest,
@@ -177,9 +181,7 @@ def build_campaign_for_multiwindow_approval(
         minimum_required_windows=2,
         minimum_total_oos_trades=1,
         per_window_minimum_oos_trades=1,
-        null_control_requirements=[
-            {"control_id": "null_daily_holdout", "required_for_evidence_complete": True}
-        ],
+        null_control_requirements=list(suite.get("control_definitions") or []),
     )
 
 
@@ -394,11 +396,19 @@ def build_preregistered_multiwindow_evidence_run(
         approval_manifest=approval_manifest,
         sampling_plan_payload=sampling_plan_payload,
     )
+    suite_sampling_plan_payload = dict(sampling_plan_payload)
+    if not suite_sampling_plan_payload.get("null_control_definitions") and campaign_plan.get("null_control_requirements"):
+        suite_sampling_plan_payload["null_control_definitions"] = list(
+            campaign_plan.get("null_control_requirements") or []
+        )
     if sampling_plan_payload["hash"] != campaign_plan["sampling_plan_hash"]:
         raise ValueError("sampling_plan_hash_mismatch")
     if campaign_plan["hash"] != campaign_builder.compute_campaign_hash(campaign_plan):
         raise ValueError("campaign_plan_hash_mismatch")
     if campaign_plan["status"] != "campaign_ready_preregistered_context":
+        suite = null_suite.build_preregistered_null_control_suite(
+            sampling_plan_payload=suite_sampling_plan_payload
+        )
         return {
             "schema_version": SCHEMA_VERSION,
             "report_kind": REPORT_KIND,
@@ -413,7 +423,7 @@ def build_preregistered_multiwindow_evidence_run(
             "failed_window_count": 0,
             "accepted_window_count": 0,
             "rejection_reasons": list(campaign_plan.get("blocked_reasons") or []),
-            "null_control_results": {"status": "not_run_due_to_blocked_campaign"},
+            "null_control_results": suite["evaluation"],
             "campaign_outcome": "blocked_approval",
             "can_clear_blockers": False,
             "can_promote_candidate": False,
@@ -510,6 +520,17 @@ def build_preregistered_multiwindow_evidence_run(
         campaign_outcome = "all_windows_non_positive_trade_count"
     else:
         campaign_outcome = "hypothesis_not_supported"
+    suite = null_suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=suite_sampling_plan_payload
+    )
+    suite = null_suite.evaluate_null_control_suite(
+        suite,
+        candidate_context={
+            "campaign_id": campaign_plan["campaign_id"],
+            "sampling_plan_id": sampling_plan_payload["sampling_plan_id"],
+        },
+        control_results=[],
+    )
     report = {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
@@ -525,9 +546,9 @@ def build_preregistered_multiwindow_evidence_run(
         "failed_window_count": failed_window_count,
         "accepted_window_count": accepted_window_count,
         "rejection_reasons": rejection_reasons,
-        "null_control_results": {
-            "status": "not_run_due_to_no_accepted_oos" if accepted_oos_count == 0 else "pending_manual_null_control_review"
-        },
+        "null_control_results": dict(suite["evaluation"]),
+        "null_control_suite_ref": _text(suite.get("suite_id")),
+        "null_control_suite_status": _text(suite.get("status")),
         "campaign_outcome": campaign_outcome,
         "can_clear_blockers": False,
         "can_promote_candidate": False,

--- a/research/qre_preregistered_multiwindow_validation.py
+++ b/research/qre_preregistered_multiwindow_validation.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Final, Literal
 
 from research import qre_bounded_validation_approval_gate as approval_gate
+from research import qre_null_control_falsification_suite as null_suite
 from research import qre_sampling_plan as sampling_plan
 
 
@@ -198,6 +199,10 @@ def build_preregistered_multiwindow_validation(
             "operator_review_required",
         ],
         "null_control_requirements": [dict(item) for item in null_control_requirements],
+        "null_control_suite_ref": "derived_from_sampling_plan",
+        "null_control_suite_status": null_suite.build_preregistered_null_control_suite(
+            sampling_plan_payload=sampling_plan_payload
+        )["status"],
         "minimum_required_windows": int(minimum_required_windows),
         "minimum_total_oos_trades": int(minimum_total_oos_trades),
         "per_window_minimum_oos_trades": int(per_window_minimum_oos_trades),

--- a/tests/unit/test_qre_multiwindow_evidence_closure.py
+++ b/tests/unit/test_qre_multiwindow_evidence_closure.py
@@ -37,7 +37,7 @@ def test_complete_evidence_requires_all_criteria() -> None:
             accepted_oos_count=2,
             positive_oos_trade_count_total=4,
             campaign_outcome="accepted_multiwindow_oos_evidence",
-            null_control_results={"status": "passed"},
+            null_control_results={"status": "controls_passed_context_only"},
         )
     )
 
@@ -80,11 +80,25 @@ def test_null_control_failure_blocks_completion() -> None:
             accepted_oos_count=2,
             positive_oos_trade_count_total=4,
             campaign_outcome="accepted_multiwindow_oos_evidence",
-            null_control_results={"status": "failed"},
+            null_control_results={"status": "controls_failed"},
         )
     )
 
     assert report["closure_status"] == "null_control_failed"
+    assert report["evidence_complete_count"] == 0
+
+
+def test_missing_null_controls_block_completion_even_with_accepted_oos() -> None:
+    report = closure.build_multiwindow_evidence_closure(
+        _campaign(
+            accepted_oos_count=2,
+            positive_oos_trade_count_total=4,
+            campaign_outcome="accepted_multiwindow_oos_evidence",
+            null_control_results={"status": "controls_incomplete"},
+        )
+    )
+
+    assert report["closure_status"] == "blocked_missing_null_controls"
     assert report["evidence_complete_count"] == 0
 
 

--- a/tests/unit/test_qre_null_control_falsification_suite.py
+++ b/tests/unit/test_qre_null_control_falsification_suite.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_null_control_falsification_suite as suite
+from research import qre_sampling_plan as sampling
+
+
+def _sampling_plan(**overrides: object) -> dict[str, object]:
+    payload = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref="trend_pullback_behavior_v1",
+        behavior_id="trend_pullback",
+        preset_id="trend_pullback_continuation_daily_v1",
+        timeframe="daily_v1",
+        minimum_window_length=20,
+        minimum_warmup_period=10,
+        required_oos_evidence_types=["structured_lineage", "structured_oos"],
+        null_control_definitions=[
+            {
+                "control_id": "buy_and_hold_baseline",
+                "control_family": "buy_and_hold",
+                "required_for_evidence_complete": True,
+            },
+            {
+                "control_id": "shuffled_signal_surrogate",
+                "control_family": "shuffled_signal",
+                "required_for_evidence_complete": True,
+            },
+        ],
+        window_definitions=[
+            {
+                "window_id": "window_01",
+                "bounded_input_window": {"start": "2026-04-08", "end": "2026-05-07"},
+                "oos_window": {"start": "2026-04-29", "end": "2026-05-07"},
+                "role": "oos",
+                "regime_label": "trend",
+                "locked": True,
+            }
+        ],
+        preregistration_timestamp="2026-06-19T10:00:00Z",
+    )
+    payload.update(overrides)
+    return payload
+
+
+def test_suite_is_deterministic_and_locked() -> None:
+    first = suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=_sampling_plan()
+    )
+    second = suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=_sampling_plan()
+    )
+
+    assert first == second
+    assert first["status"] == "suite_ready_preregistered_context"
+    assert all(row["locked"] is True for row in first["control_definitions"])
+    assert first["hash"] == suite.compute_suite_hash(first)
+
+
+def test_unlocked_or_post_hoc_controls_are_blocked() -> None:
+    report = suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=_sampling_plan(
+            null_control_definitions=[
+                {
+                    "control_id": "buy_and_hold_baseline",
+                    "control_family": "buy_and_hold",
+                    "locked": False,
+                    "selection_policy": "best_control_after_profit_review",
+                }
+            ]
+        )
+    )
+
+    assert report["status"] == "blocked_post_hoc_control_selection"
+    assert "control_not_locked:buy_and_hold_baseline" in report["blocked_reasons"]
+    assert "post_hoc_control_selection:buy_and_hold_baseline" in report["blocked_reasons"]
+
+
+def test_evaluation_fails_closed_when_controls_missing() -> None:
+    report = suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=_sampling_plan()
+    )
+    evaluated = suite.evaluate_null_control_suite(
+        report,
+        candidate_context={"campaign_id": "camp-001", "sampling_plan_id": "plan-001"},
+        control_results=[],
+    )
+
+    assert evaluated["evaluation"]["status"] == "controls_incomplete"
+    assert evaluated["evaluation"]["missing_control_ids"] == [
+        "buy_and_hold_baseline",
+        "shuffled_signal_surrogate",
+    ]
+    assert evaluated["evaluation"]["recommended_next_action"] == "materialize_missing_preregistered_controls"
+
+
+def test_evaluation_marks_failures_and_passes_without_promotion() -> None:
+    report = suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=_sampling_plan()
+    )
+    failed = suite.evaluate_null_control_suite(
+        report,
+        control_results=[
+            {"control_id": "buy_and_hold_baseline", "result_status": "completed", "passed": True},
+            {
+                "control_id": "shuffled_signal_surrogate",
+                "result_status": "completed",
+                "passed": False,
+                "failure_reason": "candidate_not_separated_from_shuffled_signal",
+            },
+        ],
+    )
+    passed = suite.evaluate_null_control_suite(
+        report,
+        control_results=[
+            {"control_id": "buy_and_hold_baseline", "result_status": "completed", "passed": True},
+            {"control_id": "shuffled_signal_surrogate", "result_status": "completed", "passed": True},
+        ],
+    )
+
+    assert failed["evaluation"]["status"] == "controls_failed"
+    assert failed["evaluation"]["failed_control_ids"] == ["shuffled_signal_surrogate"]
+    assert passed["evaluation"]["status"] == "controls_passed_context_only"
+    assert passed["authority"]["can_promote_candidate"] is False
+
+
+def test_write_outputs_and_core_module_have_no_symbol_hardcoding(tmp_path: Path) -> None:
+    report = suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=_sampling_plan()
+    )
+    paths = suite.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_null_control_falsification_suite/latest.json"
+    source = Path("research/qre_null_control_falsification_suite.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source

--- a/tests/unit/test_qre_preregistered_multiwindow_evidence_run.py
+++ b/tests/unit/test_qre_preregistered_multiwindow_evidence_run.py
@@ -133,6 +133,8 @@ def test_all_preregistered_windows_execute_in_order_and_failures_remain_visible(
     assert report["accepted_window_count"] == 1
     assert report["failed_window_count"] == 1
     assert report["window_results"][1]["rejection_reasons"] == ["non_positive_oos_trade_count"]
+    assert report["null_control_results"]["status"] in {"controls_incomplete", "controls_not_run"}
+    assert report["null_control_results"]["blockers"]
     assert report["can_promote_candidate"] is False
     assert report["can_activate_deployment"] is False
 


### PR DESCRIPTION
## Summary
- add a deterministic preregistered null-control/falsification suite contract with fail-closed evaluation states
- integrate the suite into preregistered multi-window campaign planning and evidence-run outputs
- require completed null controls before multi-window closure can count evidence as complete and index the suite in research memory

## Testing
- python -m pytest tests/unit/test_qre_null_control_falsification_suite.py tests/unit/test_qre_preregistered_multiwindow_validation.py tests/unit/test_qre_preregistered_multiwindow_evidence_run.py tests/unit/test_qre_multiwindow_evidence_closure.py tests/unit/test_qre_research_memory.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_research_memory_retrieval.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py