### PR TITLE
docs: reconcile QRE maturity after autonomous cascade

### DIFF
--- a/docs/roadmap/qre_maturity_reconciliation_after_autonomous_cascade.md
+++ b/docs/roadmap/qre_maturity_reconciliation_after_autonomous_cascade.md
@@ -1,0 +1,270 @@
+# QRE Maturity Reconciliation After Autonomous Cascade
+
+## Overall Result
+
+`WORKING_READ_ONLY_EXPANSION_WITH_EVIDENCE_STILL_FAIL_CLOSED`
+
+This audit is repository-backed against:
+
+- `docs/roadmap/qre_maturity_roadmap_to_100.md`
+- merged implementations under `research/` and `packages/`
+- unit and smoke tests
+- current local artifacts under `logs/` and `research/history/`
+
+It does not award maturity for code existence alone. A capability only counts when implementation, tests, integration, and current repository state support the claim.
+
+## PR Sequence Reconciled
+
+| PR | Work Package | Merge SHA | Repo-backed outcome |
+| --- | --- | --- | --- |
+| `#582` | hypothesis disposition memory | `902588fe91db756341e6ab0286d3142cd6da83a3` | durable rejected-scope memory implementation merged |
+| `#583` | rejected-outcome research-cycle routing | `8bb0517cba91a657f41359394ebdbfcdc0ad4f31` | deterministic next-cycle router implemented and tested |
+| `#584` | evidence breadth | `dfb63e463549cabeedc49b93840eaf34b5247595` | generic breadth matrix implemented and tested |
+| `#586` | research memory and retrieval | `9d58d50e44fc364f27d0817ee56cbe472e1f29fb` | deterministic retrieval queries with provenance implemented |
+| `#587` | null-control and falsification suite | `dfb22047b2f0308f38e2ab0dd4a2427e607cf627` | preregistered null-control framework implemented and tested |
+| `#588` | candidate identity and lifecycle | `e6f9525728d51a9d5f0f416cdc4b986025d2c1c3` | fail-closed candidate identity and lifecycle implemented |
+| `#589` | candidate quality | `21f884cee29404015ab94d6f4ab92bf5d7f4b57a` | accepted-evidence-only quality gate implemented |
+| `#590` | multi-basket portfolio intelligence | `1340d260d83b645179181f886a85e6f36ca00bd8` | read-only overlap and concentration intelligence implemented |
+| `#591` | trusted-loop operational controls | `bf6adbda832ae99a773e135c5478536822060342` | deterministic run reconciliation and resumability context implemented |
+| `#592` | shadow-readiness deferral gates | `1f8441f64523011d43c99a4401997d0000daba3c` | explicit read-only shadow deferral gate implemented |
+
+## Current Evidence State
+
+Current repository-backed state from `logs/qre_multiwindow_evidence_closure/latest.json`, `python -m research.qre_candidate_quality_framework`, `python -m research.qre_multibasket_portfolio_intelligence`, `python -m research.qre_trusted_loop_operational_controls`, and `python -m research.qre_shadow_readiness_gates`:
+
+- supported hypotheses: `0`
+- rejected hypotheses: `1`
+- accepted lineage: `4`
+- accepted OOS: `0`
+- evidence-complete scopes: `0`
+- null-control-complete scopes: `0`
+- lifecycle candidates: `15`
+- quality-review candidates: `0`
+- shadow-ready candidates: `0`
+
+Observed current blockers remain real:
+
+- `closure_status = all_windows_no_oos_trades`
+- `recommended_next_action = reject_hypothesis`
+- candidate quality summary status = `blocked_evidence_incomplete`
+- portfolio intelligence summary status = `blocked_no_accepted_oos`
+- shadow readiness summary status = `shadow_readiness_deferred`
+
+## Capability Classification
+
+| Capability | Classification | Evidence | What does not count yet |
+| --- | --- | --- | --- |
+| Hypothesis disposition memory | `working_read_only` | `research/qre_hypothesis_disposition_memory.py`, tests, retrieval references | current `logs/qre_hypothesis_disposition_memory/latest.json` is absent, so there is no current persisted operator artifact |
+| Research cycle router | `working_read_only` | `research/qre_research_cycle_router.py`, `tests/unit/test_qre_research_cycle_router.py` | current `logs/qre_research_cycle_router/latest.json` is absent |
+| Evidence breadth framework | `exercised` | `research/qre_evidence_breadth_framework.py`, tests, current breadth-dependent modules, live read-only status in shadow gate | no accepted OOS or evidence-complete scope |
+| Research memory | `integrated` | `packages/qre_research/research_memory.py`, artifact indexing extended through WP10 | retrieval remains context only |
+| Research memory retrieval | `exercised` | `research/qre_research_memory_retrieval.py`, tests, provenance-preserving queries | current result quality depends on which artifacts actually exist |
+| Null-control suite | `working_read_only` | `research/qre_null_control_falsification_suite.py`, tests, quality/shadow call sites | current `latest.json` is absent and no controls are materialized for production scopes |
+| Candidate identity and lifecycle | `exercised` | `research/qre_candidate_identity_lifecycle.py`, tests, current fallback-built lifecycle state used by quality and shadow gates | all 15 rows remain `evidence_incomplete` |
+| Candidate quality framework | `exercised` | `research/qre_candidate_quality_framework.py`, tests, current repo-backed run shows 15 blocked rows | zero accepted OOS means no candidate can qualify |
+| Multi-basket portfolio intelligence | `exercised` | `research/qre_multibasket_portfolio_intelligence.py`, tests, current repo-backed output shows overlap/concentration context | no accepted-OOS candidate set, so production intelligence remains blocked |
+| Trusted-loop operational controls | `exercised` | `research/qre_trusted_loop_operational_controls.py`, tests, current repo-backed output from actual run history | this is not direct runtime resume authority |
+| Shadow-readiness deferral gate | `exercised` | `research/qre_shadow_readiness_gates.py`, tests, current repo-backed blocker set | all activation flags remain forced false |
+
+## Integration Findings
+
+The cascade produced real cross-module integration, not isolated scaffolds:
+
+- `packages/qre_research/research_memory.py` now indexes disposition memory, router, breadth, retrieval, null-control, lifecycle, quality, multibasket, operational-controls, and shadow-readiness artifacts.
+- `research/qre_candidate_quality_framework.py` consumes breadth, lifecycle, multiwindow closure, source quality, null-control context, and reason-record contracts.
+- `research/qre_multibasket_portfolio_intelligence.py` consumes candidate quality and breadth outputs.
+- `research/qre_trusted_loop_review_packet.py` consumes trusted-loop operational controls and shadow readiness gates.
+- `research/qre_shadow_readiness_gates.py` consumes breadth, lifecycle, quality, source quality, operational controls, and trusted-loop review state.
+
+Two important integration gaps remain in current repository state:
+
+1. Some merged capabilities are implemented and tested, but their `latest.json` artifacts are not currently materialized:
+   - `logs/qre_hypothesis_disposition_memory/latest.json`
+   - `logs/qre_research_cycle_router/latest.json`
+   - `logs/qre_null_control_falsification_suite/latest.json`
+2. Because those artifacts are absent, retrieval and gate surfaces correctly fail closed rather than treating code presence as current evidence.
+
+## Current Maturity Estimate
+
+Starting merged baseline before PR `#588`:
+
+| Domain | Start |
+| --- | ---: |
+| Governance/infrastructure | 84 |
+| Evidence production | 45 |
+| Research intelligence | 63 |
+| Candidate quality | 9 |
+| Deployment/live readiness | 0 |
+
+Current conservative estimate after PR `#592`:
+
+| Domain | Start | Final | Change | Implemented evidence | What still does not count | Next major blocker |
+| --- | ---: | ---: | ---: | --- | --- | --- |
+| Governance/infrastructure | 84 | 88 | +4 | deterministic lifecycle/quality/portfolio/trusted-loop/shadow contracts with tests and read-only integrations | missing persisted artifacts are not operator trust; no mutation authority exists | source-authority normalization and artifact-state consolidation |
+| Evidence production | 45 | 46 | +1 | better blocker visibility across breadth, quality, null-control, and shadow gate surfaces | still `accepted_oos = 0`; still `evidence_complete_count = 0` | real accepted OOS across generic scopes |
+| Research intelligence | 63 | 70 | +7 | routed rejection memory, breadth planning, retrieval, quality context, portfolio context, trusted-loop state context | context-only retrieval and blocked production portfolio intelligence do not become evidence authority | stronger integrated source/evidence authority and persisted artifact continuity |
+| Candidate quality | 9 | 14 | +5 | fail-closed lifecycle and accepted-evidence-only quality gate exist and are exercised on current repo state | zero accepted OOS means zero quality-review candidates | real accepted OOS plus null-control completion and reproducibility authority |
+| Deployment/live readiness | 0 | 2 | +2 | explicit shadow-readiness deferral gate and trusted-loop operational prerequisites are implemented | no activation authority, no shadow-ready candidate, all runtime flags still false | evidence-complete candidates and operator-trusted replay/readiness |
+
+## Authority State
+
+### Contract/scaffold
+
+- none of the reconciled PRs are counted as empty scaffolds
+
+### Context-only
+
+- research memory retrieval answers
+- research cycle routing recommendations
+- null-control pass/fail interpretation
+- portfolio overlap and diversification context
+- trusted-loop duplicate-run and replay comparators
+
+### Working read-only
+
+- hypothesis disposition memory implementation
+- research cycle router implementation
+- breadth matrix
+- null-control suite
+- candidate lifecycle
+- candidate quality evaluator
+- multi-basket portfolio intelligence
+- trusted-loop operational controls
+- shadow-readiness deferral gate
+
+### Integrated
+
+- research memory artifact indexing across the new modules
+- candidate quality consumption of lifecycle, breadth, closure, source quality, and reason-record inputs
+- multibasket consumption of quality plus breadth
+- shadow gate consumption of lifecycle, quality, breadth, source-quality, trusted-loop, and audit surfaces
+
+### Exercised
+
+- evidence breadth
+- retrieval integration
+- candidate lifecycle
+- candidate quality
+- multi-basket portfolio intelligence
+- trusted-loop operational controls
+- shadow-readiness deferral gates
+
+These are exercised because implementation, tests, and current repo-backed command outputs exist.
+
+### Evidence-authoritative
+
+- none newly added in this cascade
+
+### Operator-trusted
+
+- none newly added in this cascade
+
+### Deployment-authoritative
+
+- none
+
+## Major Remaining Blocks
+
+### 1. Generic accepted-OOS evidence production across additional justified scopes
+
+Current state:
+
+- breadth, routing, lifecycle, quality, and shadow gates are present
+- accepted lineage exists
+- accepted OOS remains `0`
+
+Missing capability:
+
+- real accepted structured OOS for generic non-exact-failed scopes
+- first evidence-complete scope
+
+Why it matters:
+
+- without accepted OOS, candidate quality, portfolio intelligence, and readiness remain structurally blocked
+
+Exact next PR/work package:
+
+- not another governance-only PR
+- next major work should target generic evidence production on materially novel scopes under existing safety constraints
+
+Dependency:
+
+- may require additional operator approval or new bounded-source approval depending on exact scope and data path
+
+### 2. Source identity and evidence-source authority normalization
+
+Current state:
+
+- source quality readiness is consumed
+- source identity is not yet normalized across lifecycle, quality, breadth, retrieval, and readiness artifacts
+
+Missing capability:
+
+- deterministic source authority classification and provenance normalization across evidence and context artifacts
+
+Why it matters:
+
+- current gates can say source quality is ready, but they do not yet unify source authority at the same maturity level as other QRE blockers
+
+Exact next PR/work package:
+
+- dynamic major block: source identity and data-quality integration / evidence-source authority normalization
+
+Dependency:
+
+- no external fetch required for contract and integration work
+
+### 3. Persisted artifact continuity for merged read-only modules
+
+Current state:
+
+- disposition memory, research cycle router, and null-control suite are implemented and tested
+- current `latest.json` artifacts for those modules are absent
+
+Missing capability:
+
+- deterministic, non-misleading integration path that materializes and preserves those operator-visible artifacts when prerequisites exist
+
+Why it matters:
+
+- current retrieval and readiness state undercounts implemented capability because absent artifacts correctly fail closed
+
+Exact next PR/work package:
+
+- dynamic major block: artifact-state continuity and operator-surface consolidation for merged QRE read-only modules
+
+Dependency:
+
+- no external approval required if work remains read-only and does not mutate frozen outputs
+
+## Safety Confirmation
+
+Repository inspection after PR `#592` supports the following:
+
+- no fake evidence introduced
+- no maturity inflation from reports alone
+- no generated report treated as source evidence
+- no invented IDs, trades, metrics, costs, windows, regimes, or lineage in the reconciled counts
+- no outcome-based retry of the rejected exact scope
+- no threshold weakening
+- no OOS tuning
+- no automatic strategy registration
+- no candidate promotion
+- no shadow, paper, or live activation
+- no broker, risk, or execution changes
+- frozen research outputs remain unchanged
+- protected runtime paths remain untouched
+- no AAPL/NVDA special-casing was introduced in the new generic core modules
+
+## Next Safe Direction
+
+The largest remaining safe block that does not require protected-path mutation or fake evidence is:
+
+`source identity and evidence-source authority normalization`
+
+Reason:
+
+- it is explicitly aligned with the canonical roadmap’s artifact-authority and evidence-quality tracks
+- it strengthens multiple merged modules at once
+- it does not depend on fabricating accepted OOS
+- it improves operator trust without implying deployment authority


### PR DESCRIPTION
## Summary
- add a repository-backed QRE maturity reconciliation after the autonomous cascade
- classify merged capabilities by real authority level instead of counting files alone
- document current evidence counts, integration gaps, and the next major safe block

## Testing
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check