### PR TITLE
feat: add source identity authority normalization

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -37,6 +37,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_candidate_identity_lifecycle/latest.json"),
     Path("logs/qre_candidate_quality_framework/latest.json"),
     Path("logs/qre_multibasket_portfolio_intelligence/latest.json"),
+    Path("logs/qre_source_identity_authority_normalization/latest.json"),
     Path("logs/qre_trusted_loop_operational_controls/latest.json"),
     Path("logs/qre_shadow_readiness_gates/latest.json"),
 )

--- a/packages/qre_research/retrieval_coverage.py
+++ b/packages/qre_research/retrieval_coverage.py
@@ -34,6 +34,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/sampling_intelligence_minimal/latest.json"),
     Path("logs/qre_candidate_quality_framework/latest.json"),
     Path("logs/qre_multibasket_portfolio_intelligence/latest.json"),
+    Path("logs/qre_source_identity_authority_normalization/latest.json"),
     Path("logs/qre_trusted_loop_operational_controls/latest.json"),
     Path("logs/qre_shadow_readiness_gates/latest.json"),
 )

--- a/research/qre_candidate_quality_framework.py
+++ b/research/qre_candidate_quality_framework.py
@@ -17,6 +17,9 @@ from research.qre_reason_record_contract import (
     build_reason_record_contract_snapshot,
     validate_reason_record_contract,
 )
+from research.qre_source_identity_authority_normalization import (
+    build_source_identity_authority_report,
+)
 
 
 QualityStatus = Literal[
@@ -47,6 +50,7 @@ DEFAULT_CLOSURE_PATH: Final[Path] = Path("logs/qre_multiwindow_evidence_closure/
 DEFAULT_DISPOSITION_MEMORY_PATH: Final[Path] = Path("logs/qre_hypothesis_disposition_memory/latest.json")
 DEFAULT_NULL_CONTROL_PATH: Final[Path] = Path("logs/qre_null_control_falsification_suite/latest.json")
 DEFAULT_REASON_RECORD_CONTRACT_PATH: Final[Path] = Path("logs/qre_reason_record_contract/latest.json")
+DEFAULT_SOURCE_AUTHORITY_PATH: Final[Path] = Path("logs/qre_source_identity_authority_normalization/latest.json")
 MIN_ACCEPTED_OOS_TRADE_COUNT: Final[int] = 1
 
 
@@ -112,6 +116,12 @@ def _load_reason_record_contract(repo_root: Path) -> dict[str, Any]:
     return _read_json(repo_root / DEFAULT_REASON_RECORD_CONTRACT_PATH) or build_reason_record_contract_snapshot()
 
 
+def _load_source_authority_report(repo_root: Path) -> dict[str, Any]:
+    return _read_json(repo_root / DEFAULT_SOURCE_AUTHORITY_PATH) or build_source_identity_authority_report(
+        repo_root=repo_root
+    )
+
+
 def _breadth_index(breadth_report: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
     rows = breadth_report.get("coverage_matrix") if isinstance(breadth_report.get("coverage_matrix"), list) else []
     indexed: dict[str, dict[str, Any]] = {}
@@ -175,6 +185,19 @@ def _find_control_family(rows: Sequence[Mapping[str, Any]], family: str) -> dict
     return None
 
 
+def _source_authority_index(source_authority_report: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
+    rows = (
+        source_authority_report.get("rows")
+        if isinstance(source_authority_report, Mapping) and isinstance(source_authority_report.get("rows"), list)
+        else []
+    )
+    return {
+        _text(row.get("scope_key")): dict(row)
+        for row in rows
+        if isinstance(row, Mapping) and _text(row.get("scope_key"))
+    }
+
+
 def _quality_dimensions(
     *,
     candidate: Mapping[str, Any],
@@ -182,6 +205,7 @@ def _quality_dimensions(
     closure_report: Mapping[str, Any],
     null_control_report: Mapping[str, Any] | None,
     source_quality_status: Mapping[str, Any],
+    source_authority_row: Mapping[str, Any] | None,
 ) -> dict[str, dict[str, Any]]:
     accepted_lineage_count = int(candidate.get("accepted_lineage_count") or 0)
     accepted_oos_count = int(candidate.get("accepted_oos_count") or 0)
@@ -246,10 +270,21 @@ def _quality_dimensions(
             "reason_code": "reproducibility_not_authoritative",
         },
         "source_quality": {
-            "passed": bool(source_quality_status.get("research_ready"))
-            and not any("source_quality" in _text(reason) for reason in blocker_reasons),
-            "observed": _text(source_quality_status.get("status")) or "missing",
-            "reason_code": "source_quality_not_ready",
+            "passed": (
+                _text((source_authority_row or {}).get("authority_status")) == "normalized_context_ready"
+                if source_authority_row is not None
+                else bool(source_quality_status.get("research_ready"))
+                and not any("source_quality" in _text(reason) for reason in blocker_reasons)
+            ),
+            "observed": (
+                _text((source_authority_row or {}).get("authority_status"))
+                or _text(source_quality_status.get("status"))
+                or "missing"
+            ),
+            "reason_code": (
+                _text(((source_authority_row or {}).get("authority_reasons") or [None])[0])
+                or "source_quality_not_ready"
+            ),
         },
         "artifact_completeness": {
             "passed": accepted_lineage_count > 0 and accepted_oos_count > 0,
@@ -320,6 +355,7 @@ def evaluate_candidate_quality(
     null_control_report: Mapping[str, Any] | None,
     source_quality_status: Mapping[str, Any],
     reason_record_contract: Mapping[str, Any],
+    source_authority_report: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     lifecycle_rows = (
         candidate_report.get("rows")
@@ -369,6 +405,7 @@ def evaluate_candidate_quality(
         }
 
     breadth_by_scope = _breadth_index(breadth_report)
+    source_authority_by_scope = _source_authority_index(source_authority_report)
     rows: list[dict[str, Any]] = []
     for raw_candidate in lifecycle_rows:
         if not isinstance(raw_candidate, Mapping):
@@ -376,12 +413,14 @@ def evaluate_candidate_quality(
         candidate = dict(raw_candidate)
         scope_key = _candidate_scope_ref(candidate)
         scope_row = breadth_by_scope.get(scope_key)
+        source_authority_row = source_authority_by_scope.get(scope_key)
         dimensions = _quality_dimensions(
             candidate=candidate,
             scope_row=scope_row,
             closure_report=closure_report,
             null_control_report=null_control_report,
             source_quality_status=source_quality_status,
+            source_authority_row=source_authority_row,
         )
         status, blocker_codes = _determine_status(candidate=candidate, dimensions=dimensions)
         digest = _digest(
@@ -404,6 +443,9 @@ def evaluate_candidate_quality(
             "scope_key": scope_key,
             "scope_signature": candidate.get("scope_signature"),
             "source_scope_ref": candidate.get("source_scope_ref"),
+            "source_authority_ref": (
+                f"{DEFAULT_SOURCE_AUTHORITY_PATH.as_posix()}#rows::{scope_key}" if source_authority_row else None
+            ),
             "accepted_lineage_count": candidate.get("accepted_lineage_count"),
             "accepted_oos_count": candidate.get("accepted_oos_count"),
             "quality_dimensions": dimensions,
@@ -471,6 +513,7 @@ def evaluate_candidate_quality(
             "closure_report_kind": closure_report.get("report_kind"),
             "null_control_report_kind": (null_control_report or {}).get("report_kind"),
             "source_quality_status": dict(source_quality_status),
+            "source_authority_report_kind": (source_authority_report or {}).get("report_kind"),
             "reason_record_contract": {
                 "report_kind": reason_record_contract.get("report_kind"),
                 "validation_status": (
@@ -515,6 +558,7 @@ def build_candidate_quality_framework(*, repo_root: Path = Path(".")) -> dict[st
     if isinstance(null_control_report, Mapping):
         null_control_report = evaluate_null_control_suite(null_control_report)
     source_quality_status = read_source_quality_status(repo_root=repo_root)
+    source_authority_report = _load_source_authority_report(repo_root)
     reason_record_contract = _load_reason_record_contract(repo_root)
     return evaluate_candidate_quality(
         candidate_report=lifecycle_report,
@@ -523,6 +567,7 @@ def build_candidate_quality_framework(*, repo_root: Path = Path(".")) -> dict[st
         null_control_report=null_control_report,
         source_quality_status=source_quality_status,
         reason_record_contract=reason_record_contract,
+        source_authority_report=source_authority_report,
     )
 
 

--- a/research/qre_research_memory_retrieval.py
+++ b/research/qre_research_memory_retrieval.py
@@ -28,6 +28,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_hypothesis_disposition_memory/latest.json"),
     Path("logs/qre_research_cycle_router/latest.json"),
     Path("logs/qre_evidence_breadth_framework/latest.json"),
+    Path("logs/qre_source_identity_authority_normalization/latest.json"),
     Path("logs/qre_preregistered_multiwindow_evidence_run/latest.json"),
     Path("logs/qre_multiwindow_evidence_closure/latest.json"),
 )
@@ -178,9 +179,20 @@ def _inadequate_sample_density_presets(breadth_rows: Sequence[Mapping[str, Any]]
     }
 
 
-def _recurring_failures(disposition_index: Mapping[str, Any], breadth_rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+def _recurring_failures(
+    disposition_index: Mapping[str, Any],
+    breadth_rows: Sequence[Mapping[str, Any]],
+    source_authority: Mapping[str, Any] | None,
+) -> dict[str, Any]:
     counts = Counter(str(reason) for row in breadth_rows for reason in row.get("blocker_reasons", []))
     counts.update(str(reason) for reason in disposition_index.get("failure_classes", []))
+    authority_rows = source_authority.get("rows") if isinstance(source_authority, Mapping) and isinstance(source_authority.get("rows"), list) else []
+    counts.update(
+        str(reason)
+        for row in authority_rows
+        if isinstance(row, Mapping)
+        for reason in row.get("authority_reasons", [])
+    )
     rows = [
         {"failure_or_blocker": key, "count": count}
         for key, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
@@ -192,6 +204,7 @@ def _recurring_failures(disposition_index: Mapping[str, Any], breadth_rows: Sequ
         "provenance": [
             _provenance("logs/qre_hypothesis_disposition_memory/latest.json"),
             _provenance("logs/qre_evidence_breadth_framework/latest.json"),
+            _provenance("logs/qre_source_identity_authority_normalization/latest.json"),
         ],
     }
 
@@ -282,6 +295,7 @@ def build_research_memory_retrieval(
     artifacts = {path.as_posix(): _read_json(repo_root / path) for path in artifact_paths}
     disposition_index = _disposition_index(artifacts.get("logs/qre_hypothesis_disposition_memory/latest.json"))
     breadth_rows = _breadth_rows(artifacts.get("logs/qre_evidence_breadth_framework/latest.json"))
+    source_authority = artifacts.get("logs/qre_source_identity_authority_normalization/latest.json")
     router = artifacts.get("logs/qre_research_cycle_router/latest.json")
     campaign = artifacts.get("logs/qre_preregistered_multiwindow_evidence_run/latest.json")
 
@@ -290,7 +304,7 @@ def build_research_memory_retrieval(
         _materially_similar_scope_rejected(disposition_index),
         _regimes_with_no_trades(disposition_index, campaign),
         _inadequate_sample_density_presets(breadth_rows),
-        _recurring_failures(disposition_index, breadth_rows),
+        _recurring_failures(disposition_index, breadth_rows, source_authority),
         _novel_remaining_directions(router),
         _contradictory_outcomes(disposition_index, breadth_rows),
         _stale_or_superseded_knowledge(artifacts, memory),

--- a/research/qre_shadow_readiness_gates.py
+++ b/research/qre_shadow_readiness_gates.py
@@ -12,6 +12,9 @@ from packages.qre_data.source_quality_readiness import read_source_quality_statu
 from research.qre_candidate_quality_framework import build_candidate_quality_framework
 from research.qre_candidate_identity_lifecycle import build_qre_candidate_identity_lifecycle
 from research.qre_evidence_breadth_framework import build_evidence_breadth_framework
+from research.qre_source_identity_authority_normalization import (
+    build_source_identity_authority_report,
+)
 from research.qre_trusted_loop_operational_controls import (
     build_trusted_loop_operational_controls,
 )
@@ -32,6 +35,7 @@ OPERATIONAL_CONTROLS_PATH: Final[Path] = Path("logs/qre_trusted_loop_operational
 TRUSTED_LOOP_REVIEW_PATH: Final[Path] = Path("logs/qre_trusted_loop_review/latest.json")
 DISPOSITION_MEMORY_PATH: Final[Path] = Path("logs/qre_hypothesis_disposition_memory/latest.json")
 MULTIWINDOW_CLOSURE_PATH: Final[Path] = Path("logs/qre_multiwindow_evidence_closure/latest.json")
+SOURCE_AUTHORITY_PATH: Final[Path] = Path("logs/qre_source_identity_authority_normalization/latest.json")
 
 
 def _text(value: Any) -> str:
@@ -92,6 +96,12 @@ def _load_operational_controls(repo_root: Path) -> dict[str, Any]:
     )
 
 
+def _load_source_authority_report(repo_root: Path) -> dict[str, Any]:
+    return _read_json(repo_root / SOURCE_AUTHORITY_PATH) or build_source_identity_authority_report(
+        repo_root=repo_root
+    )
+
+
 def _load_trusted_loop_review(repo_root: Path) -> dict[str, Any]:
     return _read_json(repo_root / TRUSTED_LOOP_REVIEW_PATH) or {}
 
@@ -103,6 +113,7 @@ def _prerequisite_state(
     null_control_report: Mapping[str, Any],
     lifecycle_report: Mapping[str, Any],
     source_quality_status: Mapping[str, Any],
+    source_authority_report: Mapping[str, Any],
     operational_controls_report: Mapping[str, Any],
     trusted_loop_review: Mapping[str, Any],
 ) -> dict[str, dict[str, Any]]:
@@ -165,9 +176,9 @@ def _prerequisite_state(
             "source_ref": BREADTH_PATH.as_posix(),
         },
         "source_quality": {
-            "passed": bool(source_quality_status.get("research_ready")),
-            "observed": source_quality_status.get("status"),
-            "source_ref": "logs/qre_data_source_quality_readiness/latest.json",
+            "passed": int(((source_authority_report.get("summary") or {}).get("blocked_scope_count")) or 0) == 0,
+            "observed": (source_authority_report.get("summary") or {}).get("authority_status_counts") or {},
+            "source_ref": SOURCE_AUTHORITY_PATH.as_posix(),
         },
         "replayability": {
             "passed": bool((operational_summary.get("trusted_loop_operational_controls_ready"))),
@@ -285,6 +296,7 @@ def build_shadow_readiness_gates(*, repo_root: Path = Path(".")) -> dict[str, An
     null_control_report = _load_null_control_report(repo_root)
     lifecycle_report = _load_lifecycle_report(repo_root)
     source_quality_status = read_source_quality_status(repo_root=repo_root)
+    source_authority_report = _load_source_authority_report(repo_root)
     operational_controls_report = _load_operational_controls(repo_root)
     trusted_loop_review = _load_trusted_loop_review(repo_root)
 
@@ -294,6 +306,7 @@ def build_shadow_readiness_gates(*, repo_root: Path = Path(".")) -> dict[str, An
         null_control_report=null_control_report,
         lifecycle_report=lifecycle_report,
         source_quality_status=source_quality_status,
+        source_authority_report=source_authority_report,
         operational_controls_report=operational_controls_report,
         trusted_loop_review=trusted_loop_review,
     )
@@ -342,6 +355,7 @@ def build_shadow_readiness_gates(*, repo_root: Path = Path(".")) -> dict[str, An
             "quality_report_kind": quality_report.get("report_kind"),
             "null_control_report_kind": null_control_report.get("report_kind"),
             "lifecycle_report_kind": lifecycle_report.get("report_kind"),
+            "source_authority_report_kind": source_authority_report.get("report_kind"),
             "operational_controls_report_kind": operational_controls_report.get("report_kind"),
             "trusted_loop_review_kind": trusted_loop_review.get("report_kind"),
             "source_quality_status": dict(source_quality_status),

--- a/research/qre_source_identity_authority_normalization.py
+++ b/research/qre_source_identity_authority_normalization.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_data.symbology_resolver import resolve_symbology_row
+from packages.qre_data.source_quality_readiness import (
+    build_source_quality_report,
+)
+from research.equity_universe_identity import build_instrument_identity_report
+from research.qre_discovery_source_identity_diagnostics import (
+    build_source_identity_diagnostics,
+)
+from research.qre_evidence_breadth_framework import build_evidence_breadth_framework
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_source_identity_authority_normalization"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_source_identity_authority_normalization")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_source_identity_authority_normalization/"
+DEFAULT_BREADTH_PATH: Final[Path] = Path("logs/qre_evidence_breadth_framework/latest.json")
+DEFAULT_SOURCE_QUALITY_PATH: Final[Path] = Path("logs/qre_data_source_quality_readiness/latest.json")
+DEFAULT_DISCOVERY_IDENTITY_PATH: Final[Path] = Path("logs/qre_discovery_source_identity_diagnostics/latest.json")
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _rel(path: Path, *, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _breadth_rows(breadth_report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = breadth_report.get("coverage_matrix") if isinstance(breadth_report.get("coverage_matrix"), list) else []
+    return [
+        dict(row)
+        for row in rows
+        if isinstance(row, Mapping) and _text(row.get("dimension")) == "basket"
+    ]
+
+
+def _scope_components(scope_key: str) -> dict[str, str]:
+    parts = [part for part in scope_key.split("::") if part]
+    preset_id = parts[1] if len(parts) >= 2 else ""
+    symbol = parts[2] if len(parts) >= 3 else ""
+    timeframe = ""
+    for candidate in ("1m", "5m", "15m", "30m", "1h", "4h", "1d", "daily", "weekly"):
+        needle = f"_{candidate}_"
+        if needle in f"_{preset_id}_":
+            timeframe = "1d" if candidate == "daily" else candidate
+            break
+    behavior_id = preset_id
+    for suffix in ("_daily_v1", "_4h_v1", "_1d_v1", "_weekly_v1", "_v1"):
+        if behavior_id.endswith(suffix):
+            behavior_id = behavior_id[: -len(suffix)]
+            break
+    return {
+        "preset_id": preset_id,
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "behavior_id": behavior_id,
+    }
+
+
+def _discovery_index(report: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    return {
+        _text(row.get("instrument_symbol")): dict(row)
+        for row in rows
+        if isinstance(row, Mapping) and _text(row.get("instrument_symbol"))
+    }
+
+
+def _instrument_index(report: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    return {
+        _text(row.get("symbol")): dict(row)
+        for row in rows
+        if isinstance(row, Mapping) and _text(row.get("symbol"))
+    }
+
+
+def _resolver_input(
+    *,
+    symbol: str,
+    discovery_row: Mapping[str, Any] | None,
+    instrument_row: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    discovery_row = discovery_row or {}
+    instrument_row = instrument_row or {}
+    aliases = discovery_row.get("candidate_aliases")
+    if not isinstance(aliases, list):
+        aliases = instrument_row.get("candidate_provider_symbols")
+    return {
+        "canonical_instrument_id": _text(instrument_row.get("canonical_id")) or _text(discovery_row.get("canonical_symbol")),
+        "symbol": symbol,
+        "primary_data_provider_symbol": _text(discovery_row.get("selected_provider_symbol")) or _text(instrument_row.get("provider_symbol")),
+        "provider_symbol_aliases": list(aliases or []),
+        "provider_symbol_status": _text(discovery_row.get("provider_symbol_status")),
+        "source_identity_status": (
+            "provider_symbol_verified"
+            if bool(discovery_row.get("is_provider_symbol_verified"))
+            else _text(discovery_row.get("provider_symbol_status"))
+        ),
+    }
+
+
+def _authority_status(
+    *,
+    resolution: Mapping[str, Any],
+    discovery_row: Mapping[str, Any] | None,
+    instrument_row: Mapping[str, Any] | None,
+    source_quality_report: Mapping[str, Any] | None,
+) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    if not isinstance(source_quality_report, Mapping):
+        return "blocked_missing_source_quality_report", ["source_quality_report_missing"]
+    source_summary = source_quality_report.get("summary") if isinstance(source_quality_report.get("summary"), Mapping) else {}
+    if not bool(source_summary.get("research_ready")):
+        reasons.append("source_quality_not_research_ready")
+    if discovery_row is None:
+        reasons.append("discovery_identity_row_missing")
+    if instrument_row is None:
+        reasons.append("instrument_identity_row_missing")
+    if _text(resolution.get("resolution_status")) != "VERIFIED":
+        reasons.extend(_text(value) for value in resolution.get("blocking_reasons", []) if _text(value))
+    if instrument_row is not None and not bool(instrument_row.get("eligible_for_hypothesis_seed")):
+        reasons.append("instrument_identity_not_seed_eligible")
+    if reasons:
+        primary = reasons[0]
+        if primary == "source_quality_not_research_ready":
+            return "blocked_source_quality_not_ready", reasons
+        if primary in {"discovery_identity_row_missing", "instrument_identity_row_missing"}:
+            return "blocked_identity_inventory_missing", reasons
+        return "blocked_provider_symbol_ambiguity", reasons
+    return "normalized_context_ready", []
+
+
+def _next_action(rows: list[dict[str, Any]]) -> str:
+    statuses = {_text(row.get("authority_status")) for row in rows}
+    if "blocked_source_quality_not_ready" in statuses:
+        return "stabilize_source_quality_manifest_and_readiness"
+    if "blocked_identity_inventory_missing" in statuses:
+        return "materialize_identity_inventory_for_bounded_scope"
+    if "blocked_provider_symbol_ambiguity" in statuses:
+        return "resolve_provider_symbol_ambiguity_for_bounded_scope"
+    if "blocked_missing_source_quality_report" in statuses:
+        return "materialize_source_quality_report"
+    return "preserve_read_only_source_authority_context"
+
+
+def build_source_identity_authority_normalization(
+    *,
+    breadth_report: Mapping[str, Any],
+    source_quality_report: Mapping[str, Any] | None,
+    discovery_identity_report: Mapping[str, Any],
+    instrument_identity_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    breadth_rows = _breadth_rows(breadth_report)
+    discovery_by_symbol = _discovery_index(discovery_identity_report)
+    instrument_by_symbol = _instrument_index(instrument_identity_report)
+    rows: list[dict[str, Any]] = []
+    for breadth_row in breadth_rows:
+        scope_key = _text(breadth_row.get("scope_key"))
+        scope_components = _scope_components(scope_key)
+        symbol = _text(breadth_row.get("symbol")) or scope_components["symbol"]
+        discovery_row = discovery_by_symbol.get(symbol)
+        instrument_row = instrument_by_symbol.get(symbol)
+        resolution = resolve_symbology_row(
+            _resolver_input(
+                symbol=symbol,
+                discovery_row=discovery_row,
+                instrument_row=instrument_row,
+            )
+        )
+        authority_status, authority_reasons = _authority_status(
+            resolution=resolution,
+            discovery_row=discovery_row,
+            instrument_row=instrument_row,
+            source_quality_report=source_quality_report,
+        )
+        row = {
+            "scope_key": scope_key,
+            "symbol": symbol,
+            "region": _text(breadth_row.get("region")),
+            "behavior_id": _text(breadth_row.get("behavior_id")) or scope_components["behavior_id"],
+            "timeframe": _text(breadth_row.get("timeframe")) or scope_components["timeframe"],
+            "authority_status": authority_status,
+            "authority_reasons": authority_reasons,
+            "resolution_status": _text(resolution.get("resolution_status")),
+            "provider_symbol": resolution.get("provider_symbol"),
+            "provider_symbol_status": _text(resolution.get("provider_symbol_status")),
+            "source_identity_status": _text(resolution.get("source_identity_status")),
+            "instrument_identity_status": (
+                _text(instrument_row.get("identity_status")) if instrument_row else "missing"
+            ),
+            "instrument_seed_eligible": bool(instrument_row.get("eligible_for_hypothesis_seed")) if instrument_row else False,
+            "source_quality_ready": bool(
+                ((source_quality_report or {}).get("summary") or {}).get("research_ready")
+            ),
+            "source_quality_status": _text(
+                (((source_quality_report or {}).get("summary") or {}).get("status"))
+                or ((source_quality_report or {}).get("status"))
+            )
+            or "missing",
+            "operator_explanation": (
+                "Source identity and source authority are normalized for read-only candidate evaluation."
+                if authority_status == "normalized_context_ready"
+                else "Source authority remains fail-closed until identity ambiguity and source-quality prerequisites are resolved."
+            ),
+            "provenance": [
+                {"artifact_path": DEFAULT_BREADTH_PATH.as_posix(), "artifact_ref": f"{DEFAULT_BREADTH_PATH.as_posix()}#coverage_matrix::{scope_key}"},
+                {"artifact_path": DEFAULT_SOURCE_QUALITY_PATH.as_posix(), "artifact_ref": DEFAULT_SOURCE_QUALITY_PATH.as_posix()},
+                {"artifact_path": DEFAULT_DISCOVERY_IDENTITY_PATH.as_posix(), "artifact_ref": f"{DEFAULT_DISCOVERY_IDENTITY_PATH.as_posix()}#rows::{symbol}"},
+                {"artifact_path": "research/equity_universe_identity.py", "artifact_ref": f"instrument_identity::{symbol}"},
+            ],
+            "authority": {
+                "context_only": True,
+                "can_authorize_execution": False,
+                "can_promote_candidate": False,
+                "can_activate_shadow": False,
+            },
+        }
+        row["deterministic_hash"] = _digest(
+            {
+                "scope_key": row["scope_key"],
+                "symbol": row["symbol"],
+                "authority_status": row["authority_status"],
+                "authority_reasons": row["authority_reasons"],
+                "provider_symbol": row["provider_symbol"],
+            }
+        )
+        rows.append(row)
+
+    rows.sort(key=lambda row: (str(row["authority_status"]), str(row["scope_key"])))
+    status_counts = Counter(str(row["authority_status"]) for row in rows)
+    next_action = _next_action(rows)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "status": "ready" if rows else "not_ready",
+            "scope_count": len(rows),
+            "ready_scope_count": sum(1 for row in rows if row["authority_status"] == "normalized_context_ready"),
+            "blocked_scope_count": sum(1 for row in rows if row["authority_status"] != "normalized_context_ready"),
+            "authority_status_counts": dict(sorted(status_counts.items())),
+            "exact_next_action": next_action,
+            "operator_summary": (
+                "Source identity and source-quality context are normalized into one read-only authority surface. "
+                "Missing or ambiguous mappings remain explicit blockers and never become promotion or deployment authority."
+            ),
+        },
+        "rows": rows,
+        "supporting_reports": {
+            "breadth_report_kind": breadth_report.get("report_kind"),
+            "source_quality_report_kind": (source_quality_report or {}).get("report_kind"),
+            "discovery_identity_report_kind": discovery_identity_report.get("report_kind"),
+            "instrument_identity_report_kind": instrument_identity_report.get("report_kind"),
+        },
+        "authority_boundary": {
+            "context_only_not_authority": True,
+            "source_quality_not_alpha": True,
+            "source_quality_not_promotion_authority": True,
+            "can_authorize_execution": False,
+            "can_promote_candidate": False,
+            "can_activate_shadow": False,
+            "can_activate_live": False,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "uses_local_or_static_repo_context_only": True,
+            "uses_network": False,
+            "candidate_promotion_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+    report["deterministic_hash"] = _digest(report)
+    return report
+
+
+def _load_breadth_report(repo_root: Path) -> dict[str, Any]:
+    return _read_json(repo_root / DEFAULT_BREADTH_PATH) or build_evidence_breadth_framework(repo_root=repo_root)
+
+
+def _load_source_quality_report(repo_root: Path) -> dict[str, Any] | None:
+    persisted = _read_json(repo_root / DEFAULT_SOURCE_QUALITY_PATH)
+    if persisted is not None:
+        return persisted
+    manifest = _read_json(repo_root / "logs/qre_data_cache_manifest/latest.json")
+    if isinstance(manifest, Mapping):
+        return build_source_quality_report(manifest)
+    return None
+
+
+def _load_discovery_identity_report(repo_root: Path) -> dict[str, Any]:
+    return _read_json(repo_root / DEFAULT_DISCOVERY_IDENTITY_PATH) or build_source_identity_diagnostics()
+
+
+def build_source_identity_authority_report(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    return build_source_identity_authority_normalization(
+        breadth_report=_load_breadth_report(repo_root),
+        source_quality_report=_load_source_quality_report(repo_root),
+        discovery_identity_report=_load_discovery_identity_report(repo_root),
+        instrument_identity_report=build_instrument_identity_report(),
+    )
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    lines = [
+        "# QRE Source Identity Authority Normalization",
+        "",
+        f"- status: {summary.get('status') or 'unknown'}",
+        f"- scope_count: {summary.get('scope_count') or 0}",
+        f"- ready_scope_count: {summary.get('ready_scope_count') or 0}",
+        f"- blocked_scope_count: {summary.get('blocked_scope_count') or 0}",
+        f"- exact_next_action: {summary.get('exact_next_action') or 'unknown'}",
+        "",
+        "## Scope Rows",
+    ]
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        lines.append(
+            f"- {row.get('scope_key')} symbol={row.get('symbol')} authority_status={row.get('authority_status')} blockers={','.join(row.get('authority_reasons', [])) or 'none'}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": _rel(latest, root=repo_root),
+        "operator_summary": _rel(summary_path, root=repo_root),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_source_identity_authority_normalization",
+        description="Build a read-only normalized source identity authority surface for QRE scopes.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_source_identity_authority_report()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_candidate_quality_framework.py
+++ b/tests/unit/test_qre_candidate_quality_framework.py
@@ -21,6 +21,29 @@ def _reason_contract() -> dict[str, object]:
     }
 
 
+def _source_authority_report(*, status: str = "normalized_context_ready") -> dict[str, object]:
+    return {
+        "report_kind": "qre_source_identity_authority_normalization",
+        "rows": [
+            {
+                "scope_key": "basket-eligible",
+                "authority_status": status,
+                "authority_reasons": [] if status == "normalized_context_ready" else ["source_quality_not_research_ready"],
+            },
+            {
+                "scope_key": "basket-1",
+                "authority_status": status,
+                "authority_reasons": [] if status == "normalized_context_ready" else ["source_quality_not_research_ready"],
+            },
+            {
+                "scope_key": "basket-a",
+                "authority_status": status,
+                "authority_reasons": [] if status == "normalized_context_ready" else ["source_quality_not_research_ready"],
+            },
+        ],
+    }
+
+
 def test_quality_report_blocks_when_candidates_missing() -> None:
     report = evaluate_candidate_quality(
         candidate_report={"rows": []},
@@ -29,6 +52,7 @@ def test_quality_report_blocks_when_candidates_missing() -> None:
         null_control_report=None,
         source_quality_status={"status": "missing", "research_ready": False},
         reason_record_contract=_reason_contract(),
+        source_authority_report=None,
     )
 
     assert report["summary"]["status"] == "blocked_candidate_missing"
@@ -68,6 +92,7 @@ def test_quality_report_blocks_incomplete_evidence() -> None:
         null_control_report=None,
         source_quality_status={"status": "ready", "research_ready": True},
         reason_record_contract=_reason_contract(),
+        source_authority_report=_source_authority_report(),
     )
 
     row = report["rows"][0]
@@ -128,6 +153,7 @@ def test_quality_report_can_become_operator_review_eligible() -> None:
         },
         source_quality_status={"status": "ready", "research_ready": True},
         reason_record_contract=_reason_contract(),
+        source_authority_report=_source_authority_report(),
     )
 
     row = report["rows"][0]
@@ -169,6 +195,7 @@ def test_quality_report_blocks_scope_mismatch() -> None:
         null_control_report=None,
         source_quality_status={"status": "ready", "research_ready": True},
         reason_record_contract=_reason_contract(),
+        source_authority_report=_source_authority_report(),
     )
 
     assert report["rows"][0]["quality_status"] == "blocked_scope_mismatch"

--- a/tests/unit/test_qre_shadow_readiness_gates.py
+++ b/tests/unit/test_qre_shadow_readiness_gates.py
@@ -92,6 +92,22 @@ def _seed_reports(
             "status": "ready" if source_quality_ready else "not_ready",
         },
     )
+    _write_json(
+        tmp_path / "logs" / "qre_source_identity_authority_normalization" / "latest.json",
+        {
+            "report_kind": "qre_source_identity_authority_normalization",
+            "summary": {
+                "status": "ready",
+                "ready_scope_count": 3 if source_quality_ready else 0,
+                "blocked_scope_count": 0 if source_quality_ready else 1,
+                "authority_status_counts": (
+                    {"normalized_context_ready": 3}
+                    if source_quality_ready
+                    else {"blocked_source_quality_not_ready": 1}
+                ),
+            },
+        },
+    )
 
 
 def test_shadow_readiness_gates_fail_closed_on_missing_oos_and_evidence_complete(tmp_path: Path) -> None:

--- a/tests/unit/test_qre_source_identity_authority_normalization.py
+++ b/tests/unit/test_qre_source_identity_authority_normalization.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research.qre_source_identity_authority_normalization import (
+    build_source_identity_authority_normalization,
+    write_outputs,
+)
+
+
+def _breadth_report() -> dict[str, object]:
+    return {
+        "report_kind": "qre_evidence_breadth_framework",
+        "coverage_matrix": [
+            {
+                "dimension": "basket",
+                "scope_key": "seed::trend_continuation_daily_v1::ASML",
+                "symbol": "ASML",
+                "region": "NL/EU",
+                "behavior_id": "trend_continuation",
+                "timeframe": "1d",
+            },
+            {
+                "dimension": "basket",
+                "scope_key": "seed::relative_strength_vs_sector_daily_v1::ASMI",
+                "symbol": "ASMI",
+                "region": "NL/EU",
+                "behavior_id": "relative_strength_vs_sector",
+                "timeframe": "1d",
+            },
+        ],
+    }
+
+
+def _source_quality_report(*, ready: bool = True) -> dict[str, object]:
+    return {
+        "report_kind": "qre_data_source_quality_readiness",
+        "summary": {
+            "status": "ready" if ready else "not_ready",
+            "research_ready": ready,
+        },
+    }
+
+
+def _discovery_identity_report() -> dict[str, object]:
+    return {
+        "report_kind": "qre_discovery_source_identity_diagnostics",
+        "rows": [
+            {
+                "instrument_symbol": "ASML",
+                "canonical_symbol": "ASML",
+                "selected_provider_symbol": "ASML.AS",
+                "candidate_aliases": ["ASML.AS"],
+                "provider_symbol_status": "verified",
+                "is_provider_symbol_verified": True,
+            },
+            {
+                "instrument_symbol": "ASMI",
+                "canonical_symbol": "ASMI",
+                "selected_provider_symbol": "",
+                "candidate_aliases": ["ASMI.AS", "ASMI.AS2"],
+                "provider_symbol_status": "candidate_alias_requires_verification",
+                "is_provider_symbol_verified": False,
+            },
+        ],
+    }
+
+
+def _instrument_identity_report() -> dict[str, object]:
+    return {
+        "report_kind": "instrument_identity",
+        "rows": [
+            {
+                "symbol": "ASML",
+                "canonical_id": "eq.asml.nl",
+                "provider_symbol": "ASML.AS",
+                "candidate_provider_symbols": ["ASML.AS"],
+                "identity_status": "OK",
+                "eligible_for_hypothesis_seed": True,
+            },
+            {
+                "symbol": "ASMI",
+                "canonical_id": "eq.asmi.nl",
+                "provider_symbol": "",
+                "candidate_provider_symbols": ["ASMI.AS", "ASMI.AS2"],
+                "identity_status": "WARN",
+                "eligible_for_hypothesis_seed": False,
+            },
+        ],
+    }
+
+
+def test_source_identity_authority_normalization_is_deterministic_and_fail_closed() -> None:
+    left = build_source_identity_authority_normalization(
+        breadth_report=_breadth_report(),
+        source_quality_report=_source_quality_report(),
+        discovery_identity_report=_discovery_identity_report(),
+        instrument_identity_report=_instrument_identity_report(),
+    )
+    right = build_source_identity_authority_normalization(
+        breadth_report=_breadth_report(),
+        source_quality_report=_source_quality_report(),
+        discovery_identity_report=_discovery_identity_report(),
+        instrument_identity_report=_instrument_identity_report(),
+    )
+
+    assert left == right
+    rows = {row["symbol"]: row for row in left["rows"]}
+    assert rows["ASML"]["authority_status"] == "normalized_context_ready"
+    assert rows["ASMI"]["authority_status"] == "blocked_provider_symbol_ambiguity"
+    assert "candidate_alias_requires_verification" in rows["ASMI"]["authority_reasons"]
+    assert left["summary"]["blocked_scope_count"] == 1
+
+
+def test_source_identity_authority_normalization_blocks_when_source_quality_not_ready() -> None:
+    report = build_source_identity_authority_normalization(
+        breadth_report=_breadth_report(),
+        source_quality_report=_source_quality_report(ready=False),
+        discovery_identity_report=_discovery_identity_report(),
+        instrument_identity_report=_instrument_identity_report(),
+    )
+
+    rows = {row["symbol"]: row for row in report["rows"]}
+    assert rows["ASML"]["authority_status"] == "blocked_source_quality_not_ready"
+    assert report["summary"]["exact_next_action"] == "stabilize_source_quality_manifest_and_readiness"
+
+
+def test_source_identity_authority_outputs_use_allowlisted_location(tmp_path: Path) -> None:
+    report = build_source_identity_authority_normalization(
+        breadth_report=_breadth_report(),
+        source_quality_report=_source_quality_report(),
+        discovery_identity_report=_discovery_identity_report(),
+        instrument_identity_report=_instrument_identity_report(),
+    )
+
+    paths = write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_source_identity_authority_normalization/latest.json"
+    assert (tmp_path / paths["latest"]).is_file()


### PR DESCRIPTION
## Summary
- add a read-only source identity and source-authority normalization surface across breadth scopes
- integrate normalized source authority into candidate quality, shadow readiness, and research-memory retrieval surfaces
- keep unresolved identity inventory and provider-symbol ambiguity explicit as fail-closed blockers

## Testing
- python -m pytest tests/unit/test_qre_source_identity_authority_normalization.py tests/unit/test_qre_candidate_quality_framework.py tests/unit/test_qre_shadow_readiness_gates.py tests/unit/test_qre_research_memory_retrieval.py tests/unit/test_qre_research_retrieval_coverage.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- python -m research.qre_source_identity_authority_normalization
- python -m research.qre_candidate_quality_framework
- python -m research.qre_shadow_readiness_gates
- git diff --check