### PR TITLE
feat: add contradiction and staleness intelligence

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -33,6 +33,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_research_cycle_router/latest.json"),
     Path("logs/qre_evidence_breadth_framework/latest.json"),
     Path("logs/qre_research_memory_retrieval/latest.json"),
+    Path("logs/qre_contradiction_staleness_intelligence/latest.json"),
     Path("logs/qre_null_control_falsification_suite/latest.json"),
     Path("logs/qre_candidate_identity_lifecycle/latest.json"),
     Path("logs/qre_candidate_quality_framework/latest.json"),

--- a/research/qre_contradiction_staleness_intelligence.py
+++ b/research/qre_contradiction_staleness_intelligence.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_lineage_graph_v1 as lineage_graph
+from research import qre_research_memory_graph as memory_graph
+from research import qre_research_memory_retrieval as memory_retrieval
+from research import qre_retrieval_maturity as retrieval_maturity
+from research import qre_trusted_loop_operational_controls as operational_controls
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_contradiction_staleness_intelligence"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_contradiction_staleness_intelligence")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_contradiction_staleness_intelligence/"
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _dedupe_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for row in rows:
+        canonical = json.dumps(dict(row), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        deduped.append(dict(row))
+    return deduped
+
+
+def _query_rows(report: Mapping[str, Any], query_id: str) -> list[dict[str, Any]]:
+    queries = report.get("queries") if isinstance(report.get("queries"), list) else []
+    for query in queries:
+        if not isinstance(query, Mapping):
+            continue
+        if _text(query.get("query_id")) != query_id:
+            continue
+        rows = query.get("rows") if isinstance(query.get("rows"), list) else []
+        return [dict(row) for row in rows if isinstance(row, Mapping)]
+    return []
+
+
+def build_contradiction_staleness_intelligence(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    retrieval_report = memory_retrieval.build_research_memory_retrieval(repo_root=repo_root)
+    memory_graph_report = memory_graph.build_research_memory_graph(repo_root=repo_root)
+    lineage_graph_report = lineage_graph.build_qre_lineage_graph_v1(repo_root=repo_root)
+    maturity_report = retrieval_maturity.build_retrieval_maturity(repo_root=repo_root)
+    operational_report = operational_controls.build_trusted_loop_operational_controls(
+        repo_root=repo_root
+    )
+
+    contradiction_rows: list[dict[str, Any]] = []
+    contradiction_rows.extend(
+        {
+            "source": "qre_research_memory_retrieval",
+            "detail": _text(row.get("reason")) or _text(row.get("scope_key")),
+            "scope_key": _text(row.get("scope_key")),
+            "dimension": _text(row.get("dimension")),
+            "artifact_ref": "logs/qre_research_memory_retrieval/latest.json",
+        }
+        for row in _query_rows(retrieval_report, "contradictory_outcomes")
+    )
+    checks = memory_graph_report.get("checks") if isinstance(memory_graph_report.get("checks"), Mapping) else {}
+    contradiction_rows.extend(
+        {
+            "source": "qre_research_memory_graph",
+            "detail": _text(row.get("reason")),
+            "scope_key": _text(row.get("subject_id")),
+            "dimension": "memory_subject",
+            "artifact_ref": "logs/qre_research_memory_graph/latest.json",
+        }
+        for row in (checks.get("contradictions") or [])
+        if isinstance(row, Mapping)
+    )
+    lineage_checks = lineage_graph_report.get("checks") if isinstance(lineage_graph_report.get("checks"), Mapping) else {}
+    contradiction_rows.extend(
+        {
+            "source": "qre_lineage_graph_v1",
+            "detail": _text(row.get("detail")) or _text(row.get("kind")),
+            "scope_key": _text(row.get("campaign_id")) or _text(row.get("hypothesis_id")),
+            "dimension": _text(row.get("kind")) or "lineage_graph",
+            "artifact_ref": "logs/qre_lineage_graph_v1/latest.json",
+        }
+        for row in (lineage_checks.get("contradictions") or [])
+        if isinstance(row, Mapping)
+    )
+    contradiction_rows = _dedupe_rows(contradiction_rows)
+
+    stale_rows: list[dict[str, Any]] = []
+    stale_rows.extend(
+        {
+            "source": "qre_research_memory_retrieval",
+            "detail": _text(row.get("status")),
+            "artifact_path": _text(row.get("artifact_path")),
+            "artifact_ref": "logs/qre_research_memory_retrieval/latest.json",
+        }
+        for row in _query_rows(retrieval_report, "stale_or_superseded_knowledge")
+    )
+    reconciliation = (
+        operational_report.get("state_reconciliation")
+        if isinstance(operational_report.get("state_reconciliation"), Mapping)
+        else {}
+    )
+    stale_rows.extend(
+        {
+            "source": "qre_trusted_loop_operational_controls",
+            "detail": _text(reason),
+            "artifact_path": "research/run_manifest_latest.v1.json",
+            "artifact_ref": "logs/qre_trusted_loop_operational_controls/latest.json",
+        }
+        for reason in reconciliation.get("mismatches") or []
+        if _text(reason)
+    )
+    freshness = (
+        operational_report.get("artifact_freshness")
+        if isinstance(operational_report.get("artifact_freshness"), Mapping)
+        else {}
+    )
+    stale_rows.extend(
+        {
+            "source": "qre_trusted_loop_operational_controls",
+            "detail": _text(reason),
+            "artifact_path": "research/run_state.v1.json",
+            "artifact_ref": "logs/qre_trusted_loop_operational_controls/latest.json",
+        }
+        for reason in freshness.get("stale_reasons") or []
+        if _text(reason)
+    )
+    stale_rows = _dedupe_rows(stale_rows)
+
+    graph_statuses = {
+        "research_memory_graph": _text((memory_graph_report.get("summary") or {}).get("graph_status")),
+        "lineage_graph": _text((lineage_graph_report.get("summary") or {}).get("graph_status")),
+        "retrieval_maturity": _text((maturity_report.get("summary") or {}).get("graph_status")),
+    }
+    ready = all(status in {"ready", "partial"} for status in graph_statuses.values()) and bool(
+        (retrieval_report.get("summary") or {}).get("research_memory_ready")
+    )
+    exact_next_action = (
+        "reconcile_stale_or_superseded_artifacts"
+        if stale_rows
+        else "review_visible_contradictions_before_new_research"
+        if contradiction_rows
+        else "preserve_contradiction_and_staleness_visibility"
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "contradiction_staleness_ready": ready,
+            "contradiction_count": len(contradiction_rows),
+            "stale_or_superseded_count": len(stale_rows),
+            "graph_statuses": graph_statuses,
+            "exact_next_action": exact_next_action,
+            "operator_summary": (
+                "Contradiction and staleness intelligence unifies retrieval, research-memory graph, "
+                "lineage graph, retrieval maturity, and trusted-loop stale-artifact context as "
+                "read-only operator visibility only."
+            ),
+        },
+        "contradictions": contradiction_rows,
+        "stale_or_superseded": stale_rows,
+        "supporting_reports": {
+            "qre_research_memory_retrieval": "logs/qre_research_memory_retrieval/latest.json",
+            "qre_research_memory_graph": "logs/qre_research_memory_graph/latest.json",
+            "qre_lineage_graph_v1": "logs/qre_lineage_graph_v1/latest.json",
+            "qre_retrieval_maturity": "logs/qre_retrieval_maturity/latest.json",
+            "qre_trusted_loop_operational_controls": "logs/qre_trusted_loop_operational_controls/latest.json",
+        },
+        "authority_boundary": {
+            "read_only": True,
+            "context_only": True,
+            "can_authorize_execution": False,
+            "can_promote_candidate": False,
+            "can_activate_shadow": False,
+        },
+        "safety_invariants": {
+            "uses_local_artifacts_only": True,
+            "uses_network": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+    report["deterministic_hash"] = _digest(
+        {
+            "schema_version": report["schema_version"],
+            "report_kind": report["report_kind"],
+            "summary": report["summary"],
+            "contradictions": report["contradictions"],
+            "stale_or_superseded": report["stale_or_superseded"],
+            "supporting_reports": report["supporting_reports"],
+            "authority_boundary": report["authority_boundary"],
+        }
+    )
+    return report
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    lines = [
+        "# QRE Contradiction And Staleness Intelligence",
+        "",
+        f"- contradiction_staleness_ready: {summary.get('contradiction_staleness_ready', False)}",
+        f"- contradiction_count: {summary.get('contradiction_count', 0)}",
+        f"- stale_or_superseded_count: {summary.get('stale_or_superseded_count', 0)}",
+        f"- exact_next_action: {summary.get('exact_next_action', '')}",
+        "",
+        "## Graph Statuses",
+    ]
+    for key, value in (summary.get("graph_statuses") or {}).items():
+        lines.append(f"- {key}: {value}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    retrieval_payload = memory_retrieval.build_research_memory_retrieval(repo_root=repo_root)
+    memory_retrieval.write_outputs(retrieval_payload, repo_root=repo_root)
+    memory_graph_payload = memory_graph.build_research_memory_graph(repo_root=repo_root)
+    memory_graph.write_outputs(memory_graph_payload, repo_root=repo_root)
+    lineage_payload = lineage_graph.build_qre_lineage_graph_v1(repo_root=repo_root)
+    lineage_graph.write_outputs(lineage_payload, repo_root=repo_root)
+    maturity_payload = retrieval_maturity.build_retrieval_maturity(repo_root=repo_root)
+    retrieval_maturity.write_outputs(maturity_payload, repo_root=repo_root)
+
+    refreshed = build_contradiction_staleness_intelligence(repo_root=repo_root)
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(refreshed, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(refreshed) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_contradiction_staleness_intelligence",
+        description="Materialize deterministic contradiction and staleness visibility across QRE retrieval and graph surfaces.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_contradiction_staleness_intelligence()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_research_memory_current_artifacts.py
+++ b/research/qre_research_memory_current_artifacts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from packages.qre_research import research_memory
+from research import qre_contradiction_staleness_intelligence as contradiction_staleness
 from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_memory_coverage as memory_coverage
 
@@ -56,6 +57,11 @@ def build_research_memory_current_artifacts(
     continuity = artifact_continuity.build_read_only_artifact_continuity(repo_root=repo_root)
     continuity_summary = continuity.get("summary") if isinstance(continuity.get("summary"), Mapping) else {}
     continuity_ready = bool(continuity_summary.get("artifact_continuity_ready"))
+    contradiction_report = contradiction_staleness.build_contradiction_staleness_intelligence(repo_root=repo_root)
+    contradiction_summary = (
+        contradiction_report.get("summary") if isinstance(contradiction_report.get("summary"), Mapping) else {}
+    )
+    contradiction_ready = bool(contradiction_summary.get("contradiction_staleness_ready"))
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -66,6 +72,7 @@ def build_research_memory_current_artifacts(
             "coverage_ready": coverage_ready,
             "retrieval_ready": retrieval_ready,
             "artifact_continuity_ready": continuity_ready,
+            "contradiction_staleness_ready": contradiction_ready,
             "indexed_entry_count": int(memory_summary.get("indexed_entry_count") or 0),
             "indexed_candidate_count": int(memory_summary.get("indexed_candidate_count") or 0),
             "retrievable_failure_subject_count": int(
@@ -74,9 +81,13 @@ def build_research_memory_current_artifacts(
             "artifact_continuity_materializable_target_count": int(
                 continuity_summary.get("materializable_target_count") or 0
             ),
+            "visible_contradiction_count": int(contradiction_summary.get("contradiction_count") or 0),
+            "visible_stale_or_superseded_count": int(
+                contradiction_summary.get("stale_or_superseded_count") or 0
+            ),
             "final_recommendation": (
                 "research_memory_current_artifacts_ready"
-                if package_ready and coverage_ready and retrieval_ready and continuity_ready
+                if package_ready and coverage_ready and retrieval_ready and continuity_ready and contradiction_ready
                 else "research_memory_current_artifacts_partial"
             ),
             "operator_summary": (
@@ -88,11 +99,13 @@ def build_research_memory_current_artifacts(
         "memory_coverage_summary": dict(memory_summary),
         "failure_retrieval_summary": dict(retrieval_summary),
         "artifact_continuity_summary": dict(continuity_summary),
+        "contradiction_staleness_summary": dict(contradiction_summary),
         "memory_artifacts": {
             "package_memory_path": str(package_status.get("path") or "logs/qre_research_memory/latest.json"),
             "coverage_path": "logs/qre_research_memory_coverage/latest.json",
             "failure_retrieval_path": "logs/qre_failure_retrieval/latest.json",
             "artifact_continuity_path": "logs/qre_read_only_artifact_continuity/latest.json",
+            "contradiction_staleness_path": "logs/qre_contradiction_staleness_intelligence/latest.json",
         },
         "safety_invariants": {
             "read_only": True,
@@ -124,9 +137,12 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["coverage_ready", str(summary.get("coverage_ready") or False)],
                     ["retrieval_ready", str(summary.get("retrieval_ready") or False)],
                     ["artifact_continuity_ready", str(summary.get("artifact_continuity_ready") or False)],
+                    ["contradiction_staleness_ready", str(summary.get("contradiction_staleness_ready") or False)],
                     ["indexed_entry_count", str(summary.get("indexed_entry_count") or 0)],
                     ["retrievable_failure_subject_count", str(summary.get("retrievable_failure_subject_count") or 0)],
                     ["artifact_continuity_materializable_target_count", str(summary.get("artifact_continuity_materializable_target_count") or 0)],
+                    ["visible_contradiction_count", str(summary.get("visible_contradiction_count") or 0)],
+                    ["visible_stale_or_superseded_count", str(summary.get("visible_stale_or_superseded_count") or 0)],
                     ["final_recommendation", str(summary.get("final_recommendation") or "")],
                 ],
             ),
@@ -139,6 +155,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["coverage_path", str(artifacts.get("coverage_path") or "")],
                     ["failure_retrieval_path", str(artifacts.get("failure_retrieval_path") or "")],
                     ["artifact_continuity_path", str(artifacts.get("artifact_continuity_path") or "")],
+                    ["contradiction_staleness_path", str(artifacts.get("contradiction_staleness_path") or "")],
                 ],
             ),
             "",
@@ -167,6 +184,8 @@ def write_outputs(
     memory_paths = memory_coverage.write_outputs(memory, retrieval, repo_root=repo_root)
     continuity_report = artifact_continuity.build_read_only_artifact_continuity(repo_root=repo_root)
     continuity_paths = artifact_continuity.write_outputs(continuity_report, repo_root=repo_root)
+    contradiction_report = contradiction_staleness.build_contradiction_staleness_intelligence(repo_root=repo_root)
+    contradiction_paths = contradiction_staleness.write_outputs(contradiction_report, repo_root=repo_root)
 
     base = repo_root / DEFAULT_OUTPUT_DIR
     base.mkdir(parents=True, exist_ok=True)
@@ -184,6 +203,8 @@ def write_outputs(
         **memory_paths,
         "artifact_continuity_latest": continuity_paths["latest"],
         "artifact_continuity_operator_summary": continuity_paths["operator_summary"],
+        "contradiction_staleness_latest": contradiction_paths["latest"],
+        "contradiction_staleness_operator_summary": contradiction_paths["operator_summary"],
         "latest": latest.relative_to(repo_root).as_posix(),
         "operator_summary": summary_path.relative_to(repo_root).as_posix(),
     }

--- a/research/qre_research_memory_retrieval.py
+++ b/research/qre_research_memory_retrieval.py
@@ -30,6 +30,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_evidence_breadth_framework/latest.json"),
     Path("logs/qre_source_identity_authority_normalization/latest.json"),
     Path("logs/qre_read_only_artifact_continuity/latest.json"),
+    Path("logs/qre_contradiction_staleness_intelligence/latest.json"),
     Path("logs/qre_preregistered_multiwindow_evidence_run/latest.json"),
     Path("logs/qre_multiwindow_evidence_closure/latest.json"),
 )

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -23,6 +23,7 @@ from research import qre_failure_action_from_basket as failure_action
 from research import qre_first_batch_evidence_recovery_cascade as first_batch_cascade
 from research import qre_first_batch_evidence_recovery_readiness as first_batch_readiness
 from research import qre_basket_operator_action_plan as basket_action_plan
+from research import qre_contradiction_staleness_intelligence as contradiction_staleness
 from research import qre_reason_records_v1 as reason_records
 from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_memory_current_artifacts as research_memory
@@ -270,6 +271,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     sampling_packet = sampling_calibration.build_sampling_calibration_report(repo_root=repo_root)
     memory_packet = research_memory.build_research_memory_current_artifacts(repo_root=repo_root)
     continuity_packet = artifact_continuity.build_read_only_artifact_continuity(repo_root=repo_root)
+    contradiction_packet = contradiction_staleness.build_contradiction_staleness_intelligence(
+        repo_root=repo_root
+    )
     action_plan_packet = basket_action_plan.build_basket_operator_action_plan(repo_root=repo_root)
     operational_controls_packet = operational_controls.build_trusted_loop_operational_controls(
         repo_root=repo_root
@@ -302,6 +306,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     memory_summary = memory_packet if isinstance(memory_packet, Mapping) else {}
     continuity_summary = (
         continuity_packet.get("summary") if isinstance(continuity_packet.get("summary"), Mapping) else {}
+    )
+    contradiction_summary = (
+        contradiction_packet.get("summary") if isinstance(contradiction_packet.get("summary"), Mapping) else {}
     )
     action_plan_summary = action_plan_packet.get("summary") if isinstance(action_plan_packet.get("summary"), Mapping) else {}
     structured_lineage_summary = (
@@ -350,6 +357,14 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             == "research_memory_current_artifacts_ready",
             "artifact_continuity_ready": bool(continuity_summary.get("artifact_continuity_ready")),
             "artifact_continuity_exact_next_action": str(continuity_summary.get("exact_next_action") or ""),
+            "contradiction_staleness_ready": bool(contradiction_summary.get("contradiction_staleness_ready")),
+            "visible_contradiction_count": int(contradiction_summary.get("contradiction_count") or 0),
+            "visible_stale_or_superseded_count": int(
+                contradiction_summary.get("stale_or_superseded_count") or 0
+            ),
+            "contradiction_staleness_exact_next_action": str(
+                contradiction_summary.get("exact_next_action") or ""
+            ),
             "basket_operator_action_plan_ready": str(action_plan_summary.get("final_recommendation") or "")
             == "basket_operator_action_plan_ready",
             "trusted_loop_operational_controls_ready": bool(
@@ -436,6 +451,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "sampling_calibration": sampling_packet,
             "research_memory": memory_packet,
             "artifact_continuity": continuity_packet,
+            "contradiction_staleness": contradiction_packet,
             "operational_controls": operational_controls_packet,
             "shadow_readiness_gates": shadow_readiness_packet,
         },
@@ -529,6 +545,10 @@ def render_operator_summary(packet: Mapping[str, Any]) -> str:
             f"- research_memory_ready: {summary.get('research_memory_ready')}",
             f"- artifact_continuity_ready: {summary.get('artifact_continuity_ready')}",
             f"- artifact_continuity_exact_next_action: {summary.get('artifact_continuity_exact_next_action')}",
+            f"- contradiction_staleness_ready: {summary.get('contradiction_staleness_ready')}",
+            f"- visible_contradiction_count: {summary.get('visible_contradiction_count')}",
+            f"- visible_stale_or_superseded_count: {summary.get('visible_stale_or_superseded_count')}",
+            f"- contradiction_staleness_exact_next_action: {summary.get('contradiction_staleness_exact_next_action')}",
             f"- guarded_alias_bounded_generation_cascade_result: {summary.get('guarded_alias_bounded_generation_cascade_result')}",
             f"- guarded_alias_bounded_generation_top_blocker: {summary.get('guarded_alias_bounded_generation_top_blocker')}",
             f"- structured_lineage_artifact_status: {summary.get('structured_lineage_artifact_status')}",

--- a/tests/unit/test_qre_contradiction_staleness_intelligence.py
+++ b/tests/unit/test_qre_contradiction_staleness_intelligence.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_contradiction_staleness_intelligence as csi
+
+
+def test_contradiction_staleness_intelligence_aggregates_visible_rows(monkeypatch) -> None:
+    monkeypatch.setattr(
+        csi.memory_retrieval,
+        "build_research_memory_retrieval",
+        lambda **_: {
+            "summary": {"research_memory_ready": True},
+            "queries": [
+                {
+                    "query_id": "contradictory_outcomes",
+                    "rows": [{"scope_key": "preset_alpha", "dimension": "preset", "reason": "accepted_and_rejected_counts_visible_together"}],
+                },
+                {
+                    "query_id": "stale_or_superseded_knowledge",
+                    "rows": [{"artifact_path": "logs/missing/latest.json", "status": "missing"}],
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        csi.memory_graph,
+        "build_research_memory_graph",
+        lambda **_: {
+            "summary": {"graph_status": "partial"},
+            "checks": {"contradictions": [{"subject_id": "cand-1", "reason": "contradictory_reason_code_visible"}]},
+        },
+    )
+    monkeypatch.setattr(
+        csi.lineage_graph,
+        "build_qre_lineage_graph_v1",
+        lambda **_: {
+            "summary": {"graph_status": "ready"},
+            "checks": {"contradictions": [{"campaign_id": "cmp-1", "kind": "missing_campaign_digest_root", "detail": "Campaign has no lineage-root digest evidence."}]},
+        },
+    )
+    monkeypatch.setattr(
+        csi.retrieval_maturity,
+        "build_retrieval_maturity",
+        lambda **_: {"summary": {"graph_status": "ready"}},
+    )
+    monkeypatch.setattr(
+        csi.operational_controls,
+        "build_trusted_loop_operational_controls",
+        lambda **_: {
+            "state_reconciliation": {"mismatches": ["latest_artifacts_superseded_by_history"]},
+            "artifact_freshness": {"stale_reasons": ["run_id_mismatch"]},
+        },
+    )
+
+    report = csi.build_contradiction_staleness_intelligence()
+
+    assert report["summary"]["contradiction_staleness_ready"] is True
+    assert report["summary"]["contradiction_count"] == 3
+    assert report["summary"]["stale_or_superseded_count"] == 3
+    assert report["summary"]["exact_next_action"] == "reconcile_stale_or_superseded_artifacts"
+
+
+def test_contradiction_staleness_write_outputs_stays_in_allowlist(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        csi.memory_retrieval,
+        "build_research_memory_retrieval",
+        lambda **_: {"summary": {"research_memory_ready": True}, "queries": []},
+    )
+    monkeypatch.setattr(
+        csi.memory_retrieval,
+        "write_outputs",
+        lambda report, **_: {"latest": "logs/qre_research_memory_retrieval/latest.json"},
+    )
+    monkeypatch.setattr(
+        csi.memory_graph,
+        "build_research_memory_graph",
+        lambda **_: {"summary": {"graph_status": "ready"}, "checks": {"contradictions": []}},
+    )
+    monkeypatch.setattr(
+        csi.memory_graph,
+        "write_outputs",
+        lambda report, **_: {"latest": "logs/qre_research_memory_graph/latest.json"},
+    )
+    monkeypatch.setattr(
+        csi.lineage_graph,
+        "build_qre_lineage_graph_v1",
+        lambda **_: {"summary": {"graph_status": "ready"}, "checks": {"contradictions": []}},
+    )
+    monkeypatch.setattr(
+        csi.lineage_graph,
+        "write_outputs",
+        lambda report, **_: {"latest": "logs/qre_lineage_graph_v1/latest.json"},
+    )
+    monkeypatch.setattr(
+        csi.retrieval_maturity,
+        "build_retrieval_maturity",
+        lambda **_: {"summary": {"graph_status": "ready"}},
+    )
+    monkeypatch.setattr(
+        csi.retrieval_maturity,
+        "write_outputs",
+        lambda report, **_: {"latest": "logs/qre_retrieval_maturity/latest.json"},
+    )
+    monkeypatch.setattr(
+        csi.operational_controls,
+        "build_trusted_loop_operational_controls",
+        lambda **_: {"state_reconciliation": {"mismatches": []}, "artifact_freshness": {"stale_reasons": []}},
+    )
+
+    report = csi.build_contradiction_staleness_intelligence(repo_root=tmp_path)
+    paths = csi.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_contradiction_staleness_intelligence/latest.json"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -48,6 +48,17 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
             }
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.contradiction_staleness,
+        "build_contradiction_staleness_intelligence",
+        lambda **_: {
+            "summary": {
+                "contradiction_staleness_ready": True,
+                "contradiction_count": 0,
+                "stale_or_superseded_count": 0,
+            }
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts()
 
@@ -55,6 +66,7 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
     assert report["summary"]["coverage_ready"] is True
     assert report["summary"]["retrieval_ready"] is True
     assert report["summary"]["artifact_continuity_ready"] is True
+    assert report["summary"]["contradiction_staleness_ready"] is True
     assert report["summary"]["final_recommendation"] == "research_memory_current_artifacts_ready"
 
 
@@ -119,6 +131,25 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
             "operator_summary": "logs/qre_read_only_artifact_continuity/operator_summary.md",
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.contradiction_staleness,
+        "build_contradiction_staleness_intelligence",
+        lambda **_: {
+            "summary": {
+                "contradiction_staleness_ready": False,
+                "contradiction_count": 2,
+                "stale_or_superseded_count": 1,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        current_artifacts.contradiction_staleness,
+        "write_outputs",
+        lambda report, repo_root: {
+            "latest": "logs/qre_contradiction_staleness_intelligence/latest.json",
+            "operator_summary": "logs/qre_contradiction_staleness_intelligence/operator_summary.md",
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts(repo_root=tmp_path)
     paths = current_artifacts.write_outputs(report, repo_root=tmp_path)
@@ -126,6 +157,7 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
     markdown = (tmp_path / paths["operator_summary"]).read_text(encoding="utf-8")
     assert paths["latest"] == "logs/qre_research_memory_current_artifacts/latest.json"
     assert paths["artifact_continuity_latest"] == "logs/qre_read_only_artifact_continuity/latest.json"
+    assert paths["contradiction_staleness_latest"] == "logs/qre_contradiction_staleness_intelligence/latest.json"
     assert "# QRE Research Memory Current Artifacts" in markdown
 
 def test_memory_coverage_entries_include_resolved_entities():

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -110,6 +110,18 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         },
     )
     monkeypatch.setattr(
+        packet_module.contradiction_staleness,
+        "build_contradiction_staleness_intelligence",
+        lambda **_: {
+            "summary": {
+                "contradiction_staleness_ready": True,
+                "contradiction_count": 0,
+                "stale_or_superseded_count": 0,
+                "exact_next_action": "preserve_contradiction_and_staleness_visibility",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -170,6 +182,9 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["research_memory_ready"] is True
     assert packet["summary"]["artifact_continuity_ready"] is True
     assert packet["summary"]["artifact_continuity_exact_next_action"] == "preserve_current_read_only_artifacts"
+    assert packet["summary"]["contradiction_staleness_ready"] is True
+    assert packet["summary"]["visible_contradiction_count"] == 0
+    assert packet["summary"]["visible_stale_or_superseded_count"] == 0
     assert packet["summary"]["trusted_loop_operational_controls_ready"] is True
     assert packet["summary"]["trusted_loop_operational_exact_next_action"] == "preserve_terminal_run_and_compare_before_rerun"
     assert packet["summary"]["shadow_readiness_status"] == "shadow_readiness_deferred"
@@ -226,6 +241,18 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
             "summary": {
                 "artifact_continuity_ready": False,
                 "exact_next_action": "materialize_read_only_qre_artifacts",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.contradiction_staleness,
+        "build_contradiction_staleness_intelligence",
+        lambda **_: {
+            "summary": {
+                "contradiction_staleness_ready": False,
+                "contradiction_count": 2,
+                "stale_or_superseded_count": 1,
+                "exact_next_action": "reconcile_stale_or_superseded_artifacts",
             }
         },
     )
@@ -324,6 +351,18 @@ def test_trusted_loop_review_packet_operator_summary_renders(
         },
     )
     monkeypatch.setattr(
+        packet_module.contradiction_staleness,
+        "build_contradiction_staleness_intelligence",
+        lambda **_: {
+            "summary": {
+                "contradiction_staleness_ready": True,
+                "contradiction_count": 0,
+                "stale_or_superseded_count": 0,
+                "exact_next_action": "preserve_contradiction_and_staleness_visibility",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -400,6 +439,18 @@ def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(
             "summary": {
                 "artifact_continuity_ready": True,
                 "exact_next_action": "preserve_current_read_only_artifacts",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.contradiction_staleness,
+        "build_contradiction_staleness_intelligence",
+        lambda **_: {
+            "summary": {
+                "contradiction_staleness_ready": True,
+                "contradiction_count": 0,
+                "stale_or_superseded_count": 0,
+                "exact_next_action": "preserve_contradiction_and_staleness_visibility",
             }
         },
     )


### PR DESCRIPTION
## Summary
- add a deterministic read-only contradiction and staleness intelligence surface over retrieval, graph, lineage, and trusted-loop artifacts
- integrate the new surface into research-memory current artifacts and the trusted-loop review packet
- index the new artifact in research memory and cover the new integration paths with unit tests

## Testing
- python -m pytest tests/unit/test_qre_contradiction_staleness_intelligence.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_trusted_loop_review_packet.py tests/unit/test_qre_research_memory_graph.py tests/unit/test_qre_lineage_graph_v1.py tests/unit/test_qre_retrieval_maturity.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check