### PR TITLE
feat: add campaign throughput bottleneck intelligence

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -40,6 +40,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_multibasket_portfolio_intelligence/latest.json"),
     Path("logs/qre_source_identity_authority_normalization/latest.json"),
     Path("logs/qre_read_only_artifact_continuity/latest.json"),
+    Path("logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"),
     Path("logs/qre_trusted_loop_operational_controls/latest.json"),
     Path("logs/qre_shadow_readiness_gates/latest.json"),
 )

--- a/research/qre_campaign_throughput_bottleneck_intelligence.py
+++ b/research/qre_campaign_throughput_bottleneck_intelligence.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_cache_throughput_manifest as cache_throughput
+from research import qre_trusted_loop_operational_controls as operational_controls
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_campaign_throughput_bottleneck_intelligence"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_campaign_throughput_bottleneck_intelligence")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_campaign_throughput_bottleneck_intelligence/"
+
+REGISTRY_PATH: Final[Path] = Path("research/campaign_registry_latest.v1.json")
+QUEUE_PATH: Final[Path] = Path("research/campaign_queue_latest.v1.json")
+DIGEST_PATH: Final[Path] = Path("research/campaign_digest_latest.v1.json")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _rel(path: Path, *, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _registry_rows(payload: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    campaigns = payload.get("campaigns") if isinstance(payload, Mapping) else None
+    if not isinstance(campaigns, Mapping):
+        return []
+    rows = [dict(row) for row in campaigns.values() if isinstance(row, Mapping)]
+    rows.sort(key=lambda row: (_text(row.get("campaign_id")), _text(row.get("preset_name"))))
+    return rows
+
+
+def _queue_rows(payload: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    queue = payload.get("queue") if isinstance(payload, Mapping) else None
+    if not isinstance(queue, list):
+        return []
+    rows = [dict(row) for row in queue if isinstance(row, Mapping)]
+    rows.sort(key=lambda row: (_text(row.get("campaign_id")), _text(row.get("state"))))
+    return rows
+
+
+def _active_registry_ids(rows: list[dict[str, Any]]) -> list[str]:
+    return sorted(
+        _text(row.get("campaign_id"))
+        for row in rows
+        if _text(row.get("state")) in {"pending", "leased", "running"} and _text(row.get("campaign_id"))
+    )
+
+
+def _active_queue_ids(rows: list[dict[str, Any]]) -> list[str]:
+    return sorted(
+        _text(row.get("campaign_id"))
+        for row in rows
+        if _text(row.get("state")) in {"pending", "leased", "running"} and _text(row.get("campaign_id"))
+    )
+
+
+def _bottleneck(
+    *,
+    code: str,
+    severity: str,
+    reason_codes: list[str],
+    exact_next_action: str,
+    operator_explanation: str,
+    evidence_refs: list[str],
+) -> dict[str, Any]:
+    return {
+        "bottleneck_code": code,
+        "severity": severity,
+        "reason_codes": reason_codes,
+        "exact_next_action": exact_next_action,
+        "operator_explanation": operator_explanation,
+        "evidence_refs": evidence_refs,
+    }
+
+
+def _build_bottlenecks(
+    *,
+    repo_root: Path,
+    registry_payload: Mapping[str, Any] | None,
+    queue_payload: Mapping[str, Any] | None,
+    digest_payload: Mapping[str, Any] | None,
+    throughput_status: Mapping[str, Any],
+    controls: Mapping[str, Any],
+    registry_rows: list[dict[str, Any]],
+    queue_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if registry_payload is None:
+        rows.append(
+            _bottleneck(
+                code="missing_campaign_registry",
+                severity="critical",
+                reason_codes=["campaign_registry_missing"],
+                exact_next_action="restore_campaign_registry_artifact",
+                operator_explanation="Campaign throughput intelligence cannot reconcile current scope without the registry snapshot.",
+                evidence_refs=[_rel(repo_root / REGISTRY_PATH, root=repo_root)],
+            )
+        )
+    if queue_payload is None:
+        rows.append(
+            _bottleneck(
+                code="missing_campaign_queue",
+                severity="critical",
+                reason_codes=["campaign_queue_missing"],
+                exact_next_action="restore_campaign_queue_artifact",
+                operator_explanation="Campaign throughput intelligence cannot verify queue projection without the queue artifact.",
+                evidence_refs=[_rel(repo_root / QUEUE_PATH, root=repo_root)],
+            )
+        )
+    if digest_payload is None:
+        rows.append(
+            _bottleneck(
+                code="missing_campaign_digest",
+                severity="high",
+                reason_codes=["campaign_digest_missing"],
+                exact_next_action="restore_campaign_digest_artifact",
+                operator_explanation="Digest context is missing, so throughput trends remain fail-closed and incomplete.",
+                evidence_refs=[_rel(repo_root / DIGEST_PATH, root=repo_root)],
+            )
+        )
+
+    active_registry = set(_active_registry_ids(registry_rows))
+    active_queue = set(_active_queue_ids(queue_rows))
+    missing_in_queue = sorted(active_registry - active_queue)
+    orphaned_queue = sorted(active_queue - active_registry)
+    if missing_in_queue or orphaned_queue:
+        rows.append(
+            _bottleneck(
+                code="queue_registry_divergence",
+                severity="critical",
+                reason_codes=["active_registry_queue_mismatch"],
+                exact_next_action="reconcile_campaign_queue_from_registry",
+                operator_explanation="The queue view diverges from the registry source of truth for active campaigns.",
+                evidence_refs=[
+                    _rel(repo_root / REGISTRY_PATH, root=repo_root),
+                    _rel(repo_root / QUEUE_PATH, root=repo_root),
+                ],
+            )
+        )
+
+    if not bool(throughput_status.get("research_ready")):
+        rows.append(
+            _bottleneck(
+                code="cache_throughput_not_ready",
+                severity="high",
+                reason_codes=["cache_throughput_manifest_not_ready"],
+                exact_next_action="stabilize_cache_throughput_manifest",
+                operator_explanation="Local cache throughput context is not research-ready, so throughput analysis stays incomplete.",
+                evidence_refs=[_text(throughput_status.get("path")) or "logs/qre_cache_throughput_manifest/latest.json"],
+            )
+        )
+
+    controls_summary = controls.get("summary") if isinstance(controls.get("summary"), Mapping) else {}
+    if _text(controls_summary.get("artifact_freshness_status")) == "stale_or_missing":
+        rows.append(
+            _bottleneck(
+                code="stale_run_artifact_pressure",
+                severity="high",
+                reason_codes=["trusted_loop_artifacts_stale_or_missing"],
+                exact_next_action=_text(controls_summary.get("exact_next_safe_action")) or "reconcile_stale_or_mismatched_run_artifacts",
+                operator_explanation="Trusted-loop artifacts are stale or missing, which weakens campaign throughput comparability across runs.",
+                evidence_refs=["logs/qre_trusted_loop_operational_controls/latest.json"],
+            )
+        )
+
+    digest_meaningful = (
+        (digest_payload or {}).get("meaningful_by_classification")
+        if isinstance((digest_payload or {}).get("meaningful_by_classification"), Mapping)
+        else {}
+    )
+    queue_depth = int((digest_payload or {}).get("queue_depth") or len(active_queue))
+    campaigns_completed = int((digest_payload or {}).get("campaigns_completed") or 0)
+    campaigns_failed = int((digest_payload or {}).get("campaigns_failed") or 0)
+    duplicate_low_value = int(digest_meaningful.get("duplicate_low_value_run") or 0)
+    if queue_depth > 0 and campaigns_completed == 0:
+        rows.append(
+            _bottleneck(
+                code="queue_backpressure_without_completion",
+                severity="medium",
+                reason_codes=["queue_depth_positive_with_zero_completed_campaigns"],
+                exact_next_action="inspect_active_campaign_queue_progress",
+                operator_explanation="Campaigns remain active or queued without any completed campaigns in the current digest window.",
+                evidence_refs=[_rel(repo_root / DIGEST_PATH, root=repo_root)],
+            )
+        )
+    if campaigns_failed > 0:
+        rows.append(
+            _bottleneck(
+                code="technical_or_failed_campaign_pressure",
+                severity="medium",
+                reason_codes=["campaign_failures_visible_in_digest"],
+                exact_next_action="inspect_top_failure_reasons",
+                operator_explanation="Failed campaigns are visible in the current digest window and may be reducing meaningful research throughput.",
+                evidence_refs=[_rel(repo_root / DIGEST_PATH, root=repo_root)],
+            )
+        )
+    if duplicate_low_value > 0:
+        rows.append(
+            _bottleneck(
+                code="duplicate_low_value_run_pressure",
+                severity="medium",
+                reason_codes=["duplicate_low_value_runs_visible"],
+                exact_next_action="increase_duplicate_avoidance_review",
+                operator_explanation="Duplicate low-value runs are consuming throughput without adding meaningful evidence breadth.",
+                evidence_refs=[_rel(repo_root / DIGEST_PATH, root=repo_root)],
+            )
+        )
+    return sorted(rows, key=lambda row: (row["severity"], row["bottleneck_code"]))
+
+
+def _next_action(bottlenecks: list[dict[str, Any]]) -> str:
+    if not bottlenecks:
+        return "preserve_campaign_throughput_context"
+    severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    highest = min(
+        bottlenecks,
+        key=lambda row: (severity_order.get(_text(row.get("severity")), 99), _text(row.get("bottleneck_code"))),
+    )
+    return _text(highest.get("exact_next_action")) or "operator_review_campaign_throughput_context"
+
+
+def build_campaign_throughput_bottleneck_intelligence(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    registry_payload = _read_json(repo_root / REGISTRY_PATH)
+    queue_payload = _read_json(repo_root / QUEUE_PATH)
+    digest_payload = _read_json(repo_root / DIGEST_PATH)
+    throughput_status = cache_throughput.read_throughput_status(repo_root=repo_root)
+    controls = operational_controls.build_trusted_loop_operational_controls(repo_root=repo_root)
+
+    registry_rows = _registry_rows(registry_payload)
+    queue_rows = _queue_rows(queue_payload)
+    active_registry_ids = _active_registry_ids(registry_rows)
+    active_queue_ids = _active_queue_ids(queue_rows)
+    state_counts = Counter(_text(row.get("state")) or "unknown" for row in registry_rows)
+    outcome_counts = Counter(_text(row.get("outcome")) or "none" for row in registry_rows)
+    digest_meaningful = (
+        (digest_payload or {}).get("meaningful_by_classification")
+        if isinstance((digest_payload or {}).get("meaningful_by_classification"), Mapping)
+        else {}
+    )
+    bottlenecks = _build_bottlenecks(
+        repo_root=repo_root,
+        registry_payload=registry_payload,
+        queue_payload=queue_payload,
+        digest_payload=digest_payload,
+        throughput_status=throughput_status,
+        controls=controls,
+        registry_rows=registry_rows,
+        queue_rows=queue_rows,
+    )
+    exact_next_action = _next_action(bottlenecks)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "campaign_throughput_bottleneck_intelligence_ready": bool(
+                registry_payload is not None and queue_payload is not None and digest_payload is not None
+            ),
+            "registry_campaign_count": len(registry_rows),
+            "active_registry_campaign_count": len(active_registry_ids),
+            "active_queue_campaign_count": len(active_queue_ids),
+            "queue_registry_divergence_count": abs(len(active_registry_ids) - len(active_queue_ids))
+            + len(set(active_registry_ids) ^ set(active_queue_ids)),
+            "queue_depth": int((digest_payload or {}).get("queue_depth") or len(active_queue_ids)),
+            "campaigns_completed_today": int((digest_payload or {}).get("campaigns_completed") or 0),
+            "campaigns_failed_today": int((digest_payload or {}).get("campaigns_failed") or 0),
+            "meaningful_campaigns_total": int((digest_payload or {}).get("meaningful_campaigns_total") or 0),
+            "duplicate_low_value_run_count": int(digest_meaningful.get("duplicate_low_value_run") or 0),
+            "cache_throughput_ready": bool(throughput_status.get("research_ready")),
+            "trusted_loop_artifact_freshness_status": _text(
+                ((controls.get("summary") or {}).get("artifact_freshness_status"))
+            )
+            or "unknown",
+            "bottleneck_count": len(bottlenecks),
+            "exact_next_action": exact_next_action,
+            "operator_summary": (
+                "Campaign throughput bottleneck intelligence normalizes registry, queue, digest, cache-throughput, "
+                "and trusted-loop signals into read-only operator context. It never mutates campaign state or lowers evidence standards."
+            ),
+        },
+        "throughput_context": {
+            "registry_state_counts": dict(sorted(state_counts.items())),
+            "registry_outcome_counts": dict(sorted(outcome_counts.items())),
+            "active_registry_campaign_ids": active_registry_ids,
+            "active_queue_campaign_ids": active_queue_ids,
+            "meaningful_by_classification": dict(sorted(digest_meaningful.items())),
+            "queue_efficiency_pct": (digest_payload or {}).get("queue_efficiency_pct"),
+            "worker_utilization_pct": (digest_payload or {}).get("worker_utilization_pct"),
+            "top_failure_reasons": list((digest_payload or {}).get("top_failure_reasons") or []),
+        },
+        "bottlenecks": bottlenecks,
+        "upstream_status": {
+            "campaign_registry_path": _rel(repo_root / REGISTRY_PATH, root=repo_root),
+            "campaign_queue_path": _rel(repo_root / QUEUE_PATH, root=repo_root),
+            "campaign_digest_path": _rel(repo_root / DIGEST_PATH, root=repo_root),
+            "cache_throughput_status": dict(throughput_status),
+            "trusted_loop_operational_summary": dict((controls.get("summary") or {})),
+        },
+        "authority_boundary": {
+            "read_only": True,
+            "context_only": True,
+            "can_mutate_campaign_queue": False,
+            "can_spawn_campaigns": False,
+            "can_promote_candidates": False,
+            "can_activate_shadow_or_live": False,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "uses_local_artifacts_only": True,
+            "uses_network": False,
+            "mutates_campaigns": False,
+            "mutates_queue": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "throughput_cannot_lower_evidence_standards": True,
+        },
+    }
+    report["deterministic_hash"] = _digest(report)
+    return report
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE Campaign Throughput Bottleneck Intelligence",
+            "",
+            f"- campaign_throughput_bottleneck_intelligence_ready: {summary.get('campaign_throughput_bottleneck_intelligence_ready')}",
+            f"- registry_campaign_count: {summary.get('registry_campaign_count')}",
+            f"- active_registry_campaign_count: {summary.get('active_registry_campaign_count')}",
+            f"- active_queue_campaign_count: {summary.get('active_queue_campaign_count')}",
+            f"- queue_registry_divergence_count: {summary.get('queue_registry_divergence_count')}",
+            f"- queue_depth: {summary.get('queue_depth')}",
+            f"- campaigns_completed_today: {summary.get('campaigns_completed_today')}",
+            f"- campaigns_failed_today: {summary.get('campaigns_failed_today')}",
+            f"- meaningful_campaigns_total: {summary.get('meaningful_campaigns_total')}",
+            f"- duplicate_low_value_run_count: {summary.get('duplicate_low_value_run_count')}",
+            f"- cache_throughput_ready: {summary.get('cache_throughput_ready')}",
+            f"- trusted_loop_artifact_freshness_status: {summary.get('trusted_loop_artifact_freshness_status')}",
+            f"- bottleneck_count: {summary.get('bottleneck_count')}",
+            f"- exact_next_action: {summary.get('exact_next_action')}",
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary)
+    return {
+        "latest": _rel(latest, root=repo_root),
+        "operator_summary": _rel(summary, root=repo_root),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_campaign_throughput_bottleneck_intelligence",
+        description="Build read-only campaign throughput bottleneck intelligence.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_campaign_throughput_bottleneck_intelligence()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_research_memory_current_artifacts.py
+++ b/research/qre_research_memory_current_artifacts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from packages.qre_research import research_memory
+from research import qre_campaign_throughput_bottleneck_intelligence as throughput_bottlenecks
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
 from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_memory_coverage as memory_coverage
@@ -62,6 +63,15 @@ def build_research_memory_current_artifacts(
         contradiction_report.get("summary") if isinstance(contradiction_report.get("summary"), Mapping) else {}
     )
     contradiction_ready = bool(contradiction_summary.get("contradiction_staleness_ready"))
+    throughput_report = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(
+        repo_root=repo_root
+    )
+    throughput_summary = (
+        throughput_report.get("summary") if isinstance(throughput_report.get("summary"), Mapping) else {}
+    )
+    throughput_ready = bool(
+        throughput_summary.get("campaign_throughput_bottleneck_intelligence_ready")
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -73,6 +83,7 @@ def build_research_memory_current_artifacts(
             "retrieval_ready": retrieval_ready,
             "artifact_continuity_ready": continuity_ready,
             "contradiction_staleness_ready": contradiction_ready,
+            "campaign_throughput_bottleneck_intelligence_ready": throughput_ready,
             "indexed_entry_count": int(memory_summary.get("indexed_entry_count") or 0),
             "indexed_candidate_count": int(memory_summary.get("indexed_candidate_count") or 0),
             "retrievable_failure_subject_count": int(
@@ -85,9 +96,17 @@ def build_research_memory_current_artifacts(
             "visible_stale_or_superseded_count": int(
                 contradiction_summary.get("stale_or_superseded_count") or 0
             ),
+            "visible_campaign_throughput_bottleneck_count": int(
+                throughput_summary.get("bottleneck_count") or 0
+            ),
             "final_recommendation": (
                 "research_memory_current_artifacts_ready"
-                if package_ready and coverage_ready and retrieval_ready and continuity_ready and contradiction_ready
+                if package_ready
+                and coverage_ready
+                and retrieval_ready
+                and continuity_ready
+                and contradiction_ready
+                and throughput_ready
                 else "research_memory_current_artifacts_partial"
             ),
             "operator_summary": (
@@ -100,12 +119,14 @@ def build_research_memory_current_artifacts(
         "failure_retrieval_summary": dict(retrieval_summary),
         "artifact_continuity_summary": dict(continuity_summary),
         "contradiction_staleness_summary": dict(contradiction_summary),
+        "campaign_throughput_bottleneck_summary": dict(throughput_summary),
         "memory_artifacts": {
             "package_memory_path": str(package_status.get("path") or "logs/qre_research_memory/latest.json"),
             "coverage_path": "logs/qre_research_memory_coverage/latest.json",
             "failure_retrieval_path": "logs/qre_failure_retrieval/latest.json",
             "artifact_continuity_path": "logs/qre_read_only_artifact_continuity/latest.json",
             "contradiction_staleness_path": "logs/qre_contradiction_staleness_intelligence/latest.json",
+            "campaign_throughput_bottleneck_path": "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json",
         },
         "safety_invariants": {
             "read_only": True,
@@ -138,11 +159,13 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["retrieval_ready", str(summary.get("retrieval_ready") or False)],
                     ["artifact_continuity_ready", str(summary.get("artifact_continuity_ready") or False)],
                     ["contradiction_staleness_ready", str(summary.get("contradiction_staleness_ready") or False)],
+                    ["campaign_throughput_bottleneck_intelligence_ready", str(summary.get("campaign_throughput_bottleneck_intelligence_ready") or False)],
                     ["indexed_entry_count", str(summary.get("indexed_entry_count") or 0)],
                     ["retrievable_failure_subject_count", str(summary.get("retrievable_failure_subject_count") or 0)],
                     ["artifact_continuity_materializable_target_count", str(summary.get("artifact_continuity_materializable_target_count") or 0)],
                     ["visible_contradiction_count", str(summary.get("visible_contradiction_count") or 0)],
                     ["visible_stale_or_superseded_count", str(summary.get("visible_stale_or_superseded_count") or 0)],
+                    ["visible_campaign_throughput_bottleneck_count", str(summary.get("visible_campaign_throughput_bottleneck_count") or 0)],
                     ["final_recommendation", str(summary.get("final_recommendation") or "")],
                 ],
             ),
@@ -156,6 +179,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["failure_retrieval_path", str(artifacts.get("failure_retrieval_path") or "")],
                     ["artifact_continuity_path", str(artifacts.get("artifact_continuity_path") or "")],
                     ["contradiction_staleness_path", str(artifacts.get("contradiction_staleness_path") or "")],
+                    ["campaign_throughput_bottleneck_path", str(artifacts.get("campaign_throughput_bottleneck_path") or "")],
                 ],
             ),
             "",
@@ -186,6 +210,8 @@ def write_outputs(
     continuity_paths = artifact_continuity.write_outputs(continuity_report, repo_root=repo_root)
     contradiction_report = contradiction_staleness.build_contradiction_staleness_intelligence(repo_root=repo_root)
     contradiction_paths = contradiction_staleness.write_outputs(contradiction_report, repo_root=repo_root)
+    throughput_report = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(repo_root=repo_root)
+    throughput_paths = throughput_bottlenecks.write_outputs(throughput_report, repo_root=repo_root)
 
     base = repo_root / DEFAULT_OUTPUT_DIR
     base.mkdir(parents=True, exist_ok=True)
@@ -205,6 +231,8 @@ def write_outputs(
         "artifact_continuity_operator_summary": continuity_paths["operator_summary"],
         "contradiction_staleness_latest": contradiction_paths["latest"],
         "contradiction_staleness_operator_summary": contradiction_paths["operator_summary"],
+        "campaign_throughput_bottleneck_latest": throughput_paths["latest"],
+        "campaign_throughput_bottleneck_operator_summary": throughput_paths["operator_summary"],
         "latest": latest.relative_to(repo_root).as_posix(),
         "operator_summary": summary_path.relative_to(repo_root).as_posix(),
     }

--- a/research/qre_research_memory_retrieval.py
+++ b/research/qre_research_memory_retrieval.py
@@ -31,6 +31,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_source_identity_authority_normalization/latest.json"),
     Path("logs/qre_read_only_artifact_continuity/latest.json"),
     Path("logs/qre_contradiction_staleness_intelligence/latest.json"),
+    Path("logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"),
     Path("logs/qre_preregistered_multiwindow_evidence_run/latest.json"),
     Path("logs/qre_multiwindow_evidence_closure/latest.json"),
 )

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -23,6 +23,7 @@ from research import qre_failure_action_from_basket as failure_action
 from research import qre_first_batch_evidence_recovery_cascade as first_batch_cascade
 from research import qre_first_batch_evidence_recovery_readiness as first_batch_readiness
 from research import qre_basket_operator_action_plan as basket_action_plan
+from research import qre_campaign_throughput_bottleneck_intelligence as throughput_bottlenecks
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
 from research import qre_reason_records_v1 as reason_records
 from research import qre_read_only_artifact_continuity as artifact_continuity
@@ -274,6 +275,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     contradiction_packet = contradiction_staleness.build_contradiction_staleness_intelligence(
         repo_root=repo_root
     )
+    throughput_packet = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(
+        repo_root=repo_root
+    )
     action_plan_packet = basket_action_plan.build_basket_operator_action_plan(repo_root=repo_root)
     operational_controls_packet = operational_controls.build_trusted_loop_operational_controls(
         repo_root=repo_root
@@ -309,6 +313,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     )
     contradiction_summary = (
         contradiction_packet.get("summary") if isinstance(contradiction_packet.get("summary"), Mapping) else {}
+    )
+    throughput_summary = (
+        throughput_packet.get("summary") if isinstance(throughput_packet.get("summary"), Mapping) else {}
     )
     action_plan_summary = action_plan_packet.get("summary") if isinstance(action_plan_packet.get("summary"), Mapping) else {}
     structured_lineage_summary = (
@@ -364,6 +371,15 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             ),
             "contradiction_staleness_exact_next_action": str(
                 contradiction_summary.get("exact_next_action") or ""
+            ),
+            "campaign_throughput_bottleneck_intelligence_ready": bool(
+                throughput_summary.get("campaign_throughput_bottleneck_intelligence_ready")
+            ),
+            "visible_campaign_throughput_bottleneck_count": int(
+                throughput_summary.get("bottleneck_count") or 0
+            ),
+            "campaign_throughput_exact_next_action": str(
+                throughput_summary.get("exact_next_action") or ""
             ),
             "basket_operator_action_plan_ready": str(action_plan_summary.get("final_recommendation") or "")
             == "basket_operator_action_plan_ready",
@@ -452,6 +468,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "research_memory": memory_packet,
             "artifact_continuity": continuity_packet,
             "contradiction_staleness": contradiction_packet,
+            "campaign_throughput_bottlenecks": throughput_packet,
             "operational_controls": operational_controls_packet,
             "shadow_readiness_gates": shadow_readiness_packet,
         },
@@ -549,6 +566,9 @@ def render_operator_summary(packet: Mapping[str, Any]) -> str:
             f"- visible_contradiction_count: {summary.get('visible_contradiction_count')}",
             f"- visible_stale_or_superseded_count: {summary.get('visible_stale_or_superseded_count')}",
             f"- contradiction_staleness_exact_next_action: {summary.get('contradiction_staleness_exact_next_action')}",
+            f"- campaign_throughput_bottleneck_intelligence_ready: {summary.get('campaign_throughput_bottleneck_intelligence_ready')}",
+            f"- visible_campaign_throughput_bottleneck_count: {summary.get('visible_campaign_throughput_bottleneck_count')}",
+            f"- campaign_throughput_exact_next_action: {summary.get('campaign_throughput_exact_next_action')}",
             f"- guarded_alias_bounded_generation_cascade_result: {summary.get('guarded_alias_bounded_generation_cascade_result')}",
             f"- guarded_alias_bounded_generation_top_blocker: {summary.get('guarded_alias_bounded_generation_top_blocker')}",
             f"- structured_lineage_artifact_status: {summary.get('structured_lineage_artifact_status')}",

--- a/tests/unit/test_qre_campaign_throughput_bottleneck_intelligence.py
+++ b/tests/unit/test_qre_campaign_throughput_bottleneck_intelligence.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_campaign_throughput_bottleneck_intelligence as throughput_intel
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_campaign_throughput_bottleneck_intelligence_surfaces_divergence_and_pressure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "campaigns": {
+                "cmp-1": {
+                    "campaign_id": "cmp-1",
+                    "state": "running",
+                    "outcome": None,
+                },
+                "cmp-2": {
+                    "campaign_id": "cmp-2",
+                    "state": "failed",
+                    "outcome": "technical_failure",
+                },
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_queue_latest.v1.json",
+        {"queue": [{"campaign_id": "cmp-3", "state": "pending"}]},
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_digest_latest.v1.json",
+        {
+            "queue_depth": 1,
+            "campaigns_completed": 0,
+            "campaigns_failed": 1,
+            "meaningful_campaigns_total": 0,
+            "meaningful_by_classification": {"duplicate_low_value_run": 2},
+            "top_failure_reasons": [{"reason_code": "technical_failure", "count": 1}],
+        },
+    )
+    monkeypatch.setattr(
+        throughput_intel.cache_throughput,
+        "read_throughput_status",
+        lambda **_: {
+            "status": "not_ready",
+            "research_ready": False,
+            "path": "logs/qre_cache_throughput_manifest/latest.json",
+            "fails_closed": True,
+        },
+    )
+    monkeypatch.setattr(
+        throughput_intel.operational_controls,
+        "build_trusted_loop_operational_controls",
+        lambda **_: {
+            "summary": {
+                "artifact_freshness_status": "stale_or_missing",
+                "exact_next_safe_action": "reconcile_stale_or_mismatched_run_artifacts",
+            }
+        },
+    )
+
+    report = throughput_intel.build_campaign_throughput_bottleneck_intelligence(
+        repo_root=tmp_path
+    )
+
+    assert report["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
+    assert report["summary"]["queue_registry_divergence_count"] == 2
+    assert report["summary"]["duplicate_low_value_run_count"] == 2
+    assert report["summary"]["cache_throughput_ready"] is False
+    assert report["summary"]["exact_next_action"] == "reconcile_campaign_queue_from_registry"
+    codes = [row["bottleneck_code"] for row in report["bottlenecks"]]
+    assert "queue_registry_divergence" in codes
+    assert "cache_throughput_not_ready" in codes
+    assert "stale_run_artifact_pressure" in codes
+    assert "duplicate_low_value_run_pressure" in codes
+
+
+def test_write_outputs_stays_inside_allowlist(tmp_path: Path, monkeypatch) -> None:
+    _write_json(tmp_path / "research" / "campaign_registry_latest.v1.json", {"campaigns": {}})
+    _write_json(tmp_path / "research" / "campaign_queue_latest.v1.json", {"queue": []})
+    _write_json(
+        tmp_path / "research" / "campaign_digest_latest.v1.json",
+        {
+            "queue_depth": 0,
+            "campaigns_completed": 1,
+            "campaigns_failed": 0,
+            "meaningful_campaigns_total": 1,
+            "meaningful_by_classification": {},
+        },
+    )
+    monkeypatch.setattr(
+        throughput_intel.cache_throughput,
+        "read_throughput_status",
+        lambda **_: {
+            "status": "ready",
+            "research_ready": True,
+            "path": "logs/qre_cache_throughput_manifest/latest.json",
+            "fails_closed": False,
+        },
+    )
+    monkeypatch.setattr(
+        throughput_intel.operational_controls,
+        "build_trusted_loop_operational_controls",
+        lambda **_: {
+            "summary": {
+                "artifact_freshness_status": "fresh",
+                "exact_next_safe_action": "preserve_terminal_run_and_compare_before_rerun",
+            }
+        },
+    )
+
+    report = throughput_intel.build_campaign_throughput_bottleneck_intelligence(
+        repo_root=tmp_path
+    )
+    paths = throughput_intel.write_outputs(report, repo_root=tmp_path)
+
+    assert paths == {
+        "latest": "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json",
+        "operator_summary": "logs/qre_campaign_throughput_bottleneck_intelligence/operator_summary.md",
+    }
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -59,6 +59,16 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
             }
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.throughput_bottlenecks,
+        "build_campaign_throughput_bottleneck_intelligence",
+        lambda **_: {
+            "summary": {
+                "campaign_throughput_bottleneck_intelligence_ready": True,
+                "bottleneck_count": 0,
+            }
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts()
 
@@ -67,6 +77,7 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
     assert report["summary"]["retrieval_ready"] is True
     assert report["summary"]["artifact_continuity_ready"] is True
     assert report["summary"]["contradiction_staleness_ready"] is True
+    assert report["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
     assert report["summary"]["final_recommendation"] == "research_memory_current_artifacts_ready"
 
 
@@ -143,11 +154,29 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
         },
     )
     monkeypatch.setattr(
+        current_artifacts.throughput_bottlenecks,
+        "build_campaign_throughput_bottleneck_intelligence",
+        lambda **_: {
+            "summary": {
+                "campaign_throughput_bottleneck_intelligence_ready": False,
+                "bottleneck_count": 3,
+            }
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.contradiction_staleness,
         "write_outputs",
         lambda report, repo_root: {
             "latest": "logs/qre_contradiction_staleness_intelligence/latest.json",
             "operator_summary": "logs/qre_contradiction_staleness_intelligence/operator_summary.md",
+        },
+    )
+    monkeypatch.setattr(
+        current_artifacts.throughput_bottlenecks,
+        "write_outputs",
+        lambda report, repo_root: {
+            "latest": "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json",
+            "operator_summary": "logs/qre_campaign_throughput_bottleneck_intelligence/operator_summary.md",
         },
     )
 
@@ -158,6 +187,7 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
     assert paths["latest"] == "logs/qre_research_memory_current_artifacts/latest.json"
     assert paths["artifact_continuity_latest"] == "logs/qre_read_only_artifact_continuity/latest.json"
     assert paths["contradiction_staleness_latest"] == "logs/qre_contradiction_staleness_intelligence/latest.json"
+    assert paths["campaign_throughput_bottleneck_latest"] == "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"
     assert "# QRE Research Memory Current Artifacts" in markdown
 
 def test_memory_coverage_entries_include_resolved_entities():

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -122,6 +122,17 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         },
     )
     monkeypatch.setattr(
+        packet_module.throughput_bottlenecks,
+        "build_campaign_throughput_bottleneck_intelligence",
+        lambda **_: {
+            "summary": {
+                "campaign_throughput_bottleneck_intelligence_ready": True,
+                "bottleneck_count": 0,
+                "exact_next_action": "preserve_campaign_throughput_context",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -185,6 +196,8 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["contradiction_staleness_ready"] is True
     assert packet["summary"]["visible_contradiction_count"] == 0
     assert packet["summary"]["visible_stale_or_superseded_count"] == 0
+    assert packet["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
+    assert packet["summary"]["visible_campaign_throughput_bottleneck_count"] == 0
     assert packet["summary"]["trusted_loop_operational_controls_ready"] is True
     assert packet["summary"]["trusted_loop_operational_exact_next_action"] == "preserve_terminal_run_and_compare_before_rerun"
     assert packet["summary"]["shadow_readiness_status"] == "shadow_readiness_deferred"
@@ -253,6 +266,17 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
                 "contradiction_count": 2,
                 "stale_or_superseded_count": 1,
                 "exact_next_action": "reconcile_stale_or_superseded_artifacts",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.throughput_bottlenecks,
+        "build_campaign_throughput_bottleneck_intelligence",
+        lambda **_: {
+            "summary": {
+                "campaign_throughput_bottleneck_intelligence_ready": False,
+                "bottleneck_count": 2,
+                "exact_next_action": "reconcile_campaign_queue_from_registry",
             }
         },
     )
@@ -363,6 +387,17 @@ def test_trusted_loop_review_packet_operator_summary_renders(
         },
     )
     monkeypatch.setattr(
+        packet_module.throughput_bottlenecks,
+        "build_campaign_throughput_bottleneck_intelligence",
+        lambda **_: {
+            "summary": {
+                "campaign_throughput_bottleneck_intelligence_ready": True,
+                "bottleneck_count": 0,
+                "exact_next_action": "preserve_campaign_throughput_context",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -451,6 +486,17 @@ def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(
                 "contradiction_count": 0,
                 "stale_or_superseded_count": 0,
                 "exact_next_action": "preserve_contradiction_and_staleness_visibility",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.throughput_bottlenecks,
+        "build_campaign_throughput_bottleneck_intelligence",
+        lambda **_: {
+            "summary": {
+                "campaign_throughput_bottleneck_intelligence_ready": True,
+                "bottleneck_count": 0,
+                "exact_next_action": "preserve_campaign_throughput_context",
             }
         },
     )


### PR DESCRIPTION
## Summary
- add a deterministic read-only campaign throughput and bottleneck intelligence surface over registry, queue, digest, cache-throughput, and trusted-loop artifacts
- integrate the new throughput context into research-memory current artifacts and the trusted-loop review packet
- index the new artifact in research memory and cover the new surface plus integrations with unit tests

## Testing
- python -m pytest tests/unit/test_qre_campaign_throughput_bottleneck_intelligence.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_trusted_loop_review_packet.py tests/unit/test_qre_research_memory_retrieval.py tests/unit/test_qre_cache_throughput_manifest.py tests/unit/test_qre_trusted_loop_operational_controls.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check