### PR TITLE
feat: add incomplete artifact remediation planning

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -43,6 +43,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"),
     Path("logs/qre_experiment_dedup_novelty_enforcement/latest.json"),
     Path("logs/qre_research_state_sequential_retrieval/latest.json"),
+    Path("logs/qre_incomplete_artifact_remediation_planning/latest.json"),
     Path("logs/qre_trusted_loop_operational_controls/latest.json"),
     Path("logs/qre_shadow_readiness_gates/latest.json"),
 )

--- a/research/qre_incomplete_artifact_remediation_planning.py
+++ b/research/qre_incomplete_artifact_remediation_planning.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_campaign_throughput_bottleneck_intelligence as throughput_bottlenecks
+from research import qre_contradiction_staleness_intelligence as contradiction_staleness
+from research import qre_read_only_artifact_continuity as artifact_continuity
+from research import qre_research_state_sequential_retrieval as sequential_retrieval
+from research import qre_trusted_loop_operational_controls as operational_controls
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_incomplete_artifact_remediation_planning"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_incomplete_artifact_remediation_planning")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_incomplete_artifact_remediation_planning/"
+_PRIORITY_ORDER: Final[dict[str, int]] = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _priority(value: str) -> str:
+    normalized = _text(value).lower()
+    return normalized if normalized in _PRIORITY_ORDER else "medium"
+
+
+def _row(
+    *,
+    source_report: str,
+    blocker_class: str,
+    priority: str,
+    reason: str,
+    exact_next_action: str,
+    artifact_ref: str,
+    evidence_refs: Sequence[str],
+) -> dict[str, Any]:
+    payload = {
+        "source_report": source_report,
+        "blocker_class": blocker_class,
+        "priority": _priority(priority),
+        "reason": reason,
+        "exact_next_action": exact_next_action,
+        "artifact_ref": artifact_ref,
+        "evidence_refs": list(evidence_refs),
+    }
+    payload["remediation_id"] = _digest(payload)[:23]
+    return payload
+
+
+def _dedupe_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for row in rows:
+        canonical = json.dumps(dict(row), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        deduped.append(dict(row))
+    return deduped
+
+
+def _continuity_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("targets") if isinstance(report.get("targets"), list) else []
+    remediation_rows: list[dict[str, Any]] = []
+    for item in rows:
+        if not isinstance(item, Mapping):
+            continue
+        state = _text(item.get("materialization_state"))
+        projected_status = _text(item.get("projected_status"))
+        if state == "current_artifact_matches_projected" and projected_status == "ready":
+            continue
+        priority = "high" if projected_status != "ready" else "medium"
+        remediation_rows.append(
+            _row(
+                source_report="qre_read_only_artifact_continuity",
+                blocker_class=state or "artifact_materialization_gap",
+                priority=priority,
+                reason=", ".join(str(code) for code in item.get("reason_codes") or []) or "artifact continuity requires remediation",
+                exact_next_action=_text(item.get("exact_next_action")) or "review_artifact_materialization_gap",
+                artifact_ref=_text(item.get("artifact_path")),
+                evidence_refs=[str(ref) for ref in item.get("source_artifact_refs") or []],
+            )
+        )
+    return remediation_rows
+
+
+def _contradiction_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    stale_rows = report.get("stale_or_superseded") if isinstance(report.get("stale_or_superseded"), list) else []
+    exact_next_action = _text((report.get("summary") or {}).get("exact_next_action"))
+    return [
+        _row(
+            source_report="qre_contradiction_staleness_intelligence",
+            blocker_class="stale_or_superseded_artifact",
+            priority="medium",
+            reason=_text(row.get("detail")) or "stale_or_superseded_artifact",
+            exact_next_action=exact_next_action or "reconcile_stale_or_superseded_artifacts",
+            artifact_ref=_text(row.get("artifact_path")) or _text(row.get("artifact_ref")),
+            evidence_refs=[_text(row.get("artifact_ref"))],
+        )
+        for row in stale_rows
+        if isinstance(row, Mapping)
+    ]
+
+
+def _throughput_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("bottlenecks") if isinstance(report.get("bottlenecks"), list) else []
+    return [
+        _row(
+            source_report="qre_campaign_throughput_bottleneck_intelligence",
+            blocker_class=_text(row.get("bottleneck_code")) or "campaign_throughput_bottleneck",
+            priority=_text(row.get("severity")) or "medium",
+            reason=_text(row.get("operator_explanation")) or _text(row.get("bottleneck_code")),
+            exact_next_action=_text(row.get("exact_next_action")) or "review_campaign_throughput_bottleneck",
+            artifact_ref="logs/qre_campaign_throughput_bottleneck_intelligence/latest.json",
+            evidence_refs=[str(ref) for ref in row.get("evidence_refs") or []],
+        )
+        for row in rows
+        if isinstance(row, Mapping)
+    ]
+
+
+def _sequential_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    blockers = report.get("blockers") if isinstance(report.get("blockers"), list) else []
+    exact_next_action = _text((report.get("summary") or {}).get("exact_next_action"))
+    return [
+        _row(
+            source_report="qre_research_state_sequential_retrieval",
+            blocker_class=_text(row.get("blocker_code")) or "sequential_state_gap",
+            priority=_text(row.get("severity")) or "medium",
+            reason=_text(row.get("reason")) or _text(row.get("blocker_code")),
+            exact_next_action=exact_next_action or "restore_current_run_artifacts",
+            artifact_ref=_text(row.get("evidence_ref")) or "logs/qre_research_state_sequential_retrieval/latest.json",
+            evidence_refs=[_text(row.get("evidence_ref"))],
+        )
+        for row in blockers
+        if isinstance(row, Mapping)
+    ]
+
+
+def _operational_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    if bool(summary.get("trusted_loop_operational_controls_ready")):
+        return []
+    current_run = report.get("current_run") if isinstance(report.get("current_run"), Mapping) else {}
+    return [
+        _row(
+            source_report="qre_trusted_loop_operational_controls",
+            blocker_class=_text(summary.get("status")) or "trusted_loop_operational_gap",
+            priority="high",
+            reason=_text(current_run.get("status_reason")) or _text(summary.get("status")) or "trusted_loop_operational_controls_not_ready",
+            exact_next_action=_text(summary.get("exact_next_safe_action")) or "operator_review_required_before_retry",
+            artifact_ref="logs/qre_trusted_loop_operational_controls/latest.json",
+            evidence_refs=["logs/qre_trusted_loop_operational_controls/latest.json"],
+        )
+    ]
+
+
+def build_incomplete_artifact_remediation_planning(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    continuity_report = artifact_continuity.build_read_only_artifact_continuity(repo_root=repo_root)
+    contradiction_report = contradiction_staleness.build_contradiction_staleness_intelligence(
+        repo_root=repo_root
+    )
+    throughput_report = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(
+        repo_root=repo_root
+    )
+    sequential_report = sequential_retrieval.build_research_state_sequential_retrieval(repo_root=repo_root)
+    operational_report = operational_controls.build_trusted_loop_operational_controls(repo_root=repo_root)
+
+    remediation_rows = _dedupe_rows(
+        [
+            *_continuity_rows(continuity_report),
+            *_contradiction_rows(contradiction_report),
+            *_throughput_rows(throughput_report),
+            *_sequential_rows(sequential_report),
+            *_operational_rows(operational_report),
+        ]
+    )
+    remediation_rows.sort(
+        key=lambda row: (
+            _PRIORITY_ORDER.get(_priority(_text(row.get("priority"))), 9),
+            _text(row.get("source_report")),
+            _text(row.get("artifact_ref")),
+            _text(row.get("blocker_class")),
+        )
+    )
+    counts = Counter(_priority(_text(row.get("priority"))) for row in remediation_rows)
+    exact_next_action = (
+        _text(remediation_rows[0].get("exact_next_action"))
+        if remediation_rows
+        else "preserve_current_read_only_artifact_visibility"
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "remediation_planning_ready": True,
+            "remediation_count": len(remediation_rows),
+            "critical_count": int(counts.get("critical") or 0),
+            "high_count": int(counts.get("high") or 0),
+            "medium_count": int(counts.get("medium") or 0),
+            "low_count": int(counts.get("low") or 0),
+            "exact_next_action": exact_next_action,
+            "operator_summary": (
+                "Incomplete artifact remediation planning consolidates continuity gaps, stale or superseded "
+                "artifacts, trusted-loop blockers, throughput bottlenecks, and sequential-state gaps into one "
+                "read-only priority queue."
+            ),
+        },
+        "remediation_rows": remediation_rows,
+        "source_summaries": {
+            "artifact_continuity": dict(continuity_report.get("summary") or {}),
+            "contradiction_staleness": dict(contradiction_report.get("summary") or {}),
+            "campaign_throughput_bottlenecks": dict(throughput_report.get("summary") or {}),
+            "research_state_sequential_retrieval": dict(sequential_report.get("summary") or {}),
+            "trusted_loop_operational_controls": dict(operational_report.get("summary") or {}),
+        },
+        "authority_boundary": {
+            "read_only": True,
+            "context_only": True,
+            "can_authorize_execution": False,
+            "can_promote_candidate": False,
+            "can_activate_shadow": False,
+        },
+        "safety_invariants": {
+            "uses_local_artifacts_only": True,
+            "uses_network": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+    report["deterministic_hash"] = _digest(
+        {
+            "summary": report["summary"],
+            "remediation_rows": report["remediation_rows"],
+            "source_summaries": report["source_summaries"],
+            "authority_boundary": report["authority_boundary"],
+        }
+    )
+    return report
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    rows = report.get("remediation_rows") if isinstance(report.get("remediation_rows"), list) else []
+    lines = [
+        "# QRE Incomplete Artifact Remediation Planning",
+        "",
+        f"- remediation_planning_ready: {summary.get('remediation_planning_ready', False)}",
+        f"- remediation_count: {summary.get('remediation_count', 0)}",
+        f"- critical_count: {summary.get('critical_count', 0)}",
+        f"- high_count: {summary.get('high_count', 0)}",
+        f"- medium_count: {summary.get('medium_count', 0)}",
+        f"- exact_next_action: {summary.get('exact_next_action', '')}",
+        "",
+        "## Top Remediation Rows",
+    ]
+    for row in rows[:10]:
+        if not isinstance(row, Mapping):
+            continue
+        lines.append(
+            f"- [{row.get('priority')}] {row.get('blocker_class')} -> {row.get('exact_next_action')} ({row.get('artifact_ref')})"
+        )
+    if not rows:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    refreshed = build_incomplete_artifact_remediation_planning(repo_root=repo_root)
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(refreshed, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(refreshed) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_incomplete_artifact_remediation_planning",
+        description="Build a deterministic read-only QRE incomplete-artifact remediation plan.",
+    )
+    parser.add_argument("--write", action="store_true", help="Write allowlisted report outputs.")
+    args = parser.parse_args()
+
+    report = build_incomplete_artifact_remediation_planning()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/qre_research_memory_current_artifacts.py
+++ b/research/qre_research_memory_current_artifacts.py
@@ -11,6 +11,7 @@ from packages.qre_research import research_memory
 from research import qre_campaign_throughput_bottleneck_intelligence as throughput_bottlenecks
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
 from research import qre_experiment_dedup_novelty_enforcement as novelty_enforcement
+from research import qre_incomplete_artifact_remediation_planning as remediation_planning
 from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_state_sequential_retrieval as sequential_retrieval
 from research import qre_research_memory_coverage as memory_coverage
@@ -88,6 +89,13 @@ def build_research_memory_current_artifacts(
         sequential_report.get("summary") if isinstance(sequential_report.get("summary"), Mapping) else {}
     )
     sequential_ready = bool(sequential_summary.get("research_state_sequential_retrieval_ready"))
+    remediation_report = remediation_planning.build_incomplete_artifact_remediation_planning(
+        repo_root=repo_root
+    )
+    remediation_summary = (
+        remediation_report.get("summary") if isinstance(remediation_report.get("summary"), Mapping) else {}
+    )
+    remediation_ready = bool(remediation_summary.get("remediation_planning_ready"))
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -126,6 +134,13 @@ def build_research_memory_current_artifacts(
             "research_state_sequential_exact_next_action": str(
                 sequential_summary.get("exact_next_action") or ""
             ),
+            "incomplete_artifact_remediation_planning_ready": remediation_ready,
+            "visible_incomplete_artifact_remediation_count": int(
+                remediation_summary.get("remediation_count") or 0
+            ),
+            "incomplete_artifact_remediation_exact_next_action": str(
+                remediation_summary.get("exact_next_action") or ""
+            ),
             "final_recommendation": (
                 "research_memory_current_artifacts_ready"
                 if package_ready
@@ -136,6 +151,7 @@ def build_research_memory_current_artifacts(
                 and throughput_ready
                 and novelty_ready
                 and sequential_ready
+                and remediation_ready
                 else "research_memory_current_artifacts_partial"
             ),
             "operator_summary": (
@@ -151,6 +167,7 @@ def build_research_memory_current_artifacts(
         "campaign_throughput_bottleneck_summary": dict(throughput_summary),
         "experiment_dedup_novelty_summary": dict(novelty_summary),
         "research_state_sequential_retrieval_summary": dict(sequential_summary),
+        "incomplete_artifact_remediation_planning_summary": dict(remediation_summary),
         "memory_artifacts": {
             "package_memory_path": str(package_status.get("path") or "logs/qre_research_memory/latest.json"),
             "coverage_path": "logs/qre_research_memory_coverage/latest.json",
@@ -160,6 +177,7 @@ def build_research_memory_current_artifacts(
             "campaign_throughput_bottleneck_path": "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json",
             "experiment_dedup_novelty_path": "logs/qre_experiment_dedup_novelty_enforcement/latest.json",
             "research_state_sequential_retrieval_path": "logs/qre_research_state_sequential_retrieval/latest.json",
+            "incomplete_artifact_remediation_planning_path": "logs/qre_incomplete_artifact_remediation_planning/latest.json",
         },
         "safety_invariants": {
             "read_only": True,
@@ -204,6 +222,9 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["research_state_sequential_retrieval_ready", str(summary.get("research_state_sequential_retrieval_ready") or False)],
                     ["visible_research_state_sequence_count", str(summary.get("visible_research_state_sequence_count") or 0)],
                     ["research_state_sequential_exact_next_action", str(summary.get("research_state_sequential_exact_next_action") or "")],
+                    ["incomplete_artifact_remediation_planning_ready", str(summary.get("incomplete_artifact_remediation_planning_ready") or False)],
+                    ["visible_incomplete_artifact_remediation_count", str(summary.get("visible_incomplete_artifact_remediation_count") or 0)],
+                    ["incomplete_artifact_remediation_exact_next_action", str(summary.get("incomplete_artifact_remediation_exact_next_action") or "")],
                     ["final_recommendation", str(summary.get("final_recommendation") or "")],
                 ],
             ),
@@ -220,6 +241,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["campaign_throughput_bottleneck_path", str(artifacts.get("campaign_throughput_bottleneck_path") or "")],
                     ["experiment_dedup_novelty_path", str(artifacts.get("experiment_dedup_novelty_path") or "")],
                     ["research_state_sequential_retrieval_path", str(artifacts.get("research_state_sequential_retrieval_path") or "")],
+                    ["incomplete_artifact_remediation_planning_path", str(artifacts.get("incomplete_artifact_remediation_planning_path") or "")],
                 ],
             ),
             "",
@@ -256,6 +278,8 @@ def write_outputs(
     novelty_paths = novelty_enforcement.write_outputs(novelty_report, repo_root=repo_root)
     sequential_report = sequential_retrieval.build_research_state_sequential_retrieval(repo_root=repo_root)
     sequential_paths = sequential_retrieval.write_outputs(sequential_report, repo_root=repo_root)
+    remediation_report = remediation_planning.build_incomplete_artifact_remediation_planning(repo_root=repo_root)
+    remediation_paths = remediation_planning.write_outputs(remediation_report, repo_root=repo_root)
 
     base = repo_root / DEFAULT_OUTPUT_DIR
     base.mkdir(parents=True, exist_ok=True)
@@ -281,6 +305,8 @@ def write_outputs(
         "experiment_dedup_novelty_operator_summary": novelty_paths["operator_summary"],
         "research_state_sequential_retrieval_latest": sequential_paths["latest"],
         "research_state_sequential_retrieval_operator_summary": sequential_paths["operator_summary"],
+        "incomplete_artifact_remediation_planning_latest": remediation_paths["latest"],
+        "incomplete_artifact_remediation_planning_operator_summary": remediation_paths["operator_summary"],
         "latest": latest.relative_to(repo_root).as_posix(),
         "operator_summary": summary_path.relative_to(repo_root).as_posix(),
     }

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -22,6 +22,7 @@ from research import qre_evidence_complete_basket_closure as basket_closure
 from research import qre_failure_action_from_basket as failure_action
 from research import qre_first_batch_evidence_recovery_cascade as first_batch_cascade
 from research import qre_first_batch_evidence_recovery_readiness as first_batch_readiness
+from research import qre_incomplete_artifact_remediation_planning as remediation_planning
 from research import qre_basket_operator_action_plan as basket_action_plan
 from research import qre_campaign_throughput_bottleneck_intelligence as throughput_bottlenecks
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
@@ -286,6 +287,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     sequential_packet = sequential_retrieval.build_research_state_sequential_retrieval(
         repo_root=repo_root
     )
+    remediation_packet = remediation_planning.build_incomplete_artifact_remediation_planning(
+        repo_root=repo_root
+    )
     action_plan_packet = basket_action_plan.build_basket_operator_action_plan(repo_root=repo_root)
     operational_controls_packet = operational_controls.build_trusted_loop_operational_controls(
         repo_root=repo_root
@@ -330,6 +334,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     )
     sequential_summary = (
         sequential_packet.get("summary") if isinstance(sequential_packet.get("summary"), Mapping) else {}
+    )
+    remediation_summary = (
+        remediation_packet.get("summary") if isinstance(remediation_packet.get("summary"), Mapping) else {}
     )
     action_plan_summary = action_plan_packet.get("summary") if isinstance(action_plan_packet.get("summary"), Mapping) else {}
     structured_lineage_summary = (
@@ -412,6 +419,15 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             ),
             "research_state_sequential_exact_next_action": str(
                 sequential_summary.get("exact_next_action") or ""
+            ),
+            "incomplete_artifact_remediation_planning_ready": bool(
+                remediation_summary.get("remediation_planning_ready")
+            ),
+            "visible_incomplete_artifact_remediation_count": int(
+                remediation_summary.get("remediation_count") or 0
+            ),
+            "incomplete_artifact_remediation_exact_next_action": str(
+                remediation_summary.get("exact_next_action") or ""
             ),
             "basket_operator_action_plan_ready": str(action_plan_summary.get("final_recommendation") or "")
             == "basket_operator_action_plan_ready",
@@ -503,6 +519,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "campaign_throughput_bottlenecks": throughput_packet,
             "experiment_dedup_novelty_enforcement": novelty_packet,
             "research_state_sequential_retrieval": sequential_packet,
+            "incomplete_artifact_remediation_planning": remediation_packet,
             "operational_controls": operational_controls_packet,
             "shadow_readiness_gates": shadow_readiness_packet,
         },
@@ -609,6 +626,9 @@ def render_operator_summary(packet: Mapping[str, Any]) -> str:
             f"- research_state_sequential_retrieval_ready: {summary.get('research_state_sequential_retrieval_ready')}",
             f"- visible_research_state_sequence_count: {summary.get('visible_research_state_sequence_count')}",
             f"- research_state_sequential_exact_next_action: {summary.get('research_state_sequential_exact_next_action')}",
+            f"- incomplete_artifact_remediation_planning_ready: {summary.get('incomplete_artifact_remediation_planning_ready')}",
+            f"- visible_incomplete_artifact_remediation_count: {summary.get('visible_incomplete_artifact_remediation_count')}",
+            f"- incomplete_artifact_remediation_exact_next_action: {summary.get('incomplete_artifact_remediation_exact_next_action')}",
             f"- guarded_alias_bounded_generation_cascade_result: {summary.get('guarded_alias_bounded_generation_cascade_result')}",
             f"- guarded_alias_bounded_generation_top_blocker: {summary.get('guarded_alias_bounded_generation_top_blocker')}",
             f"- structured_lineage_artifact_status: {summary.get('structured_lineage_artifact_status')}",

--- a/tests/unit/test_qre_incomplete_artifact_remediation_planning.py
+++ b/tests/unit/test_qre_incomplete_artifact_remediation_planning.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_incomplete_artifact_remediation_planning as planning
+
+
+def test_build_incomplete_artifact_remediation_planning_prioritizes_existing_gaps(monkeypatch) -> None:
+    monkeypatch.setattr(
+        planning.artifact_continuity,
+        "build_read_only_artifact_continuity",
+        lambda **_: {
+            "summary": {"artifact_continuity_ready": False},
+            "targets": [
+                {
+                    "artifact_path": "logs/a/latest.json",
+                    "projected_status": "blocked",
+                    "materialization_state": "blocked_missing_prerequisites",
+                    "reason_codes": ["missing_inputs"],
+                    "exact_next_action": "restore_inputs",
+                    "source_artifact_refs": ["research/a.json"],
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        planning.contradiction_staleness,
+        "build_contradiction_staleness_intelligence",
+        lambda **_: {
+            "summary": {"exact_next_action": "reconcile_stale_or_superseded_artifacts"},
+            "stale_or_superseded": [
+                {
+                    "detail": "stale_manifest",
+                    "artifact_path": "research/run_manifest_latest.v1.json",
+                    "artifact_ref": "logs/qre_contradiction_staleness_intelligence/latest.json",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        planning.throughput_bottlenecks,
+        "build_campaign_throughput_bottleneck_intelligence",
+        lambda **_: {
+            "summary": {"campaign_throughput_bottleneck_intelligence_ready": True},
+            "bottlenecks": [
+                {
+                    "bottleneck_code": "queue_registry_divergence",
+                    "severity": "critical",
+                    "operator_explanation": "queue diverged",
+                    "exact_next_action": "reconcile_campaign_queue_from_registry",
+                    "evidence_refs": ["research/campaign_queue_latest.v1.json"],
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        planning.sequential_retrieval,
+        "build_research_state_sequential_retrieval",
+        lambda **_: {
+            "summary": {"exact_next_action": "restore_current_run_artifacts"},
+            "blockers": [
+                {
+                    "blocker_code": "missing_research_state",
+                    "severity": "high",
+                    "reason": "research_state missing",
+                    "evidence_ref": "research/research_state_latest.v1.json",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        planning.operational_controls,
+        "build_trusted_loop_operational_controls",
+        lambda **_: {
+            "summary": {
+                "trusted_loop_operational_controls_ready": False,
+                "status": "failed_resumable",
+                "exact_next_safe_action": "resume_from_existing_run_history",
+            },
+            "current_run": {"status_reason": "research_run_failed:screening"},
+        },
+    )
+
+    report = planning.build_incomplete_artifact_remediation_planning(repo_root=Path("."))
+
+    assert report["summary"]["remediation_planning_ready"] is True
+    assert report["summary"]["remediation_count"] == 5
+    assert report["summary"]["critical_count"] == 1
+    assert report["summary"]["high_count"] == 3
+    assert report["summary"]["exact_next_action"] == "reconcile_campaign_queue_from_registry"
+    assert report["remediation_rows"][0]["priority"] == "critical"
+
+
+def test_write_outputs_stays_in_allowlist(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        planning,
+        "build_incomplete_artifact_remediation_planning",
+        lambda **_: {
+            "schema_version": "1.0",
+            "report_kind": planning.REPORT_KIND,
+            "summary": {"remediation_planning_ready": True, "remediation_count": 0, "exact_next_action": "preserve_current_read_only_artifact_visibility"},
+            "remediation_rows": [],
+            "source_summaries": {},
+            "authority_boundary": {"read_only": True},
+            "safety_invariants": {"uses_local_artifacts_only": True},
+            "deterministic_hash": "sha256:test",
+        },
+    )
+
+    paths = planning.write_outputs({}, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_incomplete_artifact_remediation_planning/latest.json"
+    assert paths["operator_summary"] == "logs/qre_incomplete_artifact_remediation_planning/operator_summary.md"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -90,6 +90,17 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
             }
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.remediation_planning,
+        "build_incomplete_artifact_remediation_planning",
+        lambda **_: {
+            "summary": {
+                "remediation_planning_ready": True,
+                "remediation_count": 2,
+                "exact_next_action": "preserve_current_read_only_artifact_visibility",
+            }
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts()
 
@@ -101,6 +112,7 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
     assert report["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
     assert report["summary"]["experiment_dedup_novelty_enforcement_ready"] is True
     assert report["summary"]["research_state_sequential_retrieval_ready"] is True
+    assert report["summary"]["incomplete_artifact_remediation_planning_ready"] is True
     assert report["summary"]["final_recommendation"] == "research_memory_current_artifacts_ready"
 
 
@@ -208,6 +220,17 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
         },
     )
     monkeypatch.setattr(
+        current_artifacts.remediation_planning,
+        "build_incomplete_artifact_remediation_planning",
+        lambda **_: {
+            "summary": {
+                "remediation_planning_ready": False,
+                "remediation_count": 4,
+                "exact_next_action": "restore_inputs",
+            }
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.contradiction_staleness,
         "write_outputs",
         lambda report, repo_root: {
@@ -239,6 +262,14 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
             "operator_summary": "logs/qre_research_state_sequential_retrieval/operator_summary.md",
         },
     )
+    monkeypatch.setattr(
+        current_artifacts.remediation_planning,
+        "write_outputs",
+        lambda report, repo_root: {
+            "latest": "logs/qre_incomplete_artifact_remediation_planning/latest.json",
+            "operator_summary": "logs/qre_incomplete_artifact_remediation_planning/operator_summary.md",
+        },
+    )
 
     report = current_artifacts.build_research_memory_current_artifacts(repo_root=tmp_path)
     paths = current_artifacts.write_outputs(report, repo_root=tmp_path)
@@ -250,6 +281,7 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
     assert paths["campaign_throughput_bottleneck_latest"] == "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"
     assert paths["experiment_dedup_novelty_latest"] == "logs/qre_experiment_dedup_novelty_enforcement/latest.json"
     assert paths["research_state_sequential_retrieval_latest"] == "logs/qre_research_state_sequential_retrieval/latest.json"
+    assert paths["incomplete_artifact_remediation_planning_latest"] == "logs/qre_incomplete_artifact_remediation_planning/latest.json"
     assert "# QRE Research Memory Current Artifacts" in markdown
 
 def test_memory_coverage_entries_include_resolved_entities():

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -155,6 +155,17 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         },
     )
     monkeypatch.setattr(
+        packet_module.remediation_planning,
+        "build_incomplete_artifact_remediation_planning",
+        lambda **_: {
+            "summary": {
+                "remediation_planning_ready": True,
+                "remediation_count": 2,
+                "exact_next_action": "preserve_current_read_only_artifact_visibility",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -225,6 +236,9 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["research_state_sequential_retrieval_ready"] is True
     assert packet["summary"]["visible_research_state_sequence_count"] == 4
     assert packet["summary"]["research_state_sequential_exact_next_action"] == "preserve_research_state_sequence_visibility"
+    assert packet["summary"]["incomplete_artifact_remediation_planning_ready"] is True
+    assert packet["summary"]["visible_incomplete_artifact_remediation_count"] == 2
+    assert packet["summary"]["incomplete_artifact_remediation_exact_next_action"] == "preserve_current_read_only_artifact_visibility"
     assert packet["summary"]["trusted_loop_operational_controls_ready"] is True
     assert packet["summary"]["trusted_loop_operational_exact_next_action"] == "preserve_terminal_run_and_compare_before_rerun"
     assert packet["summary"]["shadow_readiness_status"] == "shadow_readiness_deferred"
@@ -326,6 +340,17 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
                 "research_state_sequential_retrieval_ready": False,
                 "visible_sequence_row_count": 0,
                 "exact_next_action": "restore_current_run_artifacts",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.remediation_planning,
+        "build_incomplete_artifact_remediation_planning",
+        lambda **_: {
+            "summary": {
+                "remediation_planning_ready": False,
+                "remediation_count": 5,
+                "exact_next_action": "restore_inputs",
             }
         },
     )
@@ -469,6 +494,17 @@ def test_trusted_loop_review_packet_operator_summary_renders(
         },
     )
     monkeypatch.setattr(
+        packet_module.remediation_planning,
+        "build_incomplete_artifact_remediation_planning",
+        lambda **_: {
+            "summary": {
+                "remediation_planning_ready": True,
+                "remediation_count": 2,
+                "exact_next_action": "preserve_current_read_only_artifact_visibility",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.operational_controls,
         "build_trusted_loop_operational_controls",
         lambda **_: snapshots["operational_controls"],
@@ -590,6 +626,17 @@ def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(
                 "research_state_sequential_retrieval_ready": True,
                 "visible_sequence_row_count": 4,
                 "exact_next_action": "preserve_research_state_sequence_visibility",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.remediation_planning,
+        "build_incomplete_artifact_remediation_planning",
+        lambda **_: {
+            "summary": {
+                "remediation_planning_ready": True,
+                "remediation_count": 2,
+                "exact_next_action": "preserve_current_read_only_artifact_visibility",
             }
         },
     )


### PR DESCRIPTION
## Summary
- add a read-only incomplete-artifact remediation planner that prioritizes continuity gaps, stale or superseded artifacts, trusted-loop blockers, throughput bottlenecks, and sequential-state gaps
- integrate the planner into research-memory current artifacts, trusted-loop review, and research-memory artifact indexing so exact next remediation steps surface in existing operator views
- cover the planner contract plus propagation into current-artifacts and trusted-loop review with focused unit tests

## Why This Block
- major roadmap gap: multiple QRE read-only reports expose blockers, but there is no deterministic remediation queue that orders them into the next safe actions
- related modules extended rather than duplicated: `research/qre_read_only_artifact_continuity.py`, `research/qre_contradiction_staleness_intelligence.py`, `research/qre_campaign_throughput_bottleneck_intelligence.py`, `research/qre_research_state_sequential_retrieval.py`, `research/qre_research_memory_current_artifacts.py`, and `research/qre_trusted_loop_review_packet.py`
- authority boundary: read-only/context-only; no queue mutation, candidate promotion, runtime recovery, or deployment activation

## Validation
- `python -m research.qre_incomplete_artifact_remediation_planning --write`
- `python -m research.qre_research_memory_current_artifacts --write`
- `python -m research.qre_trusted_loop_review_packet --write > $null`
- `python -m pytest tests/unit/test_qre_incomplete_artifact_remediation_planning.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_trusted_loop_review_packet.py -q`
- `python -m pytest tests/smoke -q`
- `python scripts/governance_lint.py`
- `git diff --check`
