### PR TITLE
feat: add read-only artifact continuity for qre memory surfaces

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -38,6 +38,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_candidate_quality_framework/latest.json"),
     Path("logs/qre_multibasket_portfolio_intelligence/latest.json"),
     Path("logs/qre_source_identity_authority_normalization/latest.json"),
+    Path("logs/qre_read_only_artifact_continuity/latest.json"),
     Path("logs/qre_trusted_loop_operational_controls/latest.json"),
     Path("logs/qre_shadow_readiness_gates/latest.json"),
 )

--- a/research/qre_null_control_falsification_suite.py
+++ b/research/qre_null_control_falsification_suite.py
@@ -372,14 +372,54 @@ def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> 
     }
 
 
+def read_null_control_suite_status(
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    latest = repo_root / output_dir / LATEST_NAME
+    if not latest.is_file():
+        return {
+            "status": "missing_null_control_suite",
+            "null_control_suite_ready": False,
+            "path": latest.relative_to(repo_root).as_posix(),
+            "fails_closed": True,
+        }
+    try:
+        payload = json.loads(latest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {
+            "status": "invalid_null_control_suite",
+            "null_control_suite_ready": False,
+            "path": latest.relative_to(repo_root).as_posix(),
+            "fails_closed": True,
+        }
+    status = _text(payload.get("status"))
+    ready = status == "suite_ready_preregistered_context"
+    return {
+        "status": "ready" if ready else "not_ready",
+        "null_control_suite_ready": ready,
+        "path": latest.relative_to(repo_root).as_posix(),
+        "fails_closed": not ready,
+        "suite_status": status,
+        "schema_version": payload.get("schema_version") if isinstance(payload, Mapping) else None,
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m research.qre_null_control_falsification_suite",
         description="Build deterministic preregistered null/control suite context.",
     )
-    parser.add_argument("--sampling-plan-file", required=True)
+    parser.add_argument("--sampling-plan-file")
+    parser.add_argument("--status", action="store_true")
     parser.add_argument("--write", action="store_true")
     args = parser.parse_args(argv)
+    if args.status:
+        print(json.dumps(read_null_control_suite_status(), indent=2, sort_keys=True))
+        return 0
+    if not args.sampling_plan_file:
+        raise SystemExit("--sampling-plan-file is required unless --status is used")
     sampling_payload = json.loads(Path(args.sampling_plan_file).read_text(encoding="utf-8"))
     report = build_preregistered_null_control_suite(sampling_plan_payload=sampling_payload)
     if args.write:
@@ -395,6 +435,7 @@ __all__ = [
     "build_preregistered_null_control_suite",
     "compute_suite_hash",
     "evaluate_null_control_suite",
+    "read_null_control_suite_status",
     "render_operator_summary",
     "write_outputs",
 ]

--- a/research/qre_read_only_artifact_continuity.py
+++ b/research/qre_read_only_artifact_continuity.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_hypothesis_disposition_memory as disposition_memory
+from research import qre_null_control_falsification_suite as null_suite
+from research import qre_preregistered_multiwindow_evidence_run as multiwindow_run
+from research import qre_research_cycle_router as cycle_router
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_read_only_artifact_continuity"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_read_only_artifact_continuity")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_read_only_artifact_continuity/"
+
+DISPOSITION_PATH: Final[Path] = disposition_memory.DEFAULT_OUTPUT_DIR / disposition_memory.LATEST_NAME
+ROUTER_PATH: Final[Path] = cycle_router.DEFAULT_OUTPUT_DIR / cycle_router.LATEST_NAME
+NULL_CONTROL_PATH: Final[Path] = null_suite.DEFAULT_OUTPUT_DIR / null_suite.LATEST_NAME
+RESEARCH_MEMORY_PATH: Final[Path] = cycle_router.DEFAULT_RESEARCH_MEMORY_PATH
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _current_status_rows(repo_root: Path) -> dict[str, dict[str, Any]]:
+    return {
+        "hypothesis_disposition_memory": disposition_memory.read_hypothesis_disposition_memory_status(
+            repo_root=repo_root
+        ),
+        "research_cycle_router": cycle_router.read_research_cycle_router_status(
+            repo_root=repo_root
+        ),
+        "null_control_falsification_suite": null_suite.read_null_control_suite_status(
+            repo_root=repo_root
+        ),
+    }
+
+
+def _report_status(report: Mapping[str, Any] | None) -> str:
+    if not isinstance(report, Mapping):
+        return "blocked"
+    if _text(report.get("status")) in {"ready", "suite_ready_preregistered_context"}:
+        return "ready"
+    return "blocked"
+
+
+def _report_hash(report: Mapping[str, Any] | None) -> str:
+    if not isinstance(report, Mapping):
+        return ""
+    for key in ("deterministic_hash", "hash"):
+        value = _text(report.get(key))
+        if value:
+            return value
+    return _digest(report)
+
+
+def _materialization_state(
+    *,
+    current_payload: Mapping[str, Any] | None,
+    projected_payload: Mapping[str, Any] | None,
+) -> str:
+    if _report_status(projected_payload) != "ready":
+        return "blocked_missing_prerequisites"
+    if not isinstance(current_payload, Mapping):
+        return "materializable_missing_current_artifact"
+    if _report_hash(current_payload) == _report_hash(projected_payload):
+        return "current_artifact_matches_projected"
+    return "materializable_stale_or_mismatched_current_artifact"
+
+
+def _disposition_target(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    current = _read_json(repo_root / DISPOSITION_PATH)
+    projected = disposition_memory.build_hypothesis_disposition_memory(repo_root=repo_root)
+    row = {
+        "artifact_key": "hypothesis_disposition_memory",
+        "artifact_path": DISPOSITION_PATH.as_posix(),
+        "current_status": _text(
+            disposition_memory.read_hypothesis_disposition_memory_status(repo_root=repo_root).get("status")
+        ),
+        "projected_status": _report_status(projected),
+        "materialization_state": _materialization_state(
+            current_payload=current,
+            projected_payload=projected,
+        ),
+        "reason_codes": [],
+        "source_artifact_refs": [
+            disposition_memory.DEFAULT_CAMPAIGN_REPORT.as_posix(),
+            disposition_memory.DEFAULT_CLOSURE_REPORT.as_posix(),
+        ],
+        "projected_hash": _report_hash(projected),
+        "current_hash": _report_hash(current),
+        "exact_next_action": (
+            "write_disposition_memory_artifact"
+            if _report_status(projected) == "ready"
+            else "restore_disposition_memory_inputs"
+        ),
+    }
+    if _report_status(projected) != "ready":
+        row["reason_codes"] = ["disposition_memory_prerequisites_missing"]
+    elif row["materialization_state"] == "current_artifact_matches_projected":
+        row["reason_codes"] = ["current_artifact_already_current"]
+    else:
+        row["reason_codes"] = ["deterministic_write_available_from_local_inputs"]
+    return row, projected
+
+
+def _router_target(
+    repo_root: Path,
+    projected_disposition: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    current = _read_json(repo_root / ROUTER_PATH)
+    research_memory_payload = _read_json(repo_root / RESEARCH_MEMORY_PATH)
+    projected = cycle_router._build_research_cycle_router_from_payloads(
+        disposition_memory=projected_disposition,
+        research_memory=research_memory_payload,
+        generated_at_utc=None,
+        disposition_memory_path=DISPOSITION_PATH,
+    )
+    row = {
+        "artifact_key": "research_cycle_router",
+        "artifact_path": ROUTER_PATH.as_posix(),
+        "current_status": _text(cycle_router.read_research_cycle_router_status(repo_root=repo_root).get("status")),
+        "projected_status": _report_status(projected),
+        "materialization_state": _materialization_state(
+            current_payload=current,
+            projected_payload=projected,
+        ),
+        "reason_codes": [],
+        "source_artifact_refs": [
+            DISPOSITION_PATH.as_posix(),
+            RESEARCH_MEMORY_PATH.as_posix(),
+        ],
+        "projected_hash": _report_hash(projected),
+        "current_hash": _report_hash(current),
+        "exact_next_action": (
+            "write_research_cycle_router_artifact"
+            if _report_status(projected) == "ready"
+            else "restore_disposition_memory_before_router"
+        ),
+    }
+    if _report_status(projected) != "ready":
+        row["reason_codes"] = ["router_prerequisites_missing"]
+    elif row["materialization_state"] == "current_artifact_matches_projected":
+        row["reason_codes"] = ["current_artifact_already_current"]
+    else:
+        row["reason_codes"] = ["deterministic_write_available_from_local_inputs"]
+    return row, projected
+
+
+def _null_control_target(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    current = _read_json(repo_root / NULL_CONTROL_PATH)
+    approval_manifest = _read_json(repo_root / multiwindow_run.DEFAULT_APPROVAL_PATH)
+    if not isinstance(approval_manifest, Mapping):
+        projected = {
+            "schema_version": null_suite.SCHEMA_VERSION,
+            "report_kind": null_suite.REPORT_KIND,
+            "status": "blocked_invalid_sampling_plan",
+            "blocked_reasons": ["missing_multiwindow_approval_manifest"],
+            "evaluation": {
+                "status": "controls_not_run",
+                "recommended_next_action": "restore_multiwindow_approval_manifest",
+                "blockers": ["missing_multiwindow_approval_manifest"],
+            },
+        }
+    else:
+        try:
+            sampling_plan_payload = multiwindow_run.build_sampling_plan_for_multiwindow_approval(
+                approval_manifest=approval_manifest,
+                repo_root=repo_root,
+            )
+            campaign_plan = multiwindow_run.build_campaign_for_multiwindow_approval(
+                approval_manifest=approval_manifest,
+                sampling_plan_payload=sampling_plan_payload,
+            )
+            projected = null_suite.build_preregistered_null_control_suite(
+                sampling_plan_payload=sampling_plan_payload
+            )
+            projected = null_suite.evaluate_null_control_suite(
+                projected,
+                candidate_context={
+                    "campaign_id": campaign_plan.get("campaign_id"),
+                    "sampling_plan_id": sampling_plan_payload.get("sampling_plan_id"),
+                },
+                control_results=[],
+            )
+        except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+            projected = {
+                "schema_version": null_suite.SCHEMA_VERSION,
+                "report_kind": null_suite.REPORT_KIND,
+                "status": "blocked_invalid_sampling_plan",
+                "blocked_reasons": [f"null_control_prerequisites_unavailable:{type(exc).__name__}"],
+                "evaluation": {
+                    "status": "controls_not_run",
+                    "recommended_next_action": "restore_sampling_plan_or_approval_inputs",
+                    "blockers": ["null_control_prerequisites_unavailable"],
+                },
+            }
+    row = {
+        "artifact_key": "null_control_falsification_suite",
+        "artifact_path": NULL_CONTROL_PATH.as_posix(),
+        "current_status": _text(null_suite.read_null_control_suite_status(repo_root=repo_root).get("status")),
+        "projected_status": _report_status(projected),
+        "materialization_state": _materialization_state(
+            current_payload=current,
+            projected_payload=projected,
+        ),
+        "reason_codes": [],
+        "source_artifact_refs": [
+            multiwindow_run.DEFAULT_APPROVAL_PATH.as_posix(),
+            multiwindow_run.DEFAULT_OUTPUT_DIR.as_posix() + "/latest.json",
+        ],
+        "projected_hash": _report_hash(projected),
+        "current_hash": _report_hash(current),
+        "exact_next_action": (
+            "write_null_control_suite_artifact"
+            if _report_status(projected) == "ready"
+            else _text((projected.get("evaluation") or {}).get("recommended_next_action"))
+            or "restore_sampling_plan_or_approval_inputs"
+        ),
+    }
+    if _report_status(projected) != "ready":
+        row["reason_codes"] = list(projected.get("blocked_reasons") or ["null_control_prerequisites_missing"])
+    elif row["materialization_state"] == "current_artifact_matches_projected":
+        row["reason_codes"] = ["current_artifact_already_current"]
+    else:
+        row["reason_codes"] = ["deterministic_write_available_from_local_inputs"]
+    return row, projected
+
+
+def build_read_only_artifact_continuity(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    current_status = _current_status_rows(repo_root)
+    disposition_row, projected_disposition = _disposition_target(repo_root)
+    router_row, projected_router = _router_target(repo_root, projected_disposition)
+    null_row, projected_null = _null_control_target(repo_root)
+    rows = [disposition_row, router_row, null_row]
+    ready_rows = [row for row in rows if row["projected_status"] == "ready"]
+    blocked_rows = [row for row in rows if row["projected_status"] != "ready"]
+    current_rows = [row for row in rows if row["materialization_state"] == "current_artifact_matches_projected"]
+    materializable_rows = [
+        row
+        for row in rows
+        if row["materialization_state"] in {
+            "materializable_missing_current_artifact",
+            "materializable_stale_or_mismatched_current_artifact",
+        }
+    ]
+    summary = {
+        "artifact_continuity_ready": len(blocked_rows) == 0,
+        "target_count": len(rows),
+        "ready_target_count": len(ready_rows),
+        "blocked_target_count": len(blocked_rows),
+        "current_target_count": len(current_rows),
+        "materializable_target_count": len(materializable_rows),
+        "exact_next_action": (
+            "materialize_read_only_qre_artifacts"
+            if materializable_rows and not blocked_rows
+            else "restore_read_only_artifact_prerequisites"
+            if blocked_rows
+            else "preserve_current_read_only_artifacts"
+        ),
+        "operator_summary": (
+            "Read-only artifact continuity verifies whether implemented QRE memory, routing, "
+            "and null-control surfaces are currently materialized from local inputs. It never "
+            "creates evidence authority or runtime execution authority."
+        ),
+    }
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": summary,
+        "current_status": current_status,
+        "targets": rows,
+        "projected_reports": {
+            "hypothesis_disposition_memory": {
+                "status": _text(projected_disposition.get("status")),
+                "hash": _report_hash(projected_disposition),
+            },
+            "research_cycle_router": {
+                "status": _text(projected_router.get("status")),
+                "hash": _report_hash(projected_router),
+            },
+            "null_control_falsification_suite": {
+                "status": _text(projected_null.get("status")),
+                "hash": _report_hash(projected_null),
+            },
+        },
+        "authority_boundary": {
+            "read_only": True,
+            "operator_review_required": True,
+            "can_authorize_execution": False,
+            "can_clear_evidence_blockers": False,
+            "can_promote_candidate": False,
+            "can_activate_shadow": False,
+        },
+        "safety_invariants": {
+            "uses_local_artifacts_only": True,
+            "uses_network": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "frozen_contracts_unchanged": True,
+        },
+    }
+    report["deterministic_hash"] = _digest(
+        {
+            "schema_version": report["schema_version"],
+            "report_kind": report["report_kind"],
+            "summary": report["summary"],
+            "current_status": report["current_status"],
+            "targets": report["targets"],
+            "projected_reports": report["projected_reports"],
+            "authority_boundary": report["authority_boundary"],
+        }
+    )
+    return report
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    targets = report.get("targets") if isinstance(report.get("targets"), list) else []
+    lines = [
+        "# QRE Read-Only Artifact Continuity",
+        "",
+        f"- artifact_continuity_ready: {summary.get('artifact_continuity_ready', False)}",
+        f"- target_count: {summary.get('target_count', 0)}",
+        f"- ready_target_count: {summary.get('ready_target_count', 0)}",
+        f"- blocked_target_count: {summary.get('blocked_target_count', 0)}",
+        f"- materializable_target_count: {summary.get('materializable_target_count', 0)}",
+        f"- exact_next_action: {summary.get('exact_next_action', '')}",
+        "",
+        "## Targets",
+    ]
+    for row in targets:
+        if not isinstance(row, Mapping):
+            continue
+        lines.append(
+            f"- {row.get('artifact_key')}: {row.get('materialization_state')} "
+            f"(current={row.get('current_status')}, projected={row.get('projected_status')})"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    disposition_report = disposition_memory.build_hypothesis_disposition_memory(repo_root=repo_root)
+    if _report_status(disposition_report) == "ready":
+        disposition_memory.write_outputs(disposition_report, repo_root=repo_root)
+
+    research_memory_payload = _read_json(repo_root / RESEARCH_MEMORY_PATH)
+    router_report = cycle_router._build_research_cycle_router_from_payloads(
+        disposition_memory=disposition_report,
+        research_memory=research_memory_payload,
+        generated_at_utc=None,
+        disposition_memory_path=DISPOSITION_PATH,
+    )
+    if _report_status(router_report) == "ready":
+        cycle_router.write_outputs(router_report, repo_root=repo_root)
+
+    approval_manifest = _read_json(repo_root / multiwindow_run.DEFAULT_APPROVAL_PATH)
+    if isinstance(approval_manifest, Mapping):
+        try:
+            sampling_plan_payload = multiwindow_run.build_sampling_plan_for_multiwindow_approval(
+                approval_manifest=approval_manifest,
+                repo_root=repo_root,
+            )
+            campaign_plan = multiwindow_run.build_campaign_for_multiwindow_approval(
+                approval_manifest=approval_manifest,
+                sampling_plan_payload=sampling_plan_payload,
+            )
+            null_report = null_suite.build_preregistered_null_control_suite(
+                sampling_plan_payload=sampling_plan_payload
+            )
+            null_report = null_suite.evaluate_null_control_suite(
+                null_report,
+                candidate_context={
+                    "campaign_id": campaign_plan.get("campaign_id"),
+                    "sampling_plan_id": sampling_plan_payload.get("sampling_plan_id"),
+                },
+                control_results=[],
+            )
+        except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+            null_report = None
+        if _report_status(null_report) == "ready":
+            null_suite.write_outputs(null_report, repo_root=repo_root)
+
+    refreshed = build_read_only_artifact_continuity(repo_root=repo_root)
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(refreshed, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(refreshed) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_read_only_artifact_continuity",
+        description="Materialize deterministic read-only continuity for QRE artifact-backed memory and control surfaces.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_read_only_artifact_continuity()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_research_cycle_router.py
+++ b/research/qre_research_cycle_router.py
@@ -224,16 +224,15 @@ def _suppressed_scopes(record: Mapping[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
-def build_research_cycle_router(
+def _build_research_cycle_router_from_payloads(
     *,
-    repo_root: Path = Path("."),
-    generated_at_utc: str | None = None,
-    disposition_memory_path: Path = DEFAULT_DISPOSITION_MEMORY_PATH,
-    research_memory_path: Path = DEFAULT_RESEARCH_MEMORY_PATH,
+    disposition_memory: Mapping[str, Any] | None,
+    research_memory: Mapping[str, Any] | None,
+    generated_at_utc: str | None,
+    disposition_memory_path: Path,
 ) -> dict[str, Any]:
-    disposition_memory = _read_json(repo_root / disposition_memory_path)
-    research_memory = _read_json(repo_root / research_memory_path)
-    if not isinstance(disposition_memory, Mapping):
+    record = disposition_memory.get("record") if isinstance(disposition_memory, Mapping) and isinstance(disposition_memory.get("record"), Mapping) else {}
+    if not isinstance(disposition_memory, Mapping) or not record:
         return {
             "schema_version": SCHEMA_VERSION,
             "report_kind": REPORT_KIND,
@@ -258,7 +257,6 @@ def build_research_cycle_router(
             },
         }
 
-    record = disposition_memory.get("record") if isinstance(disposition_memory.get("record"), Mapping) else {}
     disposition_scope = record.get("disposition_scope") if isinstance(record.get("disposition_scope"), Mapping) else {}
     source_behavior_id = _text(record.get("behavior_id"))
     source_preset_id = _text(record.get("preset_id"))
@@ -616,6 +614,23 @@ def build_research_cycle_router(
     }
     report["deterministic_hash"] = _digest(canonical)
     return report
+
+
+def build_research_cycle_router(
+    *,
+    repo_root: Path = Path("."),
+    generated_at_utc: str | None = None,
+    disposition_memory_path: Path = DEFAULT_DISPOSITION_MEMORY_PATH,
+    research_memory_path: Path = DEFAULT_RESEARCH_MEMORY_PATH,
+) -> dict[str, Any]:
+    disposition_memory = _read_json(repo_root / disposition_memory_path)
+    research_memory = _read_json(repo_root / research_memory_path)
+    return _build_research_cycle_router_from_payloads(
+        disposition_memory=disposition_memory,
+        research_memory=research_memory,
+        generated_at_utc=generated_at_utc,
+        disposition_memory_path=disposition_memory_path,
+    )
 
 
 def render_operator_summary(report: Mapping[str, Any]) -> str:

--- a/research/qre_research_memory_current_artifacts.py
+++ b/research/qre_research_memory_current_artifacts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from packages.qre_research import research_memory
+from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_memory_coverage as memory_coverage
 
 
@@ -52,6 +53,9 @@ def build_research_memory_current_artifacts(
     retrieval_ready = (
         str(retrieval_summary.get("final_recommendation") or "") == "failure_retrieval_ready"
     )
+    continuity = artifact_continuity.build_read_only_artifact_continuity(repo_root=repo_root)
+    continuity_summary = continuity.get("summary") if isinstance(continuity.get("summary"), Mapping) else {}
+    continuity_ready = bool(continuity_summary.get("artifact_continuity_ready"))
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -61,14 +65,18 @@ def build_research_memory_current_artifacts(
             "package_research_memory_ready": package_ready,
             "coverage_ready": coverage_ready,
             "retrieval_ready": retrieval_ready,
+            "artifact_continuity_ready": continuity_ready,
             "indexed_entry_count": int(memory_summary.get("indexed_entry_count") or 0),
             "indexed_candidate_count": int(memory_summary.get("indexed_candidate_count") or 0),
             "retrievable_failure_subject_count": int(
                 retrieval_summary.get("retrievable_failure_subject_count") or 0
             ),
+            "artifact_continuity_materializable_target_count": int(
+                continuity_summary.get("materializable_target_count") or 0
+            ),
             "final_recommendation": (
                 "research_memory_current_artifacts_ready"
-                if package_ready and coverage_ready and retrieval_ready
+                if package_ready and coverage_ready and retrieval_ready and continuity_ready
                 else "research_memory_current_artifacts_partial"
             ),
             "operator_summary": (
@@ -79,10 +87,12 @@ def build_research_memory_current_artifacts(
         "package_status": dict(package_status),
         "memory_coverage_summary": dict(memory_summary),
         "failure_retrieval_summary": dict(retrieval_summary),
+        "artifact_continuity_summary": dict(continuity_summary),
         "memory_artifacts": {
             "package_memory_path": str(package_status.get("path") or "logs/qre_research_memory/latest.json"),
             "coverage_path": "logs/qre_research_memory_coverage/latest.json",
             "failure_retrieval_path": "logs/qre_failure_retrieval/latest.json",
+            "artifact_continuity_path": "logs/qre_read_only_artifact_continuity/latest.json",
         },
         "safety_invariants": {
             "read_only": True,
@@ -113,8 +123,10 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["package_research_memory_ready", str(summary.get("package_research_memory_ready") or False)],
                     ["coverage_ready", str(summary.get("coverage_ready") or False)],
                     ["retrieval_ready", str(summary.get("retrieval_ready") or False)],
+                    ["artifact_continuity_ready", str(summary.get("artifact_continuity_ready") or False)],
                     ["indexed_entry_count", str(summary.get("indexed_entry_count") or 0)],
                     ["retrievable_failure_subject_count", str(summary.get("retrievable_failure_subject_count") or 0)],
+                    ["artifact_continuity_materializable_target_count", str(summary.get("artifact_continuity_materializable_target_count") or 0)],
                     ["final_recommendation", str(summary.get("final_recommendation") or "")],
                 ],
             ),
@@ -126,6 +138,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["package_memory_path", str(artifacts.get("package_memory_path") or "")],
                     ["coverage_path", str(artifacts.get("coverage_path") or "")],
                     ["failure_retrieval_path", str(artifacts.get("failure_retrieval_path") or "")],
+                    ["artifact_continuity_path", str(artifacts.get("artifact_continuity_path") or "")],
                 ],
             ),
             "",
@@ -152,6 +165,8 @@ def write_outputs(
     )
     retrieval = memory_coverage.build_failure_retrieval(memory)
     memory_paths = memory_coverage.write_outputs(memory, retrieval, repo_root=repo_root)
+    continuity_report = artifact_continuity.build_read_only_artifact_continuity(repo_root=repo_root)
+    continuity_paths = artifact_continuity.write_outputs(continuity_report, repo_root=repo_root)
 
     base = repo_root / DEFAULT_OUTPUT_DIR
     base.mkdir(parents=True, exist_ok=True)
@@ -167,6 +182,8 @@ def write_outputs(
     os.replace(tmp_md, summary_path)
     return {
         **memory_paths,
+        "artifact_continuity_latest": continuity_paths["latest"],
+        "artifact_continuity_operator_summary": continuity_paths["operator_summary"],
         "latest": latest.relative_to(repo_root).as_posix(),
         "operator_summary": summary_path.relative_to(repo_root).as_posix(),
     }

--- a/research/qre_research_memory_retrieval.py
+++ b/research/qre_research_memory_retrieval.py
@@ -29,6 +29,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_research_cycle_router/latest.json"),
     Path("logs/qre_evidence_breadth_framework/latest.json"),
     Path("logs/qre_source_identity_authority_normalization/latest.json"),
+    Path("logs/qre_read_only_artifact_continuity/latest.json"),
     Path("logs/qre_preregistered_multiwindow_evidence_run/latest.json"),
     Path("logs/qre_multiwindow_evidence_closure/latest.json"),
 )

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -24,6 +24,7 @@ from research import qre_first_batch_evidence_recovery_cascade as first_batch_ca
 from research import qre_first_batch_evidence_recovery_readiness as first_batch_readiness
 from research import qre_basket_operator_action_plan as basket_action_plan
 from research import qre_reason_records_v1 as reason_records
+from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_memory_current_artifacts as research_memory
 from research import qre_routing_calibration_report as routing_calibration
 from research import qre_sampling_calibration_report as sampling_calibration
@@ -268,6 +269,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     routing_packet = routing_calibration.build_routing_calibration_report(repo_root=repo_root)
     sampling_packet = sampling_calibration.build_sampling_calibration_report(repo_root=repo_root)
     memory_packet = research_memory.build_research_memory_current_artifacts(repo_root=repo_root)
+    continuity_packet = artifact_continuity.build_read_only_artifact_continuity(repo_root=repo_root)
     action_plan_packet = basket_action_plan.build_basket_operator_action_plan(repo_root=repo_root)
     operational_controls_packet = operational_controls.build_trusted_loop_operational_controls(
         repo_root=repo_root
@@ -298,6 +300,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     routing_summary = routing_packet.get("summary") if isinstance(routing_packet.get("summary"), Mapping) else {}
     sampling_summary = sampling_packet.get("summary") if isinstance(sampling_packet.get("summary"), Mapping) else {}
     memory_summary = memory_packet if isinstance(memory_packet, Mapping) else {}
+    continuity_summary = (
+        continuity_packet.get("summary") if isinstance(continuity_packet.get("summary"), Mapping) else {}
+    )
     action_plan_summary = action_plan_packet.get("summary") if isinstance(action_plan_packet.get("summary"), Mapping) else {}
     structured_lineage_summary = (
         structured_lineage_packet.get("summary") if isinstance(structured_lineage_packet.get("summary"), Mapping) else {}
@@ -343,6 +348,8 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
                 (memory_summary.get("summary") or {}).get("final_recommendation") or ""
             )
             == "research_memory_current_artifacts_ready",
+            "artifact_continuity_ready": bool(continuity_summary.get("artifact_continuity_ready")),
+            "artifact_continuity_exact_next_action": str(continuity_summary.get("exact_next_action") or ""),
             "basket_operator_action_plan_ready": str(action_plan_summary.get("final_recommendation") or "")
             == "basket_operator_action_plan_ready",
             "trusted_loop_operational_controls_ready": bool(
@@ -428,6 +435,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "routing_calibration": routing_packet,
             "sampling_calibration": sampling_packet,
             "research_memory": memory_packet,
+            "artifact_continuity": continuity_packet,
             "operational_controls": operational_controls_packet,
             "shadow_readiness_gates": shadow_readiness_packet,
         },
@@ -519,6 +527,8 @@ def render_operator_summary(packet: Mapping[str, Any]) -> str:
             f"- routing_evidence_ready: {summary.get('routing_evidence_ready')}",
             f"- sampling_evidence_ready: {summary.get('sampling_evidence_ready')}",
             f"- research_memory_ready: {summary.get('research_memory_ready')}",
+            f"- artifact_continuity_ready: {summary.get('artifact_continuity_ready')}",
+            f"- artifact_continuity_exact_next_action: {summary.get('artifact_continuity_exact_next_action')}",
             f"- guarded_alias_bounded_generation_cascade_result: {summary.get('guarded_alias_bounded_generation_cascade_result')}",
             f"- guarded_alias_bounded_generation_top_blocker: {summary.get('guarded_alias_bounded_generation_top_blocker')}",
             f"- structured_lineage_artifact_status: {summary.get('structured_lineage_artifact_status')}",

--- a/tests/unit/test_qre_null_control_falsification_suite.py
+++ b/tests/unit/test_qre_null_control_falsification_suite.py
@@ -134,3 +134,19 @@ def test_write_outputs_and_core_module_have_no_symbol_hardcoding(tmp_path: Path)
     source = Path("research/qre_null_control_falsification_suite.py").read_text(encoding="utf-8")
     assert "AAPL" not in source
     assert "NVDA" not in source
+
+
+def test_status_reader_fails_closed_then_round_trips_ready(tmp_path: Path) -> None:
+    missing = suite.read_null_control_suite_status(repo_root=tmp_path)
+    assert missing["status"] == "missing_null_control_suite"
+    assert missing["null_control_suite_ready"] is False
+
+    report = suite.build_preregistered_null_control_suite(
+        sampling_plan_payload=_sampling_plan()
+    )
+    suite.write_outputs(report, repo_root=tmp_path)
+
+    ready = suite.read_null_control_suite_status(repo_root=tmp_path)
+    assert ready["status"] == "ready"
+    assert ready["null_control_suite_ready"] is True
+    assert ready["path"] == "logs/qre_null_control_falsification_suite/latest.json"

--- a/tests/unit/test_qre_read_only_artifact_continuity.py
+++ b/tests/unit/test_qre_read_only_artifact_continuity.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_read_only_artifact_continuity as continuity
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_continuity_report_detects_materializable_missing_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _write_json(
+        tmp_path / "research" / "operator_approvals" / "qre_preregistered_multiwindow_validation_approval.v1.json",
+        {"approval_id": "approval-001"},
+    )
+    monkeypatch.setattr(
+        continuity.disposition_memory,
+        "read_hypothesis_disposition_memory_status",
+        lambda **_: {"status": "missing_hypothesis_disposition_memory"},
+    )
+    monkeypatch.setattr(
+        continuity.disposition_memory,
+        "build_hypothesis_disposition_memory",
+        lambda **_: {"schema_version": "1.0", "report_kind": "qre_hypothesis_disposition_memory", "status": "ready", "deterministic_hash": "sha256:disp"},
+    )
+    monkeypatch.setattr(
+        continuity.cycle_router,
+        "read_research_cycle_router_status",
+        lambda **_: {"status": "missing_research_cycle_router"},
+    )
+    monkeypatch.setattr(
+        continuity.cycle_router,
+        "_build_research_cycle_router_from_payloads",
+        lambda **_: {"schema_version": "1.0", "report_kind": "qre_research_cycle_router", "status": "ready", "deterministic_hash": "sha256:router"},
+    )
+    monkeypatch.setattr(
+        continuity.null_suite,
+        "read_null_control_suite_status",
+        lambda **_: {"status": "missing_null_control_suite"},
+    )
+    monkeypatch.setattr(
+        continuity.multiwindow_run,
+        "build_sampling_plan_for_multiwindow_approval",
+        lambda **_: {"sampling_plan_id": "plan-001", "hash": "plan-hash", "status": "sampling_plan_ready_context_only", "null_control_definitions": [{"control_id": "buy_and_hold_baseline"}]},
+    )
+    monkeypatch.setattr(
+        continuity.multiwindow_run,
+        "build_campaign_for_multiwindow_approval",
+        lambda **_: {"campaign_id": "campaign-001"},
+    )
+    monkeypatch.setattr(
+        continuity.null_suite,
+        "build_preregistered_null_control_suite",
+        lambda **_: {"schema_version": "1.0", "report_kind": "qre_null_control_falsification_suite", "status": "suite_ready_preregistered_context", "hash": "suite-hash"},
+    )
+    monkeypatch.setattr(
+        continuity.null_suite,
+        "evaluate_null_control_suite",
+        lambda report, **_: {**report, "evaluation": {"status": "controls_incomplete", "recommended_next_action": "materialize_missing_preregistered_controls"}},
+    )
+
+    report = continuity.build_read_only_artifact_continuity(repo_root=tmp_path)
+
+    assert report["summary"]["artifact_continuity_ready"] is True
+    assert report["summary"]["materializable_target_count"] == 3
+    assert report["summary"]["blocked_target_count"] == 0
+    assert report["summary"]["exact_next_action"] == "materialize_read_only_qre_artifacts"
+
+
+def test_continuity_write_outputs_materializes_nested_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[str] = []
+    _write_json(
+        tmp_path / "research" / "operator_approvals" / "qre_preregistered_multiwindow_validation_approval.v1.json",
+        {"approval_id": "approval-001"},
+    )
+    monkeypatch.setattr(
+        continuity.disposition_memory,
+        "build_hypothesis_disposition_memory",
+        lambda **_: {"schema_version": "1.0", "report_kind": "qre_hypothesis_disposition_memory", "status": "ready", "deterministic_hash": "sha256:disp"},
+    )
+    monkeypatch.setattr(
+        continuity.disposition_memory,
+        "write_outputs",
+        lambda report, **_: calls.append("disposition") or {"latest": "logs/qre_hypothesis_disposition_memory/latest.json"},
+    )
+    monkeypatch.setattr(
+        continuity.cycle_router,
+        "_build_research_cycle_router_from_payloads",
+        lambda **_: {"schema_version": "1.0", "report_kind": "qre_research_cycle_router", "status": "ready", "deterministic_hash": "sha256:router"},
+    )
+    monkeypatch.setattr(
+        continuity.cycle_router,
+        "write_outputs",
+        lambda report, **_: calls.append("router") or {"latest": "logs/qre_research_cycle_router/latest.json"},
+    )
+    monkeypatch.setattr(
+        continuity.multiwindow_run,
+        "build_sampling_plan_for_multiwindow_approval",
+        lambda **_: {"sampling_plan_id": "plan-001", "hash": "plan-hash", "status": "sampling_plan_ready_context_only", "null_control_definitions": [{"control_id": "buy_and_hold_baseline"}]},
+    )
+    monkeypatch.setattr(
+        continuity.multiwindow_run,
+        "build_campaign_for_multiwindow_approval",
+        lambda **_: {"campaign_id": "campaign-001"},
+    )
+    monkeypatch.setattr(
+        continuity.null_suite,
+        "build_preregistered_null_control_suite",
+        lambda **_: {"schema_version": "1.0", "report_kind": "qre_null_control_falsification_suite", "status": "suite_ready_preregistered_context", "hash": "suite-hash"},
+    )
+    monkeypatch.setattr(
+        continuity.null_suite,
+        "evaluate_null_control_suite",
+        lambda report, **_: {**report, "evaluation": {"status": "controls_incomplete", "recommended_next_action": "materialize_missing_preregistered_controls"}},
+    )
+    monkeypatch.setattr(
+        continuity.null_suite,
+        "write_outputs",
+        lambda report, **_: calls.append("null_suite") or {"latest": "logs/qre_null_control_falsification_suite/latest.json"},
+    )
+    monkeypatch.setattr(
+        continuity,
+        "build_read_only_artifact_continuity",
+        lambda **_: {
+            "schema_version": "1.0",
+            "report_kind": "qre_read_only_artifact_continuity",
+            "summary": {"artifact_continuity_ready": True, "exact_next_action": "preserve_current_read_only_artifacts"},
+            "targets": [],
+            "current_status": {},
+            "projected_reports": {},
+            "authority_boundary": {},
+            "deterministic_hash": "sha256:continuity",
+        },
+    )
+
+    report = {
+        "schema_version": "1.0",
+        "report_kind": "qre_read_only_artifact_continuity",
+        "summary": {"artifact_continuity_ready": True},
+        "targets": [],
+    }
+    paths = continuity.write_outputs(report, repo_root=tmp_path)
+
+    assert calls == ["disposition", "router", "null_suite"]
+    assert paths["latest"] == "logs/qre_read_only_artifact_continuity/latest.json"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -38,12 +38,23 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
             }
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.artifact_continuity,
+        "build_read_only_artifact_continuity",
+        lambda **_: {
+            "summary": {
+                "artifact_continuity_ready": True,
+                "materializable_target_count": 0,
+            }
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts()
 
     assert report["summary"]["package_research_memory_ready"] is True
     assert report["summary"]["coverage_ready"] is True
     assert report["summary"]["retrieval_ready"] is True
+    assert report["summary"]["artifact_continuity_ready"] is True
     assert report["summary"]["final_recommendation"] == "research_memory_current_artifacts_ready"
 
 
@@ -90,12 +101,31 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
             "failure_latest": "logs/qre_failure_retrieval/latest.json",
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.artifact_continuity,
+        "build_read_only_artifact_continuity",
+        lambda **_: {
+            "summary": {
+                "artifact_continuity_ready": False,
+                "materializable_target_count": 3,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        current_artifacts.artifact_continuity,
+        "write_outputs",
+        lambda report, repo_root: {
+            "latest": "logs/qre_read_only_artifact_continuity/latest.json",
+            "operator_summary": "logs/qre_read_only_artifact_continuity/operator_summary.md",
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts(repo_root=tmp_path)
     paths = current_artifacts.write_outputs(report, repo_root=tmp_path)
 
     markdown = (tmp_path / paths["operator_summary"]).read_text(encoding="utf-8")
     assert paths["latest"] == "logs/qre_research_memory_current_artifacts/latest.json"
+    assert paths["artifact_continuity_latest"] == "logs/qre_read_only_artifact_continuity/latest.json"
     assert "# QRE Research Memory Current Artifacts" in markdown
 
 def test_memory_coverage_entries_include_resolved_entities():

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -100,6 +100,16 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         lambda **_: snapshots["research_memory"],
     )
     monkeypatch.setattr(
+        packet_module.artifact_continuity,
+        "build_read_only_artifact_continuity",
+        lambda **_: {
+            "summary": {
+                "artifact_continuity_ready": True,
+                "exact_next_action": "preserve_current_read_only_artifacts",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -158,6 +168,8 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["routing_evidence_ready"] is True
     assert packet["summary"]["sampling_evidence_ready"] is True
     assert packet["summary"]["research_memory_ready"] is True
+    assert packet["summary"]["artifact_continuity_ready"] is True
+    assert packet["summary"]["artifact_continuity_exact_next_action"] == "preserve_current_read_only_artifacts"
     assert packet["summary"]["trusted_loop_operational_controls_ready"] is True
     assert packet["summary"]["trusted_loop_operational_exact_next_action"] == "preserve_terminal_run_and_compare_before_rerun"
     assert packet["summary"]["shadow_readiness_status"] == "shadow_readiness_deferred"
@@ -207,6 +219,16 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
     monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: {"summary": {"final_recommendation": "routing_calibration_scaffold_ready"}})
     monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: {"summary": {"final_recommendation": "sampling_calibration_scaffold_ready"}})
     monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: {"summary": {"final_recommendation": "research_memory_current_artifacts_partial"}})
+    monkeypatch.setattr(
+        packet_module.artifact_continuity,
+        "build_read_only_artifact_continuity",
+        lambda **_: {
+            "summary": {
+                "artifact_continuity_ready": False,
+                "exact_next_action": "materialize_read_only_qre_artifacts",
+            }
+        },
+    )
     monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
@@ -292,6 +314,16 @@ def test_trusted_loop_review_packet_operator_summary_renders(
     monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: snapshots["sampling"])
     monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: snapshots["research_memory"])
     monkeypatch.setattr(
+        packet_module.artifact_continuity,
+        "build_read_only_artifact_continuity",
+        lambda **_: {
+            "summary": {
+                "artifact_continuity_ready": True,
+                "exact_next_action": "preserve_current_read_only_artifacts",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -361,6 +393,16 @@ def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(
     monkeypatch.setattr(packet_module.routing_calibration, "build_routing_calibration_report", lambda **_: snapshots["routing"])
     monkeypatch.setattr(packet_module.sampling_calibration, "build_sampling_calibration_report", lambda **_: snapshots["sampling"])
     monkeypatch.setattr(packet_module.research_memory, "build_research_memory_current_artifacts", lambda **_: snapshots["research_memory"])
+    monkeypatch.setattr(
+        packet_module.artifact_continuity,
+        "build_read_only_artifact_continuity",
+        lambda **_: {
+            "summary": {
+                "artifact_continuity_ready": True,
+                "exact_next_action": "preserve_current_read_only_artifacts",
+            }
+        },
+    )
     monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",


### PR DESCRIPTION
## Summary
- add a deterministic read-only artifact continuity layer that materializes disposition memory, research-cycle routing, and null-control latest artifacts from existing local inputs
- integrate continuity state into research-memory current-artifact and trusted-loop review surfaces without adding evidence or execution authority
- harden router and null-control status handling so missing prerequisites fail closed instead of disappearing behind absent artifacts

## Testing
- python -m pytest tests/unit/test_qre_read_only_artifact_continuity.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_trusted_loop_review_packet.py tests/unit/test_qre_null_control_falsification_suite.py tests/unit/test_qre_research_cycle_router.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- python -m research.qre_read_only_artifact_continuity --write
- python -m research.qre_research_memory_current_artifacts --write
- python -m research.qre_trusted_loop_review_packet --write
- git diff --check