### PR TITLE
feat: add qre reason-record normalization

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -43,6 +43,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"),
     Path("logs/qre_experiment_dedup_novelty_enforcement/latest.json"),
     Path("logs/qre_research_state_sequential_retrieval/latest.json"),
+    Path("logs/qre_reason_record_normalization/latest.json"),
     Path("logs/qre_incomplete_artifact_remediation_planning/latest.json"),
     Path("logs/qre_trusted_loop_operational_controls/latest.json"),
     Path("logs/qre_shadow_readiness_gates/latest.json"),

--- a/research/qre_reason_record_normalization.py
+++ b/research/qre_reason_record_normalization.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_candidate_quality_framework as candidate_quality
+from research import qre_evidence_complete_basket_closure as basket_closure
+from research import qre_reason_records_v1 as reason_records_v1
+from research import qre_shadow_readiness_gates as shadow_readiness
+from research.qre_reason_record_contract import validate_reason_record_contract
+
+
+REPORT_KIND: Final[str] = "qre_reason_record_normalization"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_reason_record_normalization")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_reason_record_normalization/"
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _bounded_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        return []
+    out: list[str] = []
+    for item in value:
+        text = _text(item)
+        if text and text not in out:
+            out.append(text[:240])
+    return out[:24]
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _payloads_from_reason_records_v1(repo_root: Path) -> list[dict[str, Any]]:
+    snapshot = reason_records_v1.build_reason_records_snapshot(repo_root=repo_root)
+    rows = snapshot.get("records") if isinstance(snapshot.get("records"), list) else []
+    payloads: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            continue
+        payloads.append(
+            {
+                "producer_id": "qre_reason_records_v1",
+                "source_report": "logs/qre_reason_records/latest.meta.json",
+                "source_ref": f"logs/qre_reason_records/latest.jsonl#line[{index}]",
+                "payload": dict(row),
+            }
+        )
+    return payloads
+
+
+def _payloads_from_candidate_quality(repo_root: Path) -> list[dict[str, Any]]:
+    report = candidate_quality.build_candidate_quality_framework(repo_root=repo_root)
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    payloads: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            continue
+        record = row.get("reason_record")
+        if not isinstance(record, Mapping):
+            continue
+        payloads.append(
+            {
+                "producer_id": "qre_candidate_quality_framework",
+                "source_report": "logs/qre_candidate_quality_framework/latest.json",
+                "source_ref": f"logs/qre_candidate_quality_framework/latest.json#rows[{index}].reason_record",
+                "payload": dict(record),
+            }
+        )
+    return payloads
+
+
+def _payloads_from_shadow_readiness(repo_root: Path) -> list[dict[str, Any]]:
+    report = shadow_readiness.build_shadow_readiness_gates(repo_root=repo_root)
+    rows = report.get("reason_records") if isinstance(report.get("reason_records"), list) else []
+    payloads: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            continue
+        payloads.append(
+            {
+                "producer_id": "qre_shadow_readiness_gates",
+                "source_report": "logs/qre_shadow_readiness_gates/latest.json",
+                "source_ref": f"logs/qre_shadow_readiness_gates/latest.json#reason_records[{index}]",
+                "payload": dict(row),
+            }
+        )
+    return payloads
+
+
+def _payloads_from_basket_closure(repo_root: Path) -> list[dict[str, Any]]:
+    report = basket_closure.build_evidence_complete_basket_closure(repo_root=repo_root)
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    payloads: list[dict[str, Any]] = []
+    for row_index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            continue
+        reasons = row.get("clearance_reason_records")
+        if not isinstance(reasons, list):
+            continue
+        for reason_index, record in enumerate(reasons):
+            if not isinstance(record, Mapping):
+                continue
+            payloads.append(
+                {
+                    "producer_id": "qre_evidence_complete_basket_closure",
+                    "source_report": "logs/qre_evidence_complete_basket_closure/latest.json",
+                    "source_ref": (
+                        "logs/qre_evidence_complete_basket_closure/latest.json"
+                        f"#rows[{row_index}].clearance_reason_records[{reason_index}]"
+                    ),
+                    "payload": dict(record),
+                }
+            )
+    return payloads
+
+
+def _producer_payloads(repo_root: Path) -> list[dict[str, Any]]:
+    payloads: list[dict[str, Any]] = []
+    for builder in (
+        _payloads_from_reason_records_v1,
+        _payloads_from_candidate_quality,
+        _payloads_from_shadow_readiness,
+        _payloads_from_basket_closure,
+    ):
+        payloads.extend(builder(repo_root))
+    return payloads
+
+
+def _normalize_record(
+    *,
+    producer_id: str,
+    source_report: str,
+    source_ref: str,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    contract_validation = validate_reason_record_contract(payload)
+    normalized = {
+        "producer_id": producer_id,
+        "source_report": source_report,
+        "source_ref": source_ref,
+        "record_id": _text(payload.get("record_id")),
+        "record_kind": _text(payload.get("record_kind")) or "reason_record_untyped",
+        "record_family": _text(payload.get("record_family")) or producer_id,
+        "subject_id": _text(payload.get("subject_id")),
+        "reason_codes": _bounded_list(payload.get("reason_codes")),
+        "reason_text": _text(payload.get("reason_text")),
+        "evidence_refs": _bounded_list(payload.get("evidence_refs")),
+        "inputs_digest": _text(payload.get("inputs_digest")),
+        "accepted_evidence": bool(payload.get("accepted_evidence")),
+        "recommended_next_action": _text(payload.get("recommended_next_action")),
+        "contract_validation": contract_validation,
+    }
+    if not normalized["record_id"]:
+        normalized["record_id"] = (
+            "normalized::"
+            + hashlib.sha256(
+                f"{producer_id}\x1f{source_ref}\x1f{normalized['subject_id']}".encode("utf-8")
+            ).hexdigest()[:16]
+        )
+    if not normalized["inputs_digest"]:
+        normalized["inputs_digest"] = _digest(
+            {
+                "producer_id": producer_id,
+                "source_ref": source_ref,
+                "record_id": normalized["record_id"],
+                "subject_id": normalized["subject_id"],
+                "reason_codes": normalized["reason_codes"],
+            }
+        )
+    normalized["deterministic_hash"] = _digest(normalized)
+    return normalized
+
+
+def _producer_summary(
+    *,
+    producer_id: str,
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    valid_count = sum(
+        1
+        for row in rows
+        if str(((row.get("contract_validation") or {}).get("validation_status")) or "") == "valid"
+    )
+    invalid_count = len(rows) - valid_count
+    missing_counts: Counter[str] = Counter()
+    for row in rows:
+        reasons = (
+            (row.get("contract_validation") or {}).get("rejection_reasons")
+            if isinstance(row.get("contract_validation"), Mapping)
+            else []
+        )
+        for reason in reasons if isinstance(reasons, list) else []:
+            missing_counts.update([_text(reason)])
+    return {
+        "producer_id": producer_id,
+        "record_count": len(rows),
+        "valid_record_count": valid_count,
+        "invalid_record_count": invalid_count,
+        "status": "normalized_ready" if invalid_count == 0 else "normalized_with_contract_gaps",
+        "top_rejection_reasons": dict(sorted(missing_counts.items())),
+    }
+
+
+def build_reason_record_normalization(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    payloads = _producer_payloads(repo_root)
+    normalized_records = [
+        _normalize_record(
+            producer_id=_text(item.get("producer_id")),
+            source_report=_text(item.get("source_report")),
+            source_ref=_text(item.get("source_ref")),
+            payload=item.get("payload") if isinstance(item.get("payload"), Mapping) else {},
+        )
+        for item in payloads
+        if isinstance(item, Mapping)
+    ]
+    normalized_records.sort(
+        key=lambda row: (
+            str(row.get("producer_id") or ""),
+            str(row.get("subject_id") or ""),
+            str(row.get("record_id") or ""),
+        )
+    )
+    by_producer: dict[str, list[dict[str, Any]]] = {}
+    for row in normalized_records:
+        by_producer.setdefault(str(row["producer_id"]), []).append(row)
+    producer_rows = [
+        _producer_summary(producer_id=producer_id, rows=rows)
+        for producer_id, rows in sorted(by_producer.items())
+    ]
+    valid_count = sum(int(row["valid_record_count"]) for row in producer_rows)
+    invalid_count = sum(int(row["invalid_record_count"]) for row in producer_rows)
+    next_action = (
+        "normalize_reason_record_contract_gaps_before_authority_upgrade"
+        if invalid_count > 0
+        else "preserve_normalized_reason_record_visibility"
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "reason_record_normalization_ready": True,
+            "producer_count": len(producer_rows),
+            "normalized_record_count": len(normalized_records),
+            "valid_record_count": valid_count,
+            "invalid_record_count": invalid_count,
+            "producer_gap_count": sum(
+                1 for row in producer_rows if int(row.get("invalid_record_count") or 0) > 0
+            ),
+            "exact_next_action": next_action,
+            "final_recommendation": (
+                "reason_record_normalization_ready"
+                if invalid_count == 0
+                else "reason_record_normalization_has_contract_gaps"
+            ),
+            "operator_summary": (
+                "Reason-record producers are normalized into one deterministic read-only surface. "
+                "Contract-invalid producers remain explicit and do not gain authority."
+            ),
+        },
+        "producer_rows": producer_rows,
+        "normalized_records": normalized_records,
+        "authority_boundary": {
+            "read_only": True,
+            "context_only": True,
+            "does_not_authorize_evidence": True,
+            "does_not_mutate_producers": True,
+        },
+        "safety_invariants": {
+            "no_fake_reason_records": True,
+            "contract_gaps_remain_visible": True,
+            "candidate_promotion_forbidden": True,
+            "shadow_paper_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+    report["deterministic_hash"] = _digest(report)
+    return report
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    producer_rows = report.get("producer_rows") if isinstance(report.get("producer_rows"), list) else []
+    return "\n".join(
+        [
+            "# QRE Reason Record Normalization",
+            "",
+            f"- reason_record_normalization_ready: {summary.get('reason_record_normalization_ready')}",
+            f"- normalized_record_count: {summary.get('normalized_record_count') or 0}",
+            f"- valid_record_count: {summary.get('valid_record_count') or 0}",
+            f"- invalid_record_count: {summary.get('invalid_record_count') or 0}",
+            f"- exact_next_action: {summary.get('exact_next_action') or ''}",
+            "",
+            "## Producer Status",
+            _table(
+                ["Producer", "Records", "Valid", "Invalid", "Status"],
+                [
+                    [
+                        str(row.get("producer_id") or ""),
+                        str(row.get("record_count") or 0),
+                        str(row.get("valid_record_count") or 0),
+                        str(row.get("invalid_record_count") or 0),
+                        str(row.get("status") or ""),
+                    ]
+                    for row in producer_rows
+                    if isinstance(row, Mapping)
+                ],
+            ),
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_reason_record_normalization",
+        description="Normalize QRE reason-record producers into a deterministic read-only surface.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_reason_record_normalization()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_research_memory_current_artifacts.py
+++ b/research/qre_research_memory_current_artifacts.py
@@ -13,6 +13,7 @@ from research import qre_contradiction_staleness_intelligence as contradiction_s
 from research import qre_experiment_dedup_novelty_enforcement as novelty_enforcement
 from research import qre_incomplete_artifact_remediation_planning as remediation_planning
 from research import qre_read_only_artifact_continuity as artifact_continuity
+from research import qre_reason_record_normalization as reason_record_normalization
 from research import qre_research_state_sequential_retrieval as sequential_retrieval
 from research import qre_research_memory_coverage as memory_coverage
 
@@ -96,6 +97,17 @@ def build_research_memory_current_artifacts(
         remediation_report.get("summary") if isinstance(remediation_report.get("summary"), Mapping) else {}
     )
     remediation_ready = bool(remediation_summary.get("remediation_planning_ready"))
+    reason_record_normalization_report = reason_record_normalization.build_reason_record_normalization(
+        repo_root=repo_root
+    )
+    reason_record_normalization_summary = (
+        reason_record_normalization_report.get("summary")
+        if isinstance(reason_record_normalization_report.get("summary"), Mapping)
+        else {}
+    )
+    reason_record_normalization_ready = bool(
+        reason_record_normalization_summary.get("reason_record_normalization_ready")
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -134,6 +146,16 @@ def build_research_memory_current_artifacts(
             "research_state_sequential_exact_next_action": str(
                 sequential_summary.get("exact_next_action") or ""
             ),
+            "reason_record_normalization_ready": reason_record_normalization_ready,
+            "visible_reason_record_normalized_count": int(
+                reason_record_normalization_summary.get("normalized_record_count") or 0
+            ),
+            "visible_reason_record_invalid_count": int(
+                reason_record_normalization_summary.get("invalid_record_count") or 0
+            ),
+            "reason_record_normalization_exact_next_action": str(
+                reason_record_normalization_summary.get("exact_next_action") or ""
+            ),
             "incomplete_artifact_remediation_planning_ready": remediation_ready,
             "visible_incomplete_artifact_remediation_count": int(
                 remediation_summary.get("remediation_count") or 0
@@ -151,6 +173,7 @@ def build_research_memory_current_artifacts(
                 and throughput_ready
                 and novelty_ready
                 and sequential_ready
+                and reason_record_normalization_ready
                 and remediation_ready
                 else "research_memory_current_artifacts_partial"
             ),
@@ -167,6 +190,7 @@ def build_research_memory_current_artifacts(
         "campaign_throughput_bottleneck_summary": dict(throughput_summary),
         "experiment_dedup_novelty_summary": dict(novelty_summary),
         "research_state_sequential_retrieval_summary": dict(sequential_summary),
+        "reason_record_normalization_summary": dict(reason_record_normalization_summary),
         "incomplete_artifact_remediation_planning_summary": dict(remediation_summary),
         "memory_artifacts": {
             "package_memory_path": str(package_status.get("path") or "logs/qre_research_memory/latest.json"),
@@ -177,6 +201,7 @@ def build_research_memory_current_artifacts(
             "campaign_throughput_bottleneck_path": "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json",
             "experiment_dedup_novelty_path": "logs/qre_experiment_dedup_novelty_enforcement/latest.json",
             "research_state_sequential_retrieval_path": "logs/qre_research_state_sequential_retrieval/latest.json",
+            "reason_record_normalization_path": "logs/qre_reason_record_normalization/latest.json",
             "incomplete_artifact_remediation_planning_path": "logs/qre_incomplete_artifact_remediation_planning/latest.json",
         },
         "safety_invariants": {
@@ -222,6 +247,10 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["research_state_sequential_retrieval_ready", str(summary.get("research_state_sequential_retrieval_ready") or False)],
                     ["visible_research_state_sequence_count", str(summary.get("visible_research_state_sequence_count") or 0)],
                     ["research_state_sequential_exact_next_action", str(summary.get("research_state_sequential_exact_next_action") or "")],
+                    ["reason_record_normalization_ready", str(summary.get("reason_record_normalization_ready") or False)],
+                    ["visible_reason_record_normalized_count", str(summary.get("visible_reason_record_normalized_count") or 0)],
+                    ["visible_reason_record_invalid_count", str(summary.get("visible_reason_record_invalid_count") or 0)],
+                    ["reason_record_normalization_exact_next_action", str(summary.get("reason_record_normalization_exact_next_action") or "")],
                     ["incomplete_artifact_remediation_planning_ready", str(summary.get("incomplete_artifact_remediation_planning_ready") or False)],
                     ["visible_incomplete_artifact_remediation_count", str(summary.get("visible_incomplete_artifact_remediation_count") or 0)],
                     ["incomplete_artifact_remediation_exact_next_action", str(summary.get("incomplete_artifact_remediation_exact_next_action") or "")],
@@ -241,6 +270,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["campaign_throughput_bottleneck_path", str(artifacts.get("campaign_throughput_bottleneck_path") or "")],
                     ["experiment_dedup_novelty_path", str(artifacts.get("experiment_dedup_novelty_path") or "")],
                     ["research_state_sequential_retrieval_path", str(artifacts.get("research_state_sequential_retrieval_path") or "")],
+                    ["reason_record_normalization_path", str(artifacts.get("reason_record_normalization_path") or "")],
                     ["incomplete_artifact_remediation_planning_path", str(artifacts.get("incomplete_artifact_remediation_planning_path") or "")],
                 ],
             ),
@@ -278,6 +308,13 @@ def write_outputs(
     novelty_paths = novelty_enforcement.write_outputs(novelty_report, repo_root=repo_root)
     sequential_report = sequential_retrieval.build_research_state_sequential_retrieval(repo_root=repo_root)
     sequential_paths = sequential_retrieval.write_outputs(sequential_report, repo_root=repo_root)
+    reason_record_normalization_report = reason_record_normalization.build_reason_record_normalization(
+        repo_root=repo_root
+    )
+    reason_record_normalization_paths = reason_record_normalization.write_outputs(
+        reason_record_normalization_report,
+        repo_root=repo_root,
+    )
     remediation_report = remediation_planning.build_incomplete_artifact_remediation_planning(repo_root=repo_root)
     remediation_paths = remediation_planning.write_outputs(remediation_report, repo_root=repo_root)
 
@@ -305,6 +342,8 @@ def write_outputs(
         "experiment_dedup_novelty_operator_summary": novelty_paths["operator_summary"],
         "research_state_sequential_retrieval_latest": sequential_paths["latest"],
         "research_state_sequential_retrieval_operator_summary": sequential_paths["operator_summary"],
+        "reason_record_normalization_latest": reason_record_normalization_paths["latest"],
+        "reason_record_normalization_operator_summary": reason_record_normalization_paths["operator_summary"],
         "incomplete_artifact_remediation_planning_latest": remediation_paths["latest"],
         "incomplete_artifact_remediation_planning_operator_summary": remediation_paths["operator_summary"],
         "latest": latest.relative_to(repo_root).as_posix(),

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -28,6 +28,7 @@ from research import qre_campaign_throughput_bottleneck_intelligence as throughp
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
 from research import qre_experiment_dedup_novelty_enforcement as novelty_enforcement
 from research import qre_reason_records_v1 as reason_records
+from research import qre_reason_record_normalization as reason_record_normalization
 from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_research_memory_current_artifacts as research_memory
 from research import qre_research_state_sequential_retrieval as sequential_retrieval
@@ -287,6 +288,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     sequential_packet = sequential_retrieval.build_research_state_sequential_retrieval(
         repo_root=repo_root
     )
+    reason_record_normalization_packet = reason_record_normalization.build_reason_record_normalization(
+        repo_root=repo_root
+    )
     remediation_packet = remediation_planning.build_incomplete_artifact_remediation_planning(
         repo_root=repo_root
     )
@@ -334,6 +338,11 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     )
     sequential_summary = (
         sequential_packet.get("summary") if isinstance(sequential_packet.get("summary"), Mapping) else {}
+    )
+    reason_record_normalization_summary = (
+        reason_record_normalization_packet.get("summary")
+        if isinstance(reason_record_normalization_packet.get("summary"), Mapping)
+        else {}
     )
     remediation_summary = (
         remediation_packet.get("summary") if isinstance(remediation_packet.get("summary"), Mapping) else {}
@@ -419,6 +428,18 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             ),
             "research_state_sequential_exact_next_action": str(
                 sequential_summary.get("exact_next_action") or ""
+            ),
+            "reason_record_normalization_ready": bool(
+                reason_record_normalization_summary.get("reason_record_normalization_ready")
+            ),
+            "visible_reason_record_normalized_count": int(
+                reason_record_normalization_summary.get("normalized_record_count") or 0
+            ),
+            "visible_reason_record_invalid_count": int(
+                reason_record_normalization_summary.get("invalid_record_count") or 0
+            ),
+            "reason_record_normalization_exact_next_action": str(
+                reason_record_normalization_summary.get("exact_next_action") or ""
             ),
             "incomplete_artifact_remediation_planning_ready": bool(
                 remediation_summary.get("remediation_planning_ready")
@@ -519,6 +540,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "campaign_throughput_bottlenecks": throughput_packet,
             "experiment_dedup_novelty_enforcement": novelty_packet,
             "research_state_sequential_retrieval": sequential_packet,
+            "reason_record_normalization": reason_record_normalization_packet,
             "incomplete_artifact_remediation_planning": remediation_packet,
             "operational_controls": operational_controls_packet,
             "shadow_readiness_gates": shadow_readiness_packet,
@@ -626,6 +648,10 @@ def render_operator_summary(packet: Mapping[str, Any]) -> str:
             f"- research_state_sequential_retrieval_ready: {summary.get('research_state_sequential_retrieval_ready')}",
             f"- visible_research_state_sequence_count: {summary.get('visible_research_state_sequence_count')}",
             f"- research_state_sequential_exact_next_action: {summary.get('research_state_sequential_exact_next_action')}",
+            f"- reason_record_normalization_ready: {summary.get('reason_record_normalization_ready')}",
+            f"- visible_reason_record_normalized_count: {summary.get('visible_reason_record_normalized_count')}",
+            f"- visible_reason_record_invalid_count: {summary.get('visible_reason_record_invalid_count')}",
+            f"- reason_record_normalization_exact_next_action: {summary.get('reason_record_normalization_exact_next_action')}",
             f"- incomplete_artifact_remediation_planning_ready: {summary.get('incomplete_artifact_remediation_planning_ready')}",
             f"- visible_incomplete_artifact_remediation_count: {summary.get('visible_incomplete_artifact_remediation_count')}",
             f"- incomplete_artifact_remediation_exact_next_action: {summary.get('incomplete_artifact_remediation_exact_next_action')}",

--- a/tests/unit/test_qre_reason_record_normalization.py
+++ b/tests/unit/test_qre_reason_record_normalization.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_reason_record_normalization as normalization
+
+
+def test_build_reason_record_normalization_surfaces_contract_gaps(monkeypatch) -> None:
+    monkeypatch.setattr(
+        normalization.reason_records_v1,
+        "build_reason_records_snapshot",
+        lambda **_: {
+            "records": [
+                {
+                    "record_id": "rr1",
+                    "record_kind": "qre_reason_record",
+                    "record_family": "routing_readiness",
+                    "subject_id": "cand-1",
+                    "reason_codes": ["routing_ready"],
+                    "reason_text": "Routing is ready.",
+                    "evidence_refs": ["logs/qre_reason_records/latest.jsonl#line[0]"],
+                    "inputs_digest": "sha256:rr1",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        normalization.candidate_quality,
+        "build_candidate_quality_framework",
+        lambda **_: {
+            "rows": [
+                {
+                    "reason_record": {
+                        "record_id": "rr2",
+                        "record_kind": "qre_candidate_quality",
+                        "subject_id": "cand-1",
+                        "reason_codes": ["blocked_missing_accepted_oos"],
+                        "reason_text": "Accepted OOS is missing.",
+                        "evidence_refs": ["logs/qre_candidate_identity_lifecycle/latest.json"],
+                        "inputs_digest": "sha256:rr2",
+                        "accepted_evidence": False,
+                        "basket_request_ref": "logs/qre_evidence_breadth_framework/latest.json",
+                        "verifier_ref": "logs/qre_multiwindow_evidence_closure/latest.json",
+                        "closure_ref": "logs/qre_multiwindow_evidence_closure/latest.json",
+                    }
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        normalization.shadow_readiness,
+        "build_shadow_readiness_gates",
+        lambda **_: {
+            "reason_records": [
+                {
+                    "record_id": "rr3",
+                    "record_kind": "qre_shadow_readiness_deferral",
+                    "subject_id": "qre_shadow_readiness",
+                    "reason_codes": ["accepted_oos_missing"],
+                    "reason_text": "Shadow readiness remains deferred.",
+                    "evidence_refs": ["logs/qre_shadow_readiness_gates/latest.json"],
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        normalization.basket_closure,
+        "build_evidence_complete_basket_closure",
+        lambda **_: {
+            "rows": [
+                {
+                    "clearance_reason_records": [
+                        {
+                            "record_family": "accepted_structured_evidence_clearance",
+                            "subject_id": "cand-1",
+                            "reason_codes": ["campaign_lineage_missing_cleared_by_accepted_structured_evidence"],
+                            "evidence_refs": ["logs/qre_structured_lineage_artifacts/latest.json"],
+                        }
+                    ]
+                }
+            ]
+        },
+    )
+
+    report = normalization.build_reason_record_normalization()
+
+    assert report["summary"]["reason_record_normalization_ready"] is True
+    assert report["summary"]["normalized_record_count"] == 4
+    assert report["summary"]["valid_record_count"] == 1
+    assert report["summary"]["invalid_record_count"] == 3
+    assert report["summary"]["final_recommendation"] == "reason_record_normalization_has_contract_gaps"
+    rows = {row["producer_id"]: row for row in report["producer_rows"]}
+    assert rows["qre_reason_records_v1"]["invalid_record_count"] == 1
+    assert rows["qre_candidate_quality_framework"]["valid_record_count"] == 1
+    assert rows["qre_shadow_readiness_gates"]["invalid_record_count"] == 1
+    assert rows["qre_evidence_complete_basket_closure"]["invalid_record_count"] == 1
+
+
+def test_write_outputs_materializes_normalization_report(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        normalization,
+        "build_reason_record_normalization",
+        lambda **_: {
+            "summary": {
+                "reason_record_normalization_ready": True,
+                "normalized_record_count": 1,
+                "valid_record_count": 1,
+                "invalid_record_count": 0,
+                "exact_next_action": "preserve_normalized_reason_record_visibility",
+            },
+            "producer_rows": [
+                {
+                    "producer_id": "qre_reason_records_v1",
+                    "record_count": 1,
+                    "valid_record_count": 1,
+                    "invalid_record_count": 0,
+                    "status": "normalized_ready",
+                }
+            ],
+        },
+    )
+
+    report = normalization.build_reason_record_normalization(repo_root=tmp_path)
+    paths = normalization.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_reason_record_normalization/latest.json"
+    assert paths["operator_summary"] == "logs/qre_reason_record_normalization/operator_summary.md"
+    payload = json.loads((tmp_path / paths["latest"]).read_text(encoding="utf-8"))
+    assert payload["summary"]["reason_record_normalization_ready"] is True
+    assert "# QRE Reason Record Normalization" in (
+        tmp_path / paths["operator_summary"]
+    ).read_text(encoding="utf-8")

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -91,6 +91,18 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
         },
     )
     monkeypatch.setattr(
+        current_artifacts.reason_record_normalization,
+        "build_reason_record_normalization",
+        lambda **_: {
+            "summary": {
+                "reason_record_normalization_ready": True,
+                "normalized_record_count": 5,
+                "invalid_record_count": 1,
+                "exact_next_action": "normalize_reason_record_contract_gaps_before_authority_upgrade",
+            }
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.remediation_planning,
         "build_incomplete_artifact_remediation_planning",
         lambda **_: {
@@ -112,6 +124,7 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
     assert report["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
     assert report["summary"]["experiment_dedup_novelty_enforcement_ready"] is True
     assert report["summary"]["research_state_sequential_retrieval_ready"] is True
+    assert report["summary"]["reason_record_normalization_ready"] is True
     assert report["summary"]["incomplete_artifact_remediation_planning_ready"] is True
     assert report["summary"]["final_recommendation"] == "research_memory_current_artifacts_ready"
 
@@ -220,6 +233,18 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
         },
     )
     monkeypatch.setattr(
+        current_artifacts.reason_record_normalization,
+        "build_reason_record_normalization",
+        lambda **_: {
+            "summary": {
+                "reason_record_normalization_ready": False,
+                "normalized_record_count": 0,
+                "invalid_record_count": 3,
+                "exact_next_action": "normalize_reason_record_contract_gaps_before_authority_upgrade",
+            }
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.remediation_planning,
         "build_incomplete_artifact_remediation_planning",
         lambda **_: {
@@ -263,6 +288,14 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
         },
     )
     monkeypatch.setattr(
+        current_artifacts.reason_record_normalization,
+        "write_outputs",
+        lambda report, repo_root: {
+            "latest": "logs/qre_reason_record_normalization/latest.json",
+            "operator_summary": "logs/qre_reason_record_normalization/operator_summary.md",
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.remediation_planning,
         "write_outputs",
         lambda report, repo_root: {
@@ -281,6 +314,7 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
     assert paths["campaign_throughput_bottleneck_latest"] == "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"
     assert paths["experiment_dedup_novelty_latest"] == "logs/qre_experiment_dedup_novelty_enforcement/latest.json"
     assert paths["research_state_sequential_retrieval_latest"] == "logs/qre_research_state_sequential_retrieval/latest.json"
+    assert paths["reason_record_normalization_latest"] == "logs/qre_reason_record_normalization/latest.json"
     assert paths["incomplete_artifact_remediation_planning_latest"] == "logs/qre_incomplete_artifact_remediation_planning/latest.json"
     assert "# QRE Research Memory Current Artifacts" in markdown
 

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -155,6 +155,18 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         },
     )
     monkeypatch.setattr(
+        packet_module.reason_record_normalization,
+        "build_reason_record_normalization",
+        lambda **_: {
+            "summary": {
+                "reason_record_normalization_ready": True,
+                "normalized_record_count": 7,
+                "invalid_record_count": 2,
+                "exact_next_action": "normalize_reason_record_contract_gaps_before_authority_upgrade",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.remediation_planning,
         "build_incomplete_artifact_remediation_planning",
         lambda **_: {
@@ -236,6 +248,10 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["research_state_sequential_retrieval_ready"] is True
     assert packet["summary"]["visible_research_state_sequence_count"] == 4
     assert packet["summary"]["research_state_sequential_exact_next_action"] == "preserve_research_state_sequence_visibility"
+    assert packet["summary"]["reason_record_normalization_ready"] is True
+    assert packet["summary"]["visible_reason_record_normalized_count"] == 7
+    assert packet["summary"]["visible_reason_record_invalid_count"] == 2
+    assert packet["summary"]["reason_record_normalization_exact_next_action"] == "normalize_reason_record_contract_gaps_before_authority_upgrade"
     assert packet["summary"]["incomplete_artifact_remediation_planning_ready"] is True
     assert packet["summary"]["visible_incomplete_artifact_remediation_count"] == 2
     assert packet["summary"]["incomplete_artifact_remediation_exact_next_action"] == "preserve_current_read_only_artifact_visibility"
@@ -262,6 +278,7 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["evidence_inputs"]["trusted_loop_readiness"]["readiness_state"] == "operator_trusted"
     assert packet["evidence_inputs"]["structured_lineage_artifacts"]["summary"]["final_recommendation"] == "request_invalid_fails_closed"
     assert packet["evidence_inputs"]["structured_oos_artifacts"]["summary"]["final_recommendation"] == "request_invalid_fails_closed"
+    assert packet["evidence_inputs"]["reason_record_normalization"]["summary"]["normalized_record_count"] == 7
 
 
 def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomplete(


### PR DESCRIPTION
## Summary
- add a deterministic read-only reason-record normalization report across current QRE producers
- surface contract-invalid reason-record producers explicitly instead of treating them as authoritative
- integrate normalization visibility into research-memory and trusted-loop review operator surfaces

## Testing
- python -m pytest tests/unit/test_qre_reason_record_normalization.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_trusted_loop_review_packet.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check