### PR TITLE
feat: add evidence-backed candidate identity and lifecycle

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -34,6 +34,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_evidence_breadth_framework/latest.json"),
     Path("logs/qre_research_memory_retrieval/latest.json"),
     Path("logs/qre_null_control_falsification_suite/latest.json"),
+    Path("logs/qre_candidate_identity_lifecycle/latest.json"),
 )
 _TOKEN_RE: Final[re.Pattern[str]] = re.compile(r"[a-z0-9_./:-]+")
 _PREVIEW_LIMIT: Final[int] = 280

--- a/research/candidate_lifecycle.py
+++ b/research/candidate_lifecycle.py
@@ -22,7 +22,11 @@ per entry in the registry-v2 sidecar.
 
 from __future__ import annotations
 
+import hashlib
+import json
+from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 
 STATUS_MODEL_VERSION = "v3.12.0"
@@ -138,6 +142,237 @@ class InvalidTransitionError(Exception):
 
 class UnknownLegacyVerdictError(Exception):
     """Raised when a legacy verdict string has no defined mapping."""
+
+
+QRE_STATUS_MODEL_VERSION = "qre.v1"
+
+
+class QRECandidateLifecycleStatus(str, Enum):
+    DRAFT = "draft"
+    EVIDENCE_INCOMPLETE = "evidence_incomplete"
+    EVIDENCE_COMPLETE = "evidence_complete"
+    QUALITY_REVIEW = "quality_review"
+    PROMOTION_REVIEW = "promotion_review"
+    REJECTED = "rejected"
+    SUPPRESSED = "suppressed"
+    COOLDOWN = "cooldown"
+    RETIRED = "retired"
+    SHADOW_READINESS_CANDIDATE = "shadow_readiness_candidate"
+
+
+QRE_FULL_LIFECYCLE_GRAPH: dict[QRECandidateLifecycleStatus, frozenset[QRECandidateLifecycleStatus]] = {
+    QRECandidateLifecycleStatus.DRAFT: frozenset(
+        {
+            QRECandidateLifecycleStatus.EVIDENCE_INCOMPLETE,
+            QRECandidateLifecycleStatus.REJECTED,
+            QRECandidateLifecycleStatus.SUPPRESSED,
+            QRECandidateLifecycleStatus.RETIRED,
+        }
+    ),
+    QRECandidateLifecycleStatus.EVIDENCE_INCOMPLETE: frozenset(
+        {
+            QRECandidateLifecycleStatus.EVIDENCE_COMPLETE,
+            QRECandidateLifecycleStatus.REJECTED,
+            QRECandidateLifecycleStatus.SUPPRESSED,
+            QRECandidateLifecycleStatus.COOLDOWN,
+            QRECandidateLifecycleStatus.RETIRED,
+        }
+    ),
+    QRECandidateLifecycleStatus.EVIDENCE_COMPLETE: frozenset(
+        {
+            QRECandidateLifecycleStatus.QUALITY_REVIEW,
+            QRECandidateLifecycleStatus.REJECTED,
+            QRECandidateLifecycleStatus.SUPPRESSED,
+            QRECandidateLifecycleStatus.COOLDOWN,
+            QRECandidateLifecycleStatus.RETIRED,
+        }
+    ),
+    QRECandidateLifecycleStatus.QUALITY_REVIEW: frozenset(
+        {
+            QRECandidateLifecycleStatus.PROMOTION_REVIEW,
+            QRECandidateLifecycleStatus.REJECTED,
+            QRECandidateLifecycleStatus.SUPPRESSED,
+            QRECandidateLifecycleStatus.COOLDOWN,
+            QRECandidateLifecycleStatus.RETIRED,
+        }
+    ),
+    QRECandidateLifecycleStatus.PROMOTION_REVIEW: frozenset(
+        {
+            QRECandidateLifecycleStatus.SHADOW_READINESS_CANDIDATE,
+            QRECandidateLifecycleStatus.REJECTED,
+            QRECandidateLifecycleStatus.SUPPRESSED,
+            QRECandidateLifecycleStatus.COOLDOWN,
+            QRECandidateLifecycleStatus.RETIRED,
+        }
+    ),
+    QRECandidateLifecycleStatus.SUPPRESSED: frozenset(
+        {
+            QRECandidateLifecycleStatus.EVIDENCE_INCOMPLETE,
+            QRECandidateLifecycleStatus.COOLDOWN,
+            QRECandidateLifecycleStatus.RETIRED,
+        }
+    ),
+    QRECandidateLifecycleStatus.COOLDOWN: frozenset(
+        {
+            QRECandidateLifecycleStatus.EVIDENCE_INCOMPLETE,
+            QRECandidateLifecycleStatus.SUPPRESSED,
+            QRECandidateLifecycleStatus.RETIRED,
+        }
+    ),
+    QRECandidateLifecycleStatus.SHADOW_READINESS_CANDIDATE: frozenset(
+        {
+            QRECandidateLifecycleStatus.REJECTED,
+            QRECandidateLifecycleStatus.COOLDOWN,
+            QRECandidateLifecycleStatus.RETIRED,
+        }
+    ),
+    QRECandidateLifecycleStatus.REJECTED: frozenset(),
+    QRECandidateLifecycleStatus.RETIRED: frozenset(),
+}
+
+
+class QREInvalidTransitionError(Exception):
+    """Raised when a QRE lifecycle transition is not allowed."""
+
+
+class QREDuplicateScopeError(Exception):
+    """Raised when two QRE candidate records share the same deterministic scope."""
+
+
+def _qre_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _qre_unique(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def _scope_seed(scope: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "hypothesis_id": _qre_text(scope.get("hypothesis_id")),
+        "behavior_id": _qre_text(scope.get("behavior_id")),
+        "preset_id": _qre_text(scope.get("preset_id")),
+        "timeframe": _qre_text(scope.get("timeframe")),
+        "universe_or_basket_scope": _qre_text(scope.get("universe_or_basket_scope")),
+        "region": _qre_text(scope.get("region")),
+        "symbol": _qre_text(scope.get("symbol")),
+    }
+
+
+def compute_qre_scope_signature(scope: dict[str, Any]) -> str:
+    payload = _scope_seed(scope)
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_qre_candidate_identity(scope: dict[str, Any]) -> dict[str, str]:
+    signature = compute_qre_scope_signature(scope)
+    version_seed = {
+        **_scope_seed(scope),
+        "sampling_plan_ref": _qre_text(scope.get("sampling_plan_ref")),
+        "accepted_lineage_count": int(scope.get("accepted_lineage_count", 0) or 0),
+        "accepted_oos_count": int(scope.get("accepted_oos_count", 0) or 0),
+    }
+    version_raw = json.dumps(version_seed, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    version_hash = hashlib.sha256(version_raw.encode("utf-8")).hexdigest()
+    return {
+        "candidate_id": "qre_cand_" + signature[:16],
+        "scope_signature": signature,
+        "candidate_version": "qre_v_" + version_hash[:16],
+    }
+
+
+@dataclass(frozen=True)
+class QRETransitionContext:
+    accepted_lineage_count: int = 0
+    accepted_oos_count: int = 0
+    evidence_complete: bool = False
+    quality_gate_passed: bool = False
+    promotion_gate_passed: bool = False
+    readiness_gate_passed: bool = False
+    operator_shadow_authority: bool = False
+    rejected_scope: bool = False
+    suppressed_scope: bool = False
+    duplicate_scope: bool = False
+
+
+def validate_qre_transition(
+    from_: QRECandidateLifecycleStatus,
+    to_: QRECandidateLifecycleStatus,
+    *,
+    context: QRETransitionContext,
+) -> None:
+    allowed = QRE_FULL_LIFECYCLE_GRAPH.get(from_, frozenset())
+    if to_ not in allowed:
+        raise QREInvalidTransitionError(f"transition {from_.value!r} -> {to_.value!r} is not permitted")
+    if context.duplicate_scope:
+        raise QREInvalidTransitionError("duplicate_scope_blocked")
+    if to_ == QRECandidateLifecycleStatus.EVIDENCE_COMPLETE:
+        if not context.evidence_complete or context.accepted_lineage_count <= 0 or context.accepted_oos_count <= 0:
+            raise QREInvalidTransitionError("evidence_complete_requires_accepted_evidence")
+    if to_ == QRECandidateLifecycleStatus.QUALITY_REVIEW and not context.evidence_complete:
+        raise QREInvalidTransitionError("quality_review_requires_evidence_complete")
+    if to_ == QRECandidateLifecycleStatus.PROMOTION_REVIEW and not context.quality_gate_passed:
+        raise QREInvalidTransitionError("promotion_review_requires_quality_gate")
+    if to_ == QRECandidateLifecycleStatus.SHADOW_READINESS_CANDIDATE:
+        if not context.promotion_gate_passed:
+            raise QREInvalidTransitionError("shadow_readiness_requires_promotion_gate")
+        if not context.readiness_gate_passed:
+            raise QREInvalidTransitionError("shadow_readiness_requires_readiness_gate")
+        if not context.operator_shadow_authority:
+            raise QREInvalidTransitionError("shadow_readiness_requires_operator_authority")
+
+
+def build_qre_candidate_record(
+    scope: dict[str, Any],
+    *,
+    context: QRETransitionContext,
+) -> dict[str, Any]:
+    identity = build_qre_candidate_identity(scope)
+    blockers: list[str] = []
+    status = QRECandidateLifecycleStatus.DRAFT
+
+    if context.duplicate_scope:
+        blockers.append("duplicate_scope_blocked")
+        status = QRECandidateLifecycleStatus.SUPPRESSED
+    elif context.rejected_scope:
+        blockers.append("rejected_scope_cannot_become_candidate")
+        status = QRECandidateLifecycleStatus.REJECTED
+    elif context.suppressed_scope:
+        blockers.append("suppressed_scope_requires_material_novelty")
+        status = QRECandidateLifecycleStatus.SUPPRESSED
+    elif context.evidence_complete and context.accepted_lineage_count > 0 and context.accepted_oos_count > 0:
+        status = QRECandidateLifecycleStatus.EVIDENCE_COMPLETE
+    else:
+        blockers.append("accepted_evidence_incomplete")
+        status = QRECandidateLifecycleStatus.EVIDENCE_INCOMPLETE
+
+    return {
+        **identity,
+        "status_model_version": QRE_STATUS_MODEL_VERSION,
+        "scope": dict(_scope_seed(scope)),
+        "sampling_plan_ref": _qre_text(scope.get("sampling_plan_ref")),
+        "accepted_lineage_count": int(context.accepted_lineage_count),
+        "accepted_oos_count": int(context.accepted_oos_count),
+        "status": status.value,
+        "blockers": _qre_unique(blockers),
+        "authority": {
+            "non_authoritative": True,
+            "can_promote_candidate": False,
+            "can_activate_shadow": False,
+            "can_activate_paper": False,
+            "can_activate_live": False,
+        },
+    }
+
+
+def assert_unique_qre_scope(records: list[dict[str, Any]]) -> None:
+    seen: set[str] = set()
+    for record in records:
+        signature = _qre_text(record.get("scope_signature"))
+        if signature in seen:
+            raise QREDuplicateScopeError(f"duplicate scope signature: {signature}")
+        seen.add(signature)
 
 
 def is_active_in_v3_12(status: CandidateLifecycleStatus) -> bool:

--- a/research/qre_candidate_identity_lifecycle.py
+++ b/research/qre_candidate_identity_lifecycle.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import candidate_lifecycle
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_candidate_identity_lifecycle"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_candidate_identity_lifecycle")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_candidate_identity_lifecycle/"
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _load_scope_rows(breadth_report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = breadth_report.get("coverage_matrix") if isinstance(breadth_report.get("coverage_matrix"), list) else []
+    return [
+        dict(row)
+        for row in rows
+        if isinstance(row, Mapping) and _text(row.get("dimension")) == "basket"
+    ]
+
+
+def _build_scope(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "hypothesis_id": _text(row.get("hypothesis_id")) or "unknown_hypothesis",
+        "behavior_id": _text(row.get("behavior_id")) or "unknown_behavior",
+        "preset_id": _text(row.get("scope_key")) or _text(row.get("preset_id")) or "unknown_preset",
+        "timeframe": _text(row.get("timeframe")) or "unknown_timeframe",
+        "universe_or_basket_scope": _text(row.get("scope_label")) or _text(row.get("scope_key")),
+        "region": _text(row.get("region")),
+        "symbol": _text(row.get("symbol")),
+        "sampling_plan_ref": _text(row.get("sampling_plan_ref")),
+    }
+
+
+def build_qre_candidate_identity_lifecycle(
+    *,
+    breadth_report: Mapping[str, Any],
+    disposition_memory: Mapping[str, Any] | None = None,
+    closure_report: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    scope_rows = _load_scope_rows(breadth_report)
+    disposition_record = disposition_memory.get("record") if isinstance(disposition_memory, Mapping) and isinstance(disposition_memory.get("record"), Mapping) else {}
+    rejected_scope_key = _text((disposition_record.get("disposition_scope") or {}).get("preset_id")) or _text(disposition_record.get("preset_id"))
+    evidence_complete_count = int(((closure_report or {}).get("evidence_complete_count")) or 0)
+
+    records: list[dict[str, Any]] = []
+    for row in scope_rows:
+        scope = _build_scope(row)
+        suppressed = _text(row.get("scope_key")) == rejected_scope_key and int(row.get("accepted_oos_count") or 0) == 0
+        context = candidate_lifecycle.QRETransitionContext(
+            accepted_lineage_count=int(row.get("accepted_lineage_count") or 0),
+            accepted_oos_count=int(row.get("accepted_oos_count") or 0),
+            evidence_complete=evidence_complete_count > 0 and int(row.get("accepted_oos_count") or 0) > 0,
+            rejected_scope=suppressed and evidence_complete_count == 0,
+            suppressed_scope=suppressed,
+        )
+        record = candidate_lifecycle.build_qre_candidate_record(scope, context=context)
+        record["source_scope_ref"] = f"coverage_matrix::{_text(row.get('scope_key'))}"
+        records.append(record)
+
+    candidate_lifecycle.assert_unique_qre_scope(records)
+    records.sort(key=lambda row: (str(row["status"]), str(row["candidate_id"])))
+    status_counts = Counter(str(row["status"]) for row in records)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "candidate_count": len(records),
+            "status_counts": dict(sorted(status_counts.items())),
+            "evidence_complete_count": sum(1 for row in records if row["status"] == "evidence_complete"),
+            "suppressed_count": sum(1 for row in records if row["status"] == "suppressed"),
+            "rejected_count": sum(1 for row in records if row["status"] == "rejected"),
+            "final_recommendation": "qre_candidate_lifecycle_fail_closed",
+            "operator_summary": (
+                "Candidate identity and lifecycle remain fail-closed: rejected or duplicate scopes are blocked, "
+                "and no candidate advances beyond evidence completeness without explicit prerequisite gates."
+            ),
+        },
+        "rows": records,
+        "authority": {
+            "non_authoritative": True,
+            "can_promote_candidate": False,
+            "can_activate_shadow": False,
+            "can_activate_paper": False,
+            "can_activate_live": False,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "uses_subprocess": False,
+            "candidate_promotion_forbidden": True,
+            "shadow_paper_live_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    lines = [
+        "# QRE Candidate Identity Lifecycle",
+        "",
+        f"- candidate_count: {summary.get('candidate_count', 0)}",
+        f"- evidence_complete_count: {summary.get('evidence_complete_count', 0)}",
+        f"- suppressed_count: {summary.get('suppressed_count', 0)}",
+        f"- rejected_count: {summary.get('rejected_count', 0)}",
+        "",
+        "## Candidates",
+    ]
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        lines.append(
+            f"- {row.get('candidate_id')} status={row.get('status')} blockers={','.join(row.get('blockers', [])) or 'none'}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_candidate_identity_lifecycle",
+        description="Build a fail-closed QRE candidate identity and lifecycle report.",
+    )
+    parser.add_argument("--breadth-report", required=True)
+    parser.add_argument("--disposition-memory", default="")
+    parser.add_argument("--closure-report", default="")
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    breadth_report = _read_json(Path(args.breadth_report)) or {}
+    disposition_memory = _read_json(Path(args.disposition_memory)) if args.disposition_memory else {}
+    closure_report = _read_json(Path(args.closure_report)) if args.closure_report else {}
+    report = build_qre_candidate_identity_lifecycle(
+        breadth_report=breadth_report,
+        disposition_memory=disposition_memory,
+        closure_report=closure_report,
+    )
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+

--- a/tests/unit/test_qre_candidate_identity_lifecycle.py
+++ b/tests/unit/test_qre_candidate_identity_lifecycle.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from research import candidate_lifecycle
+from research import qre_candidate_identity_lifecycle as lifecycle_report
+
+
+def test_qre_identity_is_deterministic() -> None:
+    scope = {
+        "hypothesis_id": "h1",
+        "behavior_id": "b1",
+        "preset_id": "p1",
+        "timeframe": "1d",
+        "universe_or_basket_scope": "basket-a",
+    }
+    first = candidate_lifecycle.build_qre_candidate_identity(scope)
+    second = candidate_lifecycle.build_qre_candidate_identity(scope)
+
+    assert first == second
+    assert first["candidate_id"].startswith("qre_cand_")
+    assert first["candidate_version"].startswith("qre_v_")
+
+
+def test_qre_record_fails_closed_for_rejected_or_duplicate_scope() -> None:
+    scope = {
+        "hypothesis_id": "h1",
+        "behavior_id": "b1",
+        "preset_id": "p1",
+        "timeframe": "1d",
+        "universe_or_basket_scope": "basket-a",
+    }
+    rejected = candidate_lifecycle.build_qre_candidate_record(
+        scope,
+        context=candidate_lifecycle.QRETransitionContext(rejected_scope=True),
+    )
+    duplicate = candidate_lifecycle.build_qre_candidate_record(
+        scope,
+        context=candidate_lifecycle.QRETransitionContext(duplicate_scope=True),
+    )
+
+    assert rejected["status"] == "rejected"
+    assert "rejected_scope_cannot_become_candidate" in rejected["blockers"]
+    assert duplicate["status"] == "suppressed"
+    assert "duplicate_scope_blocked" in duplicate["blockers"]
+
+
+@pytest.mark.parametrize(
+    ("from_status", "to_status", "context"),
+    [
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.EVIDENCE_INCOMPLETE,
+            candidate_lifecycle.QRECandidateLifecycleStatus.EVIDENCE_COMPLETE,
+            candidate_lifecycle.QRETransitionContext(
+                accepted_lineage_count=1,
+                accepted_oos_count=1,
+                evidence_complete=True,
+            ),
+        ),
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.EVIDENCE_COMPLETE,
+            candidate_lifecycle.QRECandidateLifecycleStatus.QUALITY_REVIEW,
+            candidate_lifecycle.QRETransitionContext(evidence_complete=True),
+        ),
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.QUALITY_REVIEW,
+            candidate_lifecycle.QRECandidateLifecycleStatus.PROMOTION_REVIEW,
+            candidate_lifecycle.QRETransitionContext(quality_gate_passed=True),
+        ),
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.PROMOTION_REVIEW,
+            candidate_lifecycle.QRECandidateLifecycleStatus.SHADOW_READINESS_CANDIDATE,
+            candidate_lifecycle.QRETransitionContext(
+                promotion_gate_passed=True,
+                readiness_gate_passed=True,
+                operator_shadow_authority=True,
+            ),
+        ),
+    ],
+)
+def test_qre_allowed_transitions(from_status, to_status, context) -> None:
+    candidate_lifecycle.validate_qre_transition(from_status, to_status, context=context)
+
+
+@pytest.mark.parametrize(
+    ("from_status", "to_status", "context", "message"),
+    [
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.EVIDENCE_INCOMPLETE,
+            candidate_lifecycle.QRECandidateLifecycleStatus.EVIDENCE_COMPLETE,
+            candidate_lifecycle.QRETransitionContext(),
+            "evidence_complete_requires_accepted_evidence",
+        ),
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.EVIDENCE_COMPLETE,
+            candidate_lifecycle.QRECandidateLifecycleStatus.QUALITY_REVIEW,
+            candidate_lifecycle.QRETransitionContext(evidence_complete=False),
+            "quality_review_requires_evidence_complete",
+        ),
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.QUALITY_REVIEW,
+            candidate_lifecycle.QRECandidateLifecycleStatus.PROMOTION_REVIEW,
+            candidate_lifecycle.QRETransitionContext(quality_gate_passed=False),
+            "promotion_review_requires_quality_gate",
+        ),
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.PROMOTION_REVIEW,
+            candidate_lifecycle.QRECandidateLifecycleStatus.SHADOW_READINESS_CANDIDATE,
+            candidate_lifecycle.QRETransitionContext(promotion_gate_passed=True, readiness_gate_passed=False),
+            "shadow_readiness_requires_readiness_gate",
+        ),
+        (
+            candidate_lifecycle.QRECandidateLifecycleStatus.DRAFT,
+            candidate_lifecycle.QRECandidateLifecycleStatus.PROMOTION_REVIEW,
+            candidate_lifecycle.QRETransitionContext(),
+            "is not permitted",
+        ),
+    ],
+)
+def test_qre_forbidden_transitions(from_status, to_status, context, message) -> None:
+    with pytest.raises(candidate_lifecycle.QREInvalidTransitionError, match=message):
+        candidate_lifecycle.validate_qre_transition(from_status, to_status, context=context)
+
+
+def test_duplicate_scope_detector_raises() -> None:
+    scope = {
+        "hypothesis_id": "h1",
+        "behavior_id": "b1",
+        "preset_id": "p1",
+        "timeframe": "1d",
+        "universe_or_basket_scope": "basket-a",
+    }
+    record = candidate_lifecycle.build_qre_candidate_record(
+        scope,
+        context=candidate_lifecycle.QRETransitionContext(),
+    )
+    with pytest.raises(candidate_lifecycle.QREDuplicateScopeError):
+        candidate_lifecycle.assert_unique_qre_scope([record, dict(record)])
+
+
+def test_qre_candidate_lifecycle_report_is_fail_closed_and_writable(tmp_path: Path) -> None:
+    breadth_report = {
+        "coverage_matrix": [
+            {
+                "dimension": "basket",
+                "scope_key": "preset_rejected",
+                "scope_label": "basket-rejected",
+                "accepted_lineage_count": 1,
+                "accepted_oos_count": 0,
+                "hypothesis_id": "h1",
+                "behavior_id": "b1",
+                "timeframe": "1d",
+            },
+            {
+                "dimension": "basket",
+                "scope_key": "preset_candidate",
+                "scope_label": "basket-candidate",
+                "accepted_lineage_count": 0,
+                "accepted_oos_count": 0,
+                "hypothesis_id": "h2",
+                "behavior_id": "b2",
+                "timeframe": "1d",
+            },
+        ]
+    }
+    disposition_memory = {
+        "record": {
+            "preset_id": "preset_rejected",
+            "disposition_scope": {"preset_id": "preset_rejected"},
+        }
+    }
+    closure_report = {"evidence_complete_count": 0}
+
+    report = lifecycle_report.build_qre_candidate_identity_lifecycle(
+        breadth_report=breadth_report,
+        disposition_memory=disposition_memory,
+        closure_report=closure_report,
+    )
+    paths = lifecycle_report.write_outputs(report, repo_root=tmp_path)
+
+    assert report["summary"]["candidate_count"] == 2
+    assert report["summary"]["suppressed_count"] + report["summary"]["rejected_count"] >= 1
+    assert all(row["authority"]["can_promote_candidate"] is False for row in report["rows"])
+    assert paths["latest"] == "logs/qre_candidate_identity_lifecycle/latest.json"
+    source = Path("research/qre_candidate_identity_lifecycle.py").read_text(encoding="utf-8")
+    assert "AAPL" not in source
+    assert "NVDA" not in source


### PR DESCRIPTION
## Summary
- extend the existing candidate lifecycle module with a QRE-specific fail-closed identity and transition model
- add a read-only candidate identity/lifecycle report driven by breadth plus rejected-scope context
- index the new lifecycle artifact in research memory and cover allowed and forbidden transitions with tests

## Testing
- python -m pytest tests/unit/test_candidate_lifecycle.py tests/unit/test_qre_candidate_identity_lifecycle.py tests/unit/test_qre_research_memory.py tests/unit/test_qre_research_memory_current_artifacts.py tests/smoke -q
- python scripts/governance_lint.py