### PR TITLE
feat: add experiment dedup and novelty enforcement

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -41,6 +41,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_source_identity_authority_normalization/latest.json"),
     Path("logs/qre_read_only_artifact_continuity/latest.json"),
     Path("logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"),
+    Path("logs/qre_experiment_dedup_novelty_enforcement/latest.json"),
     Path("logs/qre_trusted_loop_operational_controls/latest.json"),
     Path("logs/qre_shadow_readiness_gates/latest.json"),
 )

--- a/research/qre_experiment_dedup_novelty_enforcement.py
+++ b/research/qre_experiment_dedup_novelty_enforcement.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_experiment_dedup_novelty_enforcement"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_experiment_dedup_novelty_enforcement")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_experiment_dedup_novelty_enforcement/"
+
+ROUTER_PATH: Final[Path] = Path("logs/qre_research_cycle_router/latest.json")
+DISPOSITION_PATH: Final[Path] = Path("logs/qre_hypothesis_disposition_memory/latest.json")
+REGISTRY_PATH: Final[Path] = Path("research/campaign_registry_latest.v1.json")
+THROUGHPUT_PATH: Final[Path] = Path("logs/qre_campaign_throughput_bottleneck_intelligence/latest.json")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _rel(path: Path, *, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _campaign_rows(payload: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    campaigns = payload.get("campaigns") if isinstance(payload, Mapping) else None
+    if not isinstance(campaigns, Mapping):
+        return []
+    rows = [dict(row) for row in campaigns.values() if isinstance(row, Mapping)]
+    rows.sort(key=lambda row: (_text(row.get("campaign_id")), _text(row.get("preset_name"))))
+    return rows
+
+
+def _fingerprint(row: Mapping[str, Any]) -> str:
+    parts = {
+        "campaign_type": _text(row.get("campaign_type")),
+        "preset_name": _text(row.get("preset_name")),
+        "parent_campaign_id": _text(row.get("parent_campaign_id")),
+        "lineage_root_campaign_id": _text(row.get("lineage_root_campaign_id")),
+        "input_artifact_fingerprint": _text(row.get("input_artifact_fingerprint")),
+    }
+    return _digest(parts)
+
+
+def _scope_key(row: Mapping[str, Any]) -> str:
+    return "|".join(
+        [
+            _text(row.get("hypothesis_id")),
+            _text(row.get("strategy_family")),
+            _text(row.get("preset_name")),
+            _text(row.get("asset_class")),
+        ]
+    )
+
+
+def _build_duplicate_rows(
+    *,
+    campaigns: list[dict[str, Any]],
+    suppressed_scopes: list[dict[str, Any]],
+    throughput: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    active_rows = [
+        row for row in campaigns if _text(row.get("state")) in {"pending", "leased", "running"}
+    ]
+    by_fingerprint: dict[str, list[dict[str, Any]]] = {}
+    by_scope: dict[str, list[dict[str, Any]]] = {}
+    for row in active_rows:
+        by_fingerprint.setdefault(_fingerprint(row), []).append(row)
+        by_scope.setdefault(_scope_key(row), []).append(row)
+
+    for fingerprint, items in sorted(by_fingerprint.items()):
+        if len(items) <= 1:
+            continue
+        rows.append(
+            {
+                "duplicate_class": "active_duplicate_fingerprint",
+                "duplicate_key": fingerprint,
+                "status": "blocked_duplicate",
+                "campaign_ids": [_text(item.get("campaign_id")) for item in items],
+                "exact_next_action": "deduplicate_active_campaign_scope",
+                "evidence_refs": ["research/campaign_registry_latest.v1.json"],
+            }
+        )
+
+    for scope_key, items in sorted(by_scope.items()):
+        if len(items) <= 1 or not scope_key.strip("|"):
+            continue
+        rows.append(
+            {
+                "duplicate_class": "active_scope_conflict",
+                "duplicate_key": scope_key,
+                "status": "blocked_scope_conflict",
+                "campaign_ids": [_text(item.get("campaign_id")) for item in items],
+                "exact_next_action": "review_scope_collision_before_new_research",
+                "evidence_refs": ["research/campaign_registry_latest.v1.json"],
+            }
+        )
+
+    for scope in suppressed_scopes:
+        if not isinstance(scope, Mapping):
+            continue
+        rows.append(
+            {
+                "duplicate_class": _text(scope.get("scope_kind")) or "suppressed_scope",
+                "duplicate_key": _digest(scope),
+                "status": "suppressed",
+                "campaign_ids": [],
+                "exact_next_action": "preserve_suppressed_scope_boundary",
+                "evidence_refs": ["logs/qre_research_cycle_router/latest.json", "logs/qre_hypothesis_disposition_memory/latest.json"],
+            }
+        )
+
+    throughput_rows = throughput.get("bottlenecks") if isinstance(throughput, Mapping) and isinstance(throughput.get("bottlenecks"), list) else []
+    for row in throughput_rows:
+        if not isinstance(row, Mapping):
+            continue
+        if _text(row.get("bottleneck_code")) != "duplicate_low_value_run_pressure":
+            continue
+        rows.append(
+            {
+                "duplicate_class": "duplicate_low_value_run_pressure",
+                "duplicate_key": "duplicate_low_value_run_pressure",
+                "status": "context_only_duplicate_pressure",
+                "campaign_ids": [],
+                "exact_next_action": _text(row.get("exact_next_action")) or "increase_duplicate_avoidance_review",
+                "evidence_refs": list(row.get("evidence_refs") or []),
+            }
+        )
+    rows.sort(key=lambda row: (_text(row.get("duplicate_class")), _text(row.get("duplicate_key"))))
+    return rows
+
+
+def _build_novelty_rows(router: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    eligible = router.get("eligible_directions") if isinstance(router, Mapping) and isinstance(router.get("eligible_directions"), list) else []
+    rows: list[dict[str, Any]] = []
+    for row in eligible:
+        if not isinstance(row, Mapping):
+            continue
+        rows.append(
+            {
+                "direction_id": _text(row.get("direction_id")),
+                "direction_type": _text(row.get("direction_type")),
+                "status": "eligible_novel_direction",
+                "route_status": _text(row.get("route_status")),
+                "eligibility_reasons": list(row.get("eligibility_reasons") or []),
+            }
+        )
+    rows.sort(key=lambda row: row["direction_id"])
+    return rows
+
+
+def _next_action(duplicate_rows: list[dict[str, Any]], novelty_rows: list[dict[str, Any]]) -> str:
+    if any(_text(row.get("status")) == "blocked_duplicate" for row in duplicate_rows):
+        return "deduplicate_active_campaign_scope"
+    if any(_text(row.get("status")) == "suppressed" for row in duplicate_rows):
+        return "preserve_suppressed_scope_boundary"
+    if novelty_rows:
+        return "route_only_to_eligible_novel_directions"
+    return "operator_review_required_before_new_scope"
+
+
+def build_experiment_dedup_novelty_enforcement(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    router = _read_json(repo_root / ROUTER_PATH)
+    disposition = _read_json(repo_root / DISPOSITION_PATH)
+    registry = _read_json(repo_root / REGISTRY_PATH)
+    throughput = _read_json(repo_root / THROUGHPUT_PATH)
+
+    campaigns = _campaign_rows(registry)
+    suppressed_scopes = router.get("suppressed_scopes") if isinstance(router, Mapping) and isinstance(router.get("suppressed_scopes"), list) else []
+    duplicate_rows = _build_duplicate_rows(
+        campaigns=campaigns,
+        suppressed_scopes=suppressed_scopes,
+        throughput=throughput,
+    )
+    novelty_rows = _build_novelty_rows(router)
+    duplicate_counts = Counter(_text(row.get("duplicate_class")) or "unknown" for row in duplicate_rows)
+    exact_next_action = _next_action(duplicate_rows, novelty_rows)
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "experiment_dedup_novelty_enforcement_ready": bool(
+                router is not None and disposition is not None and registry is not None
+            ),
+            "suppressed_scope_count": sum(1 for row in duplicate_rows if _text(row.get("status")) == "suppressed"),
+            "active_duplicate_fingerprint_count": sum(
+                1 for row in duplicate_rows if _text(row.get("duplicate_class")) == "active_duplicate_fingerprint"
+            ),
+            "active_scope_conflict_count": sum(
+                1 for row in duplicate_rows if _text(row.get("duplicate_class")) == "active_scope_conflict"
+            ),
+            "duplicate_pressure_count": len(duplicate_rows),
+            "eligible_novel_direction_count": len(novelty_rows),
+            "exact_next_action": exact_next_action,
+            "operator_summary": (
+                "Experiment dedup and novelty enforcement consolidates exact suppression, active duplicate pressure, "
+                "and eligible novel directions into one read-only contract. It never mutates campaigns or consumes queue authority."
+            ),
+        },
+        "duplicate_rows": duplicate_rows,
+        "novelty_rows": novelty_rows,
+        "upstream_status": {
+            "router_path": _rel(repo_root / ROUTER_PATH, root=repo_root),
+            "disposition_path": _rel(repo_root / DISPOSITION_PATH, root=repo_root),
+            "registry_path": _rel(repo_root / REGISTRY_PATH, root=repo_root),
+            "throughput_path": _rel(repo_root / THROUGHPUT_PATH, root=repo_root),
+            "duplicate_class_counts": dict(sorted(duplicate_counts.items())),
+        },
+        "authority_boundary": {
+            "read_only": True,
+            "context_only": True,
+            "can_spawn_campaigns": False,
+            "can_mutate_queue": False,
+            "can_register_strategy": False,
+            "can_promote_candidate": False,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "uses_local_artifacts_only": True,
+            "uses_network": False,
+            "mutates_campaigns": False,
+            "mutates_queue": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+    report["deterministic_hash"] = _digest(report)
+    return report
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE Experiment Dedup and Novelty Enforcement",
+            "",
+            f"- experiment_dedup_novelty_enforcement_ready: {summary.get('experiment_dedup_novelty_enforcement_ready')}",
+            f"- suppressed_scope_count: {summary.get('suppressed_scope_count')}",
+            f"- active_duplicate_fingerprint_count: {summary.get('active_duplicate_fingerprint_count')}",
+            f"- active_scope_conflict_count: {summary.get('active_scope_conflict_count')}",
+            f"- duplicate_pressure_count: {summary.get('duplicate_pressure_count')}",
+            f"- eligible_novel_direction_count: {summary.get('eligible_novel_direction_count')}",
+            f"- exact_next_action: {summary.get('exact_next_action')}",
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary)
+    return {
+        "latest": _rel(latest, root=repo_root),
+        "operator_summary": _rel(summary, root=repo_root),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_experiment_dedup_novelty_enforcement",
+        description="Build read-only experiment dedup and novelty enforcement.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_experiment_dedup_novelty_enforcement()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_research_memory_current_artifacts.py
+++ b/research/qre_research_memory_current_artifacts.py
@@ -10,6 +10,7 @@ from typing import Any, Final
 from packages.qre_research import research_memory
 from research import qre_campaign_throughput_bottleneck_intelligence as throughput_bottlenecks
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
+from research import qre_experiment_dedup_novelty_enforcement as novelty_enforcement
 from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_memory_coverage as memory_coverage
 
@@ -72,6 +73,13 @@ def build_research_memory_current_artifacts(
     throughput_ready = bool(
         throughput_summary.get("campaign_throughput_bottleneck_intelligence_ready")
     )
+    novelty_report = novelty_enforcement.build_experiment_dedup_novelty_enforcement(
+        repo_root=repo_root
+    )
+    novelty_summary = (
+        novelty_report.get("summary") if isinstance(novelty_report.get("summary"), Mapping) else {}
+    )
+    novelty_ready = bool(novelty_summary.get("experiment_dedup_novelty_enforcement_ready"))
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -84,6 +92,7 @@ def build_research_memory_current_artifacts(
             "artifact_continuity_ready": continuity_ready,
             "contradiction_staleness_ready": contradiction_ready,
             "campaign_throughput_bottleneck_intelligence_ready": throughput_ready,
+            "experiment_dedup_novelty_enforcement_ready": novelty_ready,
             "indexed_entry_count": int(memory_summary.get("indexed_entry_count") or 0),
             "indexed_candidate_count": int(memory_summary.get("indexed_candidate_count") or 0),
             "retrievable_failure_subject_count": int(
@@ -99,6 +108,9 @@ def build_research_memory_current_artifacts(
             "visible_campaign_throughput_bottleneck_count": int(
                 throughput_summary.get("bottleneck_count") or 0
             ),
+            "visible_experiment_duplicate_pressure_count": int(
+                novelty_summary.get("duplicate_pressure_count") or 0
+            ),
             "final_recommendation": (
                 "research_memory_current_artifacts_ready"
                 if package_ready
@@ -107,6 +119,7 @@ def build_research_memory_current_artifacts(
                 and continuity_ready
                 and contradiction_ready
                 and throughput_ready
+                and novelty_ready
                 else "research_memory_current_artifacts_partial"
             ),
             "operator_summary": (
@@ -120,6 +133,7 @@ def build_research_memory_current_artifacts(
         "artifact_continuity_summary": dict(continuity_summary),
         "contradiction_staleness_summary": dict(contradiction_summary),
         "campaign_throughput_bottleneck_summary": dict(throughput_summary),
+        "experiment_dedup_novelty_summary": dict(novelty_summary),
         "memory_artifacts": {
             "package_memory_path": str(package_status.get("path") or "logs/qre_research_memory/latest.json"),
             "coverage_path": "logs/qre_research_memory_coverage/latest.json",
@@ -127,6 +141,7 @@ def build_research_memory_current_artifacts(
             "artifact_continuity_path": "logs/qre_read_only_artifact_continuity/latest.json",
             "contradiction_staleness_path": "logs/qre_contradiction_staleness_intelligence/latest.json",
             "campaign_throughput_bottleneck_path": "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json",
+            "experiment_dedup_novelty_path": "logs/qre_experiment_dedup_novelty_enforcement/latest.json",
         },
         "safety_invariants": {
             "read_only": True,
@@ -160,12 +175,14 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["artifact_continuity_ready", str(summary.get("artifact_continuity_ready") or False)],
                     ["contradiction_staleness_ready", str(summary.get("contradiction_staleness_ready") or False)],
                     ["campaign_throughput_bottleneck_intelligence_ready", str(summary.get("campaign_throughput_bottleneck_intelligence_ready") or False)],
+                    ["experiment_dedup_novelty_enforcement_ready", str(summary.get("experiment_dedup_novelty_enforcement_ready") or False)],
                     ["indexed_entry_count", str(summary.get("indexed_entry_count") or 0)],
                     ["retrievable_failure_subject_count", str(summary.get("retrievable_failure_subject_count") or 0)],
                     ["artifact_continuity_materializable_target_count", str(summary.get("artifact_continuity_materializable_target_count") or 0)],
                     ["visible_contradiction_count", str(summary.get("visible_contradiction_count") or 0)],
                     ["visible_stale_or_superseded_count", str(summary.get("visible_stale_or_superseded_count") or 0)],
                     ["visible_campaign_throughput_bottleneck_count", str(summary.get("visible_campaign_throughput_bottleneck_count") or 0)],
+                    ["visible_experiment_duplicate_pressure_count", str(summary.get("visible_experiment_duplicate_pressure_count") or 0)],
                     ["final_recommendation", str(summary.get("final_recommendation") or "")],
                 ],
             ),
@@ -180,6 +197,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["artifact_continuity_path", str(artifacts.get("artifact_continuity_path") or "")],
                     ["contradiction_staleness_path", str(artifacts.get("contradiction_staleness_path") or "")],
                     ["campaign_throughput_bottleneck_path", str(artifacts.get("campaign_throughput_bottleneck_path") or "")],
+                    ["experiment_dedup_novelty_path", str(artifacts.get("experiment_dedup_novelty_path") or "")],
                 ],
             ),
             "",
@@ -212,6 +230,8 @@ def write_outputs(
     contradiction_paths = contradiction_staleness.write_outputs(contradiction_report, repo_root=repo_root)
     throughput_report = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(repo_root=repo_root)
     throughput_paths = throughput_bottlenecks.write_outputs(throughput_report, repo_root=repo_root)
+    novelty_report = novelty_enforcement.build_experiment_dedup_novelty_enforcement(repo_root=repo_root)
+    novelty_paths = novelty_enforcement.write_outputs(novelty_report, repo_root=repo_root)
 
     base = repo_root / DEFAULT_OUTPUT_DIR
     base.mkdir(parents=True, exist_ok=True)
@@ -233,6 +253,8 @@ def write_outputs(
         "contradiction_staleness_operator_summary": contradiction_paths["operator_summary"],
         "campaign_throughput_bottleneck_latest": throughput_paths["latest"],
         "campaign_throughput_bottleneck_operator_summary": throughput_paths["operator_summary"],
+        "experiment_dedup_novelty_latest": novelty_paths["latest"],
+        "experiment_dedup_novelty_operator_summary": novelty_paths["operator_summary"],
         "latest": latest.relative_to(repo_root).as_posix(),
         "operator_summary": summary_path.relative_to(repo_root).as_posix(),
     }

--- a/research/qre_research_memory_retrieval.py
+++ b/research/qre_research_memory_retrieval.py
@@ -32,6 +32,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_read_only_artifact_continuity/latest.json"),
     Path("logs/qre_contradiction_staleness_intelligence/latest.json"),
     Path("logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"),
+    Path("logs/qre_experiment_dedup_novelty_enforcement/latest.json"),
     Path("logs/qre_preregistered_multiwindow_evidence_run/latest.json"),
     Path("logs/qre_multiwindow_evidence_closure/latest.json"),
 )

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -25,6 +25,7 @@ from research import qre_first_batch_evidence_recovery_readiness as first_batch_
 from research import qre_basket_operator_action_plan as basket_action_plan
 from research import qre_campaign_throughput_bottleneck_intelligence as throughput_bottlenecks
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
+from research import qre_experiment_dedup_novelty_enforcement as novelty_enforcement
 from research import qre_reason_records_v1 as reason_records
 from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_memory_current_artifacts as research_memory
@@ -278,6 +279,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     throughput_packet = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(
         repo_root=repo_root
     )
+    novelty_packet = novelty_enforcement.build_experiment_dedup_novelty_enforcement(
+        repo_root=repo_root
+    )
     action_plan_packet = basket_action_plan.build_basket_operator_action_plan(repo_root=repo_root)
     operational_controls_packet = operational_controls.build_trusted_loop_operational_controls(
         repo_root=repo_root
@@ -316,6 +320,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     )
     throughput_summary = (
         throughput_packet.get("summary") if isinstance(throughput_packet.get("summary"), Mapping) else {}
+    )
+    novelty_summary = (
+        novelty_packet.get("summary") if isinstance(novelty_packet.get("summary"), Mapping) else {}
     )
     action_plan_summary = action_plan_packet.get("summary") if isinstance(action_plan_packet.get("summary"), Mapping) else {}
     structured_lineage_summary = (
@@ -380,6 +387,15 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             ),
             "campaign_throughput_exact_next_action": str(
                 throughput_summary.get("exact_next_action") or ""
+            ),
+            "experiment_dedup_novelty_enforcement_ready": bool(
+                novelty_summary.get("experiment_dedup_novelty_enforcement_ready")
+            ),
+            "visible_experiment_duplicate_pressure_count": int(
+                novelty_summary.get("duplicate_pressure_count") or 0
+            ),
+            "experiment_novelty_exact_next_action": str(
+                novelty_summary.get("exact_next_action") or ""
             ),
             "basket_operator_action_plan_ready": str(action_plan_summary.get("final_recommendation") or "")
             == "basket_operator_action_plan_ready",
@@ -469,6 +485,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "artifact_continuity": continuity_packet,
             "contradiction_staleness": contradiction_packet,
             "campaign_throughput_bottlenecks": throughput_packet,
+            "experiment_dedup_novelty_enforcement": novelty_packet,
             "operational_controls": operational_controls_packet,
             "shadow_readiness_gates": shadow_readiness_packet,
         },
@@ -569,6 +586,9 @@ def render_operator_summary(packet: Mapping[str, Any]) -> str:
             f"- campaign_throughput_bottleneck_intelligence_ready: {summary.get('campaign_throughput_bottleneck_intelligence_ready')}",
             f"- visible_campaign_throughput_bottleneck_count: {summary.get('visible_campaign_throughput_bottleneck_count')}",
             f"- campaign_throughput_exact_next_action: {summary.get('campaign_throughput_exact_next_action')}",
+            f"- experiment_dedup_novelty_enforcement_ready: {summary.get('experiment_dedup_novelty_enforcement_ready')}",
+            f"- visible_experiment_duplicate_pressure_count: {summary.get('visible_experiment_duplicate_pressure_count')}",
+            f"- experiment_novelty_exact_next_action: {summary.get('experiment_novelty_exact_next_action')}",
             f"- guarded_alias_bounded_generation_cascade_result: {summary.get('guarded_alias_bounded_generation_cascade_result')}",
             f"- guarded_alias_bounded_generation_top_blocker: {summary.get('guarded_alias_bounded_generation_top_blocker')}",
             f"- structured_lineage_artifact_status: {summary.get('structured_lineage_artifact_status')}",

--- a/tests/unit/test_qre_experiment_dedup_novelty_enforcement.py
+++ b/tests/unit/test_qre_experiment_dedup_novelty_enforcement.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_experiment_dedup_novelty_enforcement as novelty
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_experiment_dedup_novelty_enforcement_surfaces_duplicates_and_novelty(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_research_cycle_router" / "latest.json",
+        {
+            "suppressed_scopes": [{"scope_kind": "exact_failed_scope", "suppression_reason": "same_failed_scope_suppressed"}],
+            "eligible_directions": [
+                {
+                    "direction_id": "behavior_rotation::momentum_continuation",
+                    "direction_type": "different_behavior_family",
+                    "route_status": "eligible_context_only",
+                    "eligibility_reasons": ["materially_new_behavior_direction"],
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_hypothesis_disposition_memory" / "latest.json",
+        {"record": {"memory_record_id": "mem-1"}},
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "campaigns": {
+                "cmp-1": {
+                    "campaign_id": "cmp-1",
+                    "campaign_type": "daily_primary",
+                    "preset_name": "trend_pullback_continuation_daily_v1",
+                    "parent_campaign_id": None,
+                    "lineage_root_campaign_id": "cmp-1",
+                    "input_artifact_fingerprint": "fp-1",
+                    "state": "running",
+                    "hypothesis_id": "hyp-1",
+                    "strategy_family": "trend_pullback",
+                    "asset_class": "equity",
+                },
+                "cmp-2": {
+                    "campaign_id": "cmp-2",
+                    "campaign_type": "daily_primary",
+                    "preset_name": "trend_pullback_continuation_daily_v1",
+                    "parent_campaign_id": None,
+                    "lineage_root_campaign_id": "cmp-1",
+                    "input_artifact_fingerprint": "fp-1",
+                    "state": "pending",
+                    "hypothesis_id": "hyp-1",
+                    "strategy_family": "trend_pullback",
+                    "asset_class": "equity",
+                },
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_campaign_throughput_bottleneck_intelligence" / "latest.json",
+        {
+            "bottlenecks": [
+                {
+                    "bottleneck_code": "duplicate_low_value_run_pressure",
+                    "exact_next_action": "increase_duplicate_avoidance_review",
+                    "evidence_refs": ["research/campaign_digest_latest.v1.json"],
+                }
+            ]
+        },
+    )
+
+    report = novelty.build_experiment_dedup_novelty_enforcement(repo_root=tmp_path)
+
+    assert report["summary"]["experiment_dedup_novelty_enforcement_ready"] is True
+    assert report["summary"]["suppressed_scope_count"] == 1
+    assert report["summary"]["active_duplicate_fingerprint_count"] == 1
+    assert report["summary"]["active_scope_conflict_count"] == 1
+    assert report["summary"]["eligible_novel_direction_count"] == 1
+    assert report["summary"]["exact_next_action"] == "deduplicate_active_campaign_scope"
+
+
+def test_write_outputs_stays_inside_allowlist(tmp_path: Path) -> None:
+    _write_json(tmp_path / "logs" / "qre_research_cycle_router" / "latest.json", {"suppressed_scopes": [], "eligible_directions": []})
+    _write_json(tmp_path / "logs" / "qre_hypothesis_disposition_memory" / "latest.json", {"record": {"memory_record_id": "mem-1"}})
+    _write_json(tmp_path / "research" / "campaign_registry_latest.v1.json", {"campaigns": {}})
+
+    report = novelty.build_experiment_dedup_novelty_enforcement(repo_root=tmp_path)
+    paths = novelty.write_outputs(report, repo_root=tmp_path)
+
+    assert paths == {
+        "latest": "logs/qre_experiment_dedup_novelty_enforcement/latest.json",
+        "operator_summary": "logs/qre_experiment_dedup_novelty_enforcement/operator_summary.md",
+    }
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -69,6 +69,16 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
             }
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.novelty_enforcement,
+        "build_experiment_dedup_novelty_enforcement",
+        lambda **_: {
+            "summary": {
+                "experiment_dedup_novelty_enforcement_ready": True,
+                "duplicate_pressure_count": 0,
+            }
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts()
 
@@ -78,6 +88,7 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
     assert report["summary"]["artifact_continuity_ready"] is True
     assert report["summary"]["contradiction_staleness_ready"] is True
     assert report["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
+    assert report["summary"]["experiment_dedup_novelty_enforcement_ready"] is True
     assert report["summary"]["final_recommendation"] == "research_memory_current_artifacts_ready"
 
 
@@ -164,6 +175,16 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
         },
     )
     monkeypatch.setattr(
+        current_artifacts.novelty_enforcement,
+        "build_experiment_dedup_novelty_enforcement",
+        lambda **_: {
+            "summary": {
+                "experiment_dedup_novelty_enforcement_ready": False,
+                "duplicate_pressure_count": 4,
+            }
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.contradiction_staleness,
         "write_outputs",
         lambda report, repo_root: {
@@ -179,6 +200,14 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
             "operator_summary": "logs/qre_campaign_throughput_bottleneck_intelligence/operator_summary.md",
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.novelty_enforcement,
+        "write_outputs",
+        lambda report, repo_root: {
+            "latest": "logs/qre_experiment_dedup_novelty_enforcement/latest.json",
+            "operator_summary": "logs/qre_experiment_dedup_novelty_enforcement/operator_summary.md",
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts(repo_root=tmp_path)
     paths = current_artifacts.write_outputs(report, repo_root=tmp_path)
@@ -188,6 +217,7 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
     assert paths["artifact_continuity_latest"] == "logs/qre_read_only_artifact_continuity/latest.json"
     assert paths["contradiction_staleness_latest"] == "logs/qre_contradiction_staleness_intelligence/latest.json"
     assert paths["campaign_throughput_bottleneck_latest"] == "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"
+    assert paths["experiment_dedup_novelty_latest"] == "logs/qre_experiment_dedup_novelty_enforcement/latest.json"
     assert "# QRE Research Memory Current Artifacts" in markdown
 
 def test_memory_coverage_entries_include_resolved_entities():

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -133,6 +133,17 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         },
     )
     monkeypatch.setattr(
+        packet_module.novelty_enforcement,
+        "build_experiment_dedup_novelty_enforcement",
+        lambda **_: {
+            "summary": {
+                "experiment_dedup_novelty_enforcement_ready": True,
+                "duplicate_pressure_count": 0,
+                "exact_next_action": "route_only_to_eligible_novel_directions",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -198,6 +209,8 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["visible_stale_or_superseded_count"] == 0
     assert packet["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
     assert packet["summary"]["visible_campaign_throughput_bottleneck_count"] == 0
+    assert packet["summary"]["experiment_dedup_novelty_enforcement_ready"] is True
+    assert packet["summary"]["visible_experiment_duplicate_pressure_count"] == 0
     assert packet["summary"]["trusted_loop_operational_controls_ready"] is True
     assert packet["summary"]["trusted_loop_operational_exact_next_action"] == "preserve_terminal_run_and_compare_before_rerun"
     assert packet["summary"]["shadow_readiness_status"] == "shadow_readiness_deferred"
@@ -277,6 +290,17 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
                 "campaign_throughput_bottleneck_intelligence_ready": False,
                 "bottleneck_count": 2,
                 "exact_next_action": "reconcile_campaign_queue_from_registry",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.novelty_enforcement,
+        "build_experiment_dedup_novelty_enforcement",
+        lambda **_: {
+            "summary": {
+                "experiment_dedup_novelty_enforcement_ready": False,
+                "duplicate_pressure_count": 2,
+                "exact_next_action": "deduplicate_active_campaign_scope",
             }
         },
     )
@@ -398,6 +422,17 @@ def test_trusted_loop_review_packet_operator_summary_renders(
         },
     )
     monkeypatch.setattr(
+        packet_module.novelty_enforcement,
+        "build_experiment_dedup_novelty_enforcement",
+        lambda **_: {
+            "summary": {
+                "experiment_dedup_novelty_enforcement_ready": True,
+                "duplicate_pressure_count": 0,
+                "exact_next_action": "route_only_to_eligible_novel_directions",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -497,6 +532,17 @@ def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(
                 "campaign_throughput_bottleneck_intelligence_ready": True,
                 "bottleneck_count": 0,
                 "exact_next_action": "preserve_campaign_throughput_context",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.novelty_enforcement,
+        "build_experiment_dedup_novelty_enforcement",
+        lambda **_: {
+            "summary": {
+                "experiment_dedup_novelty_enforcement_ready": True,
+                "duplicate_pressure_count": 0,
+                "exact_next_action": "route_only_to_eligible_novel_directions",
             }
         },
     )


### PR DESCRIPTION
## Summary
- add a deterministic read-only experiment dedup and novelty enforcement surface over router, disposition memory, campaign registry, and throughput diagnostics
- integrate the new novelty surface into research-memory current artifacts and the trusted-loop review packet
- index the new artifact in research memory and cover the new contract plus integrations with unit tests

## Testing
- python -m pytest tests/unit/test_qre_experiment_dedup_novelty_enforcement.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_trusted_loop_review_packet.py tests/unit/test_qre_research_memory_retrieval.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check