### PR TITLE
feat: integrate qre evidence lineage graph

### DIFF
--- a/packages/qre_research/research_memory.py
+++ b/packages/qre_research/research_memory.py
@@ -42,6 +42,7 @@ DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
     Path("logs/qre_read_only_artifact_continuity/latest.json"),
     Path("logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"),
     Path("logs/qre_experiment_dedup_novelty_enforcement/latest.json"),
+    Path("logs/qre_lineage_graph_v1/latest.json"),
     Path("logs/qre_research_state_sequential_retrieval/latest.json"),
     Path("logs/qre_reason_record_normalization/latest.json"),
     Path("logs/qre_incomplete_artifact_remediation_planning/latest.json"),

--- a/research/qre_lineage_graph_v1.py
+++ b/research/qre_lineage_graph_v1.py
@@ -9,6 +9,11 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
 
+from research import qre_evidence_complete_basket_closure as basket_closure
+from research import qre_reason_record_normalization as reason_record_normalization
+from research import qre_structured_lineage_artifacts as structured_lineage_artifacts
+from research import qre_structured_oos_artifacts as structured_oos_artifacts
+
 
 REPORT_KIND: Final[str] = "qre_lineage_graph_v1"
 SCHEMA_VERSION: Final[str] = "1.0"
@@ -26,6 +31,10 @@ SOURCE_QUALITY_PATH: Final[Path] = Path("logs/qre_data_source_quality_readiness/
 HYPOTHESIS_CATALOG_PATH: Final[Path] = Path("research/strategy_hypothesis_catalog_latest.v1.json")
 CAMPAIGN_REGISTRY_PATH: Final[Path] = Path("research/campaign_registry_latest.v1.json")
 CAMPAIGN_DIGEST_PATH: Final[Path] = Path("research/campaign_digest_latest.v1.json")
+STRUCTURED_LINEAGE_PATH: Final[Path] = Path("logs/qre_structured_lineage_artifacts/latest.json")
+STRUCTURED_OOS_PATH: Final[Path] = Path("logs/qre_structured_oos_artifacts/latest.json")
+EVIDENCE_CLOSURE_PATH: Final[Path] = Path("logs/qre_evidence_complete_basket_closure/latest.json")
+REASON_RECORD_NORMALIZATION_PATH: Final[Path] = Path("logs/qre_reason_record_normalization/latest.json")
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -126,8 +135,41 @@ def _campaign_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
     return [row for row in rows if isinstance(row, Mapping)]
 
 
+def _load_or_build(
+    path: Path,
+    *,
+    repo_root: Path,
+    builder: callable,
+) -> dict[str, Any]:
+    payload = _read_json(repo_root / path)
+    if isinstance(payload, dict):
+        return payload
+    built = builder(repo_root=repo_root)
+    return built if isinstance(built, dict) else {}
+
+
 def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]:
     reports, missing_reports = _load_reports(repo_root)
+    structured_lineage_report = _load_or_build(
+        STRUCTURED_LINEAGE_PATH,
+        repo_root=repo_root,
+        builder=structured_lineage_artifacts.build_structured_lineage_artifacts,
+    )
+    structured_oos_report = _load_or_build(
+        STRUCTURED_OOS_PATH,
+        repo_root=repo_root,
+        builder=structured_oos_artifacts.build_structured_oos_artifacts,
+    )
+    closure_report = _load_or_build(
+        EVIDENCE_CLOSURE_PATH,
+        repo_root=repo_root,
+        builder=basket_closure.build_evidence_complete_basket_closure,
+    )
+    reason_record_normalization_report = _load_or_build(
+        REASON_RECORD_NORMALIZATION_PATH,
+        repo_root=repo_root,
+        builder=reason_record_normalization.build_reason_record_normalization,
+    )
 
     source_lifecycle_rows = _rows_from_report(reports.get("source_lifecycle", {}), "rows")
     historical_rows = _rows_from_report(reports.get("historical_accounting", {}), "rows")
@@ -137,6 +179,10 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
     source_quality_rows = _rows_from_report(reports.get("source_quality", {}), "rows")
     hypotheses = _rows_from_report(reports.get("hypothesis_catalog", {}), "hypotheses")
     campaigns = _campaign_rows(reports.get("campaign_registry", {}))
+    structured_lineage_rows = _rows_from_report(structured_lineage_report, "rows")
+    structured_oos_rows = _rows_from_report(structured_oos_report, "rows")
+    closure_rows = _rows_from_report(closure_report, "rows")
+    normalized_reason_rows = _rows_from_report(reason_record_normalization_report, "normalized_records")
     digest = reports.get("campaign_digest", {})
     digest_by_lineage_root = (
         digest.get("compute_by_lineage_root")
@@ -153,7 +199,9 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
     normalized_node_ids: list[str] = []
     factor_node_ids: list[str] = []
     hypothesis_node_ids: list[str] = []
+    candidate_node_ids: list[str] = []
     campaign_node_ids: list[str] = []
+    evidence_nodes: list[str] = []
 
     source_quality_groups = _group_by_alias(
         source_quality_rows,
@@ -276,6 +324,50 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
                 evidence_refs=[FACTOR_COVERAGE_PATH.as_posix(), HYPOTHESIS_CATALOG_PATH.as_posix()],
             )
 
+    candidate_nodes_by_id: dict[str, str] = {}
+    for row in sorted(closure_rows, key=lambda item: str(item.get("candidate_id") or "")):
+        candidate_id = str(row.get("candidate_id") or "")
+        if not candidate_id:
+            continue
+        candidate_node_id = f"candidate::{candidate_id}"
+        candidate_node_ids.append(candidate_node_id)
+        candidate_nodes_by_id[candidate_id] = candidate_node_id
+        _add_node(
+            nodes,
+            {
+                "node_id": candidate_node_id,
+                "node_type": "candidate",
+                "lineage_layer": "candidate",
+                "label": candidate_id,
+                "symbol": row.get("symbol"),
+                "preset_id": row.get("preset_id"),
+                "closure_status": row.get("closure_status"),
+                "exact_next_action": row.get("exact_next_action"),
+            },
+        )
+        closure_node_id = f"evidence::candidate_closure::{candidate_id}"
+        evidence_nodes.append(closure_node_id)
+        _add_node(
+            nodes,
+            {
+                "node_id": closure_node_id,
+                "node_type": "evidence",
+                "lineage_layer": "evidence",
+                "label": f"candidate_closure::{candidate_id}",
+                "report_kind": "qre_evidence_complete_basket_closure_row",
+                "candidate_id": candidate_id,
+                "closure_status": row.get("closure_status"),
+                "reason_record_count": row.get("reason_record_count"),
+            },
+        )
+        _add_edge(
+            edges,
+            candidate_node_id,
+            closure_node_id,
+            "documented_by",
+            evidence_refs=[EVIDENCE_CLOSURE_PATH.as_posix()],
+        )
+
     hypothesis_ids = {str(row.get("hypothesis_id") or "") for row in hypotheses}
     campaign_by_id = {str(row.get("campaign_id") or ""): row for row in campaigns}
     for row in sorted(campaigns, key=lambda item: str(item.get("campaign_id") or "")):
@@ -316,7 +408,6 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
                 }
             )
 
-    evidence_nodes: list[str] = []
     report_evidence_specs = [
         ("source_lifecycle_quality_gate", SOURCE_LIFECYCLE_PATH, reports.get("source_lifecycle", {})),
         ("historical_accounting_foundation", HISTORICAL_ACCOUNTING_PATH, reports.get("historical_accounting", {})),
@@ -326,6 +417,10 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
         ("source_quality_readiness", SOURCE_QUALITY_PATH, reports.get("source_quality", {})),
         ("strategy_hypothesis_catalog", HYPOTHESIS_CATALOG_PATH, reports.get("hypothesis_catalog", {})),
         ("campaign_registry", CAMPAIGN_REGISTRY_PATH, reports.get("campaign_registry", {})),
+        ("structured_lineage_artifacts", STRUCTURED_LINEAGE_PATH, structured_lineage_report),
+        ("structured_oos_artifacts", STRUCTURED_OOS_PATH, structured_oos_report),
+        ("evidence_complete_basket_closure", EVIDENCE_CLOSURE_PATH, closure_report),
+        ("reason_record_normalization", REASON_RECORD_NORMALIZATION_PATH, reason_record_normalization_report),
     ]
     for report_name, path, payload in report_evidence_specs:
         evidence_node_id = f"evidence::{report_name}"
@@ -397,6 +492,101 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
                 evidence_refs=[CAMPAIGN_DIGEST_PATH.as_posix(), GRID_BRIDGE_PATH.as_posix()],
             )
 
+    for row in structured_lineage_rows:
+        candidate_id = str(row.get("candidate_id") or "")
+        campaign_id = str(row.get("campaign_id") or "")
+        artifact_id = str(row.get("artifact_id") or "")
+        if not artifact_id:
+            continue
+        evidence_node_id = f"evidence::structured_lineage::{artifact_id}"
+        evidence_nodes.append(evidence_node_id)
+        _add_node(
+            nodes,
+            {
+                "node_id": evidence_node_id,
+                "node_type": "evidence",
+                "lineage_layer": "evidence",
+                "label": f"structured_lineage::{artifact_id}",
+                "report_kind": "qre_structured_lineage_artifacts_row",
+                "candidate_id": candidate_id,
+                "campaign_id": campaign_id,
+                "validation_status": row.get("validation_status"),
+            },
+        )
+        if candidate_id and candidate_id in candidate_nodes_by_id:
+            _add_edge(
+                edges,
+                candidate_nodes_by_id[candidate_id],
+                evidence_node_id,
+                "documented_by",
+                evidence_refs=[STRUCTURED_LINEAGE_PATH.as_posix()],
+            )
+        if campaign_id and campaign_id in campaign_by_id:
+            _add_edge(
+                edges,
+                f"campaign::{campaign_id}",
+                evidence_node_id,
+                "documented_by",
+                evidence_refs=[STRUCTURED_LINEAGE_PATH.as_posix()],
+            )
+
+    for row in structured_oos_rows:
+        candidate_id = str(row.get("candidate_id") or "")
+        artifact_id = str(row.get("artifact_id") or "")
+        if not artifact_id:
+            continue
+        evidence_node_id = f"evidence::structured_oos::{artifact_id}"
+        evidence_nodes.append(evidence_node_id)
+        _add_node(
+            nodes,
+            {
+                "node_id": evidence_node_id,
+                "node_type": "evidence",
+                "lineage_layer": "evidence",
+                "label": f"structured_oos::{artifact_id}",
+                "report_kind": "qre_structured_oos_artifacts_row",
+                "candidate_id": candidate_id,
+                "validation_status": row.get("validation_status"),
+            },
+        )
+        if candidate_id and candidate_id in candidate_nodes_by_id:
+            _add_edge(
+                edges,
+                candidate_nodes_by_id[candidate_id],
+                evidence_node_id,
+                "documented_by",
+                evidence_refs=[STRUCTURED_OOS_PATH.as_posix()],
+            )
+
+    for row in normalized_reason_rows:
+        candidate_id = str(row.get("subject_id") or "")
+        if candidate_id not in candidate_nodes_by_id:
+            continue
+        reason_node_id = f"reason_record::{row.get('record_id') or candidate_id}"
+        _add_node(
+            nodes,
+            {
+                "node_id": reason_node_id,
+                "node_type": "reason_record",
+                "lineage_layer": "reason_record",
+                "label": str(row.get("record_id") or candidate_id),
+                "candidate_id": candidate_id,
+                "record_family": row.get("record_family"),
+                "contract_validation_status": (
+                    (row.get("contract_validation") or {}).get("validation_status")
+                    if isinstance(row.get("contract_validation"), Mapping)
+                    else None
+                ),
+            },
+        )
+        _add_edge(
+            edges,
+            candidate_nodes_by_id[candidate_id],
+            reason_node_id,
+            "reason_recorded_by",
+            evidence_refs=[REASON_RECORD_NORMALIZATION_PATH.as_posix()],
+        )
+
     orphan_layer_counts = Counter()
     for node_id, node in nodes.items():
         layer = str(node.get("lineage_layer") or "unknown")
@@ -421,13 +611,25 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
                     }
                 )
                 orphan_layer_counts[layer] += 1
+        elif layer == "candidate":
+            if not any(edge["source"] == node_id for edge in edges):
+                orphan_nodes.append(
+                    {
+                        "node_id": node_id,
+                        "lineage_layer": layer,
+                        "reason": "candidate_has_no_evidence_reference",
+                    }
+                )
+                orphan_layer_counts[layer] += 1
 
     source_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "source")
     normalized_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "normalized_data")
     factor_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "factor")
     hypothesis_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "hypothesis")
+    candidate_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "candidate")
     campaign_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "campaign")
     evidence_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "evidence")
+    reason_record_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "reason_record")
     edge_counts = Counter(edge["relation"] for edge in edges)
 
     if missing_reports or contradictions:
@@ -442,8 +644,20 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
         "normalized_data_count": normalized_count,
         "factor_count": factor_count,
         "hypothesis_count": hypothesis_count,
+        "candidate_count": candidate_count,
         "campaign_count": campaign_count,
         "evidence_count": evidence_count,
+        "reason_record_count": reason_record_count,
+        "evidence_complete_candidate_count": len(candidate_nodes_by_id),
+        "structured_lineage_artifact_count": int(
+            ((structured_lineage_report.get("summary") or {}).get("artifact_count")) or 0
+        ),
+        "structured_oos_artifact_count": int(
+            ((structured_oos_report.get("summary") or {}).get("artifact_count")) or 0
+        ),
+        "normalized_reason_record_count": int(
+            ((reason_record_normalization_report.get("summary") or {}).get("normalized_record_count")) or 0
+        ),
         "edge_count": len(edges),
         "orphan_count": len(orphan_nodes),
         "contradiction_count": len(contradictions),
@@ -451,9 +665,9 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
         "orphan_layer_counts": dict(sorted(orphan_layer_counts.items())),
         "edge_relation_counts": dict(sorted(edge_counts.items())),
         "operator_summary": (
-            "Deterministic lineage graph stays read-only and report-only. Layer-adjacency edges show how source, "
-            "normalized data, factor, hypothesis, campaign, and evidence surfaces are connected without granting "
-            "alpha authority or mutation permission."
+            "Deterministic lineage graph stays read-only and report-only. Layer-adjacency edges now expose source, "
+            "normalized data, factor, hypothesis, candidate, campaign, reason-record, and evidence-closure surfaces "
+            "without granting alpha authority or mutation permission."
         ),
     }
 
@@ -481,6 +695,10 @@ def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]
             "strategy_hypothesis_catalog": HYPOTHESIS_CATALOG_PATH.as_posix(),
             "campaign_registry": CAMPAIGN_REGISTRY_PATH.as_posix(),
             "campaign_digest": CAMPAIGN_DIGEST_PATH.as_posix(),
+            "structured_lineage_artifacts": STRUCTURED_LINEAGE_PATH.as_posix(),
+            "structured_oos_artifacts": STRUCTURED_OOS_PATH.as_posix(),
+            "evidence_complete_basket_closure": EVIDENCE_CLOSURE_PATH.as_posix(),
+            "reason_record_normalization": REASON_RECORD_NORMALIZATION_PATH.as_posix(),
         },
         "safety_invariants": {
             "read_only": True,
@@ -516,8 +734,10 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["normalized_data_count", str(summary.get("normalized_data_count") or 0)],
                     ["factor_count", str(summary.get("factor_count") or 0)],
                     ["hypothesis_count", str(summary.get("hypothesis_count") or 0)],
+                    ["candidate_count", str(summary.get("candidate_count") or 0)],
                     ["campaign_count", str(summary.get("campaign_count") or 0)],
                     ["evidence_count", str(summary.get("evidence_count") or 0)],
+                    ["reason_record_count", str(summary.get("reason_record_count") or 0)],
                     ["orphan_count", str(summary.get("orphan_count") or 0)],
                     ["contradiction_count", str(summary.get("contradiction_count") or 0)],
                 ],

--- a/research/qre_research_memory_current_artifacts.py
+++ b/research/qre_research_memory_current_artifacts.py
@@ -12,6 +12,7 @@ from research import qre_campaign_throughput_bottleneck_intelligence as throughp
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
 from research import qre_experiment_dedup_novelty_enforcement as novelty_enforcement
 from research import qre_incomplete_artifact_remediation_planning as remediation_planning
+from research import qre_lineage_graph_v1 as lineage_graph
 from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_reason_record_normalization as reason_record_normalization
 from research import qre_research_state_sequential_retrieval as sequential_retrieval
@@ -67,6 +68,11 @@ def build_research_memory_current_artifacts(
         contradiction_report.get("summary") if isinstance(contradiction_report.get("summary"), Mapping) else {}
     )
     contradiction_ready = bool(contradiction_summary.get("contradiction_staleness_ready"))
+    lineage_graph_report = lineage_graph.build_qre_lineage_graph_v1(repo_root=repo_root)
+    lineage_graph_summary = (
+        lineage_graph_report.get("summary") if isinstance(lineage_graph_report.get("summary"), Mapping) else {}
+    )
+    lineage_graph_ready = str(lineage_graph_summary.get("graph_status") or "") in {"ready", "partial"}
     throughput_report = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(
         repo_root=repo_root
     )
@@ -119,6 +125,7 @@ def build_research_memory_current_artifacts(
             "retrieval_ready": retrieval_ready,
             "artifact_continuity_ready": continuity_ready,
             "contradiction_staleness_ready": contradiction_ready,
+            "lineage_graph_ready": lineage_graph_ready,
             "campaign_throughput_bottleneck_intelligence_ready": throughput_ready,
             "experiment_dedup_novelty_enforcement_ready": novelty_ready,
             "indexed_entry_count": int(memory_summary.get("indexed_entry_count") or 0),
@@ -133,6 +140,11 @@ def build_research_memory_current_artifacts(
             "visible_stale_or_superseded_count": int(
                 contradiction_summary.get("stale_or_superseded_count") or 0
             ),
+            "visible_lineage_candidate_count": int(lineage_graph_summary.get("candidate_count") or 0),
+            "visible_lineage_reason_record_count": int(
+                lineage_graph_summary.get("reason_record_count") or 0
+            ),
+            "lineage_graph_status": str(lineage_graph_summary.get("graph_status") or ""),
             "visible_campaign_throughput_bottleneck_count": int(
                 throughput_summary.get("bottleneck_count") or 0
             ),
@@ -170,6 +182,7 @@ def build_research_memory_current_artifacts(
                 and retrieval_ready
                 and continuity_ready
                 and contradiction_ready
+                and lineage_graph_ready
                 and throughput_ready
                 and novelty_ready
                 and sequential_ready
@@ -187,6 +200,7 @@ def build_research_memory_current_artifacts(
         "failure_retrieval_summary": dict(retrieval_summary),
         "artifact_continuity_summary": dict(continuity_summary),
         "contradiction_staleness_summary": dict(contradiction_summary),
+        "lineage_graph_summary": dict(lineage_graph_summary),
         "campaign_throughput_bottleneck_summary": dict(throughput_summary),
         "experiment_dedup_novelty_summary": dict(novelty_summary),
         "research_state_sequential_retrieval_summary": dict(sequential_summary),
@@ -198,6 +212,7 @@ def build_research_memory_current_artifacts(
             "failure_retrieval_path": "logs/qre_failure_retrieval/latest.json",
             "artifact_continuity_path": "logs/qre_read_only_artifact_continuity/latest.json",
             "contradiction_staleness_path": "logs/qre_contradiction_staleness_intelligence/latest.json",
+            "lineage_graph_path": "logs/qre_lineage_graph_v1/latest.json",
             "campaign_throughput_bottleneck_path": "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json",
             "experiment_dedup_novelty_path": "logs/qre_experiment_dedup_novelty_enforcement/latest.json",
             "research_state_sequential_retrieval_path": "logs/qre_research_state_sequential_retrieval/latest.json",
@@ -235,6 +250,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["retrieval_ready", str(summary.get("retrieval_ready") or False)],
                     ["artifact_continuity_ready", str(summary.get("artifact_continuity_ready") or False)],
                     ["contradiction_staleness_ready", str(summary.get("contradiction_staleness_ready") or False)],
+                    ["lineage_graph_ready", str(summary.get("lineage_graph_ready") or False)],
                     ["campaign_throughput_bottleneck_intelligence_ready", str(summary.get("campaign_throughput_bottleneck_intelligence_ready") or False)],
                     ["experiment_dedup_novelty_enforcement_ready", str(summary.get("experiment_dedup_novelty_enforcement_ready") or False)],
                     ["indexed_entry_count", str(summary.get("indexed_entry_count") or 0)],
@@ -242,6 +258,9 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["artifact_continuity_materializable_target_count", str(summary.get("artifact_continuity_materializable_target_count") or 0)],
                     ["visible_contradiction_count", str(summary.get("visible_contradiction_count") or 0)],
                     ["visible_stale_or_superseded_count", str(summary.get("visible_stale_or_superseded_count") or 0)],
+                    ["visible_lineage_candidate_count", str(summary.get("visible_lineage_candidate_count") or 0)],
+                    ["visible_lineage_reason_record_count", str(summary.get("visible_lineage_reason_record_count") or 0)],
+                    ["lineage_graph_status", str(summary.get("lineage_graph_status") or "")],
                     ["visible_campaign_throughput_bottleneck_count", str(summary.get("visible_campaign_throughput_bottleneck_count") or 0)],
                     ["visible_experiment_duplicate_pressure_count", str(summary.get("visible_experiment_duplicate_pressure_count") or 0)],
                     ["research_state_sequential_retrieval_ready", str(summary.get("research_state_sequential_retrieval_ready") or False)],
@@ -267,6 +286,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["failure_retrieval_path", str(artifacts.get("failure_retrieval_path") or "")],
                     ["artifact_continuity_path", str(artifacts.get("artifact_continuity_path") or "")],
                     ["contradiction_staleness_path", str(artifacts.get("contradiction_staleness_path") or "")],
+                    ["lineage_graph_path", str(artifacts.get("lineage_graph_path") or "")],
                     ["campaign_throughput_bottleneck_path", str(artifacts.get("campaign_throughput_bottleneck_path") or "")],
                     ["experiment_dedup_novelty_path", str(artifacts.get("experiment_dedup_novelty_path") or "")],
                     ["research_state_sequential_retrieval_path", str(artifacts.get("research_state_sequential_retrieval_path") or "")],
@@ -302,6 +322,8 @@ def write_outputs(
     continuity_paths = artifact_continuity.write_outputs(continuity_report, repo_root=repo_root)
     contradiction_report = contradiction_staleness.build_contradiction_staleness_intelligence(repo_root=repo_root)
     contradiction_paths = contradiction_staleness.write_outputs(contradiction_report, repo_root=repo_root)
+    lineage_graph_report = lineage_graph.build_qre_lineage_graph_v1(repo_root=repo_root)
+    lineage_graph_paths = lineage_graph.write_outputs(lineage_graph_report, repo_root=repo_root)
     throughput_report = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(repo_root=repo_root)
     throughput_paths = throughput_bottlenecks.write_outputs(throughput_report, repo_root=repo_root)
     novelty_report = novelty_enforcement.build_experiment_dedup_novelty_enforcement(repo_root=repo_root)
@@ -336,6 +358,8 @@ def write_outputs(
         "artifact_continuity_operator_summary": continuity_paths["operator_summary"],
         "contradiction_staleness_latest": contradiction_paths["latest"],
         "contradiction_staleness_operator_summary": contradiction_paths["operator_summary"],
+        "lineage_graph_latest": lineage_graph_paths["latest"],
+        "lineage_graph_operator_summary": lineage_graph_paths["operator_summary"],
         "campaign_throughput_bottleneck_latest": throughput_paths["latest"],
         "campaign_throughput_bottleneck_operator_summary": throughput_paths["operator_summary"],
         "experiment_dedup_novelty_latest": novelty_paths["latest"],

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -27,6 +27,7 @@ from research import qre_basket_operator_action_plan as basket_action_plan
 from research import qre_campaign_throughput_bottleneck_intelligence as throughput_bottlenecks
 from research import qre_contradiction_staleness_intelligence as contradiction_staleness
 from research import qre_experiment_dedup_novelty_enforcement as novelty_enforcement
+from research import qre_lineage_graph_v1 as lineage_graph
 from research import qre_reason_records_v1 as reason_records
 from research import qre_reason_record_normalization as reason_record_normalization
 from research import qre_read_only_artifact_continuity as artifact_continuity
@@ -279,6 +280,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     contradiction_packet = contradiction_staleness.build_contradiction_staleness_intelligence(
         repo_root=repo_root
     )
+    lineage_graph_packet = lineage_graph.build_qre_lineage_graph_v1(repo_root=repo_root)
     throughput_packet = throughput_bottlenecks.build_campaign_throughput_bottleneck_intelligence(
         repo_root=repo_root
     )
@@ -329,6 +331,9 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     )
     contradiction_summary = (
         contradiction_packet.get("summary") if isinstance(contradiction_packet.get("summary"), Mapping) else {}
+    )
+    lineage_graph_summary = (
+        lineage_graph_packet.get("summary") if isinstance(lineage_graph_packet.get("summary"), Mapping) else {}
     )
     throughput_summary = (
         throughput_packet.get("summary") if isinstance(throughput_packet.get("summary"), Mapping) else {}
@@ -395,6 +400,11 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "artifact_continuity_ready": bool(continuity_summary.get("artifact_continuity_ready")),
             "artifact_continuity_exact_next_action": str(continuity_summary.get("exact_next_action") or ""),
             "contradiction_staleness_ready": bool(contradiction_summary.get("contradiction_staleness_ready")),
+            "lineage_graph_status": str(lineage_graph_summary.get("graph_status") or ""),
+            "visible_lineage_candidate_count": int(lineage_graph_summary.get("candidate_count") or 0),
+            "visible_lineage_reason_record_count": int(
+                lineage_graph_summary.get("reason_record_count") or 0
+            ),
             "visible_contradiction_count": int(contradiction_summary.get("contradiction_count") or 0),
             "visible_stale_or_superseded_count": int(
                 contradiction_summary.get("stale_or_superseded_count") or 0
@@ -537,6 +547,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "research_memory": memory_packet,
             "artifact_continuity": continuity_packet,
             "contradiction_staleness": contradiction_packet,
+            "lineage_graph": lineage_graph_packet,
             "campaign_throughput_bottlenecks": throughput_packet,
             "experiment_dedup_novelty_enforcement": novelty_packet,
             "research_state_sequential_retrieval": sequential_packet,
@@ -636,6 +647,9 @@ def render_operator_summary(packet: Mapping[str, Any]) -> str:
             f"- artifact_continuity_ready: {summary.get('artifact_continuity_ready')}",
             f"- artifact_continuity_exact_next_action: {summary.get('artifact_continuity_exact_next_action')}",
             f"- contradiction_staleness_ready: {summary.get('contradiction_staleness_ready')}",
+            f"- lineage_graph_status: {summary.get('lineage_graph_status')}",
+            f"- visible_lineage_candidate_count: {summary.get('visible_lineage_candidate_count')}",
+            f"- visible_lineage_reason_record_count: {summary.get('visible_lineage_reason_record_count')}",
             f"- visible_contradiction_count: {summary.get('visible_contradiction_count')}",
             f"- visible_stale_or_superseded_count: {summary.get('visible_stale_or_superseded_count')}",
             f"- contradiction_staleness_exact_next_action: {summary.get('contradiction_staleness_exact_next_action')}",

--- a/tests/unit/test_qre_lineage_graph_v1.py
+++ b/tests/unit/test_qre_lineage_graph_v1.py
@@ -181,6 +181,67 @@ def _write_required_fixture_set(
             },
         },
     )
+    _write_json(
+        tmp_path / "logs" / "qre_evidence_complete_basket_closure" / "latest.json",
+        {
+            "report_kind": "qre_evidence_complete_basket_closure",
+            "summary": {"evidence_complete_count": 0},
+            "rows": [
+                {
+                    "candidate_id": "cand-1",
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback",
+                    "closure_status": "blocked_not_evidence_complete",
+                    "exact_next_action": "collect_more_evidence",
+                    "reason_record_count": 1,
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_reason_record_normalization" / "latest.json",
+        {
+            "report_kind": "qre_reason_record_normalization",
+            "summary": {"normalized_record_count": 1},
+            "normalized_records": [
+                {
+                    "record_id": "rr-cand-1",
+                    "subject_id": "cand-1",
+                    "record_family": "routing_readiness",
+                    "contract_validation": {"validation_status": "valid"},
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_structured_lineage_artifacts" / "latest.json",
+        {
+            "report_kind": "qre_structured_lineage_artifacts",
+            "summary": {"artifact_count": 1},
+            "rows": [
+                {
+                    "artifact_id": "lineage-1",
+                    "candidate_id": "cand-1",
+                    "campaign_id": "col-1",
+                    "validation_status": "provisional",
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_structured_oos_artifacts" / "latest.json",
+        {
+            "report_kind": "qre_structured_oos_artifacts",
+            "summary": {"artifact_count": 1},
+            "rows": [
+                {
+                    "artifact_id": "oos-1",
+                    "candidate_id": "cand-1",
+                    "validation_status": "provisional",
+                }
+            ],
+        },
+    )
 
 
 def test_lineage_graph_builds_complete_read_only_graph(tmp_path: Path) -> None:
@@ -193,13 +254,15 @@ def test_lineage_graph_builds_complete_read_only_graph(tmp_path: Path) -> None:
     assert summary["normalized_data_count"] == 1
     assert summary["factor_count"] == 1
     assert summary["hypothesis_count"] == 1
+    assert summary["candidate_count"] == 1
     assert summary["campaign_count"] == 1
     assert summary["evidence_count"] >= 8
+    assert summary["reason_record_count"] == 1
     assert checks["missing_reports"] == []
     assert checks["orphan_nodes"] == []
     assert checks["contradictions"] == []
     node_types = {str(node["node_type"]) for node in report["nodes"]}
-    assert {"source", "normalized_data", "factor", "hypothesis", "campaign", "evidence"} <= node_types
+    assert {"source", "normalized_data", "factor", "hypothesis", "candidate", "campaign", "evidence", "reason_record"} <= node_types
 
 
 def test_lineage_graph_flags_missing_hypothesis_as_contradiction(tmp_path: Path) -> None:

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -60,6 +60,17 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
         },
     )
     monkeypatch.setattr(
+        current_artifacts.lineage_graph,
+        "build_qre_lineage_graph_v1",
+        lambda **_: {
+            "summary": {
+                "graph_status": "partial",
+                "candidate_count": 2,
+                "reason_record_count": 3,
+            }
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.throughput_bottlenecks,
         "build_campaign_throughput_bottleneck_intelligence",
         lambda **_: {
@@ -121,6 +132,7 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
     assert report["summary"]["retrieval_ready"] is True
     assert report["summary"]["artifact_continuity_ready"] is True
     assert report["summary"]["contradiction_staleness_ready"] is True
+    assert report["summary"]["lineage_graph_ready"] is True
     assert report["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
     assert report["summary"]["experiment_dedup_novelty_enforcement_ready"] is True
     assert report["summary"]["research_state_sequential_retrieval_ready"] is True
@@ -202,6 +214,17 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
         },
     )
     monkeypatch.setattr(
+        current_artifacts.lineage_graph,
+        "build_qre_lineage_graph_v1",
+        lambda **_: {
+            "summary": {
+                "graph_status": "blocked",
+                "candidate_count": 0,
+                "reason_record_count": 0,
+            }
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.throughput_bottlenecks,
         "build_campaign_throughput_bottleneck_intelligence",
         lambda **_: {
@@ -264,6 +287,14 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
         },
     )
     monkeypatch.setattr(
+        current_artifacts.lineage_graph,
+        "write_outputs",
+        lambda report, repo_root: {
+            "latest": "logs/qre_lineage_graph_v1/latest.json",
+            "operator_summary": "logs/qre_lineage_graph_v1/operator_summary.md",
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.throughput_bottlenecks,
         "write_outputs",
         lambda report, repo_root: {
@@ -311,6 +342,7 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
     assert paths["latest"] == "logs/qre_research_memory_current_artifacts/latest.json"
     assert paths["artifact_continuity_latest"] == "logs/qre_read_only_artifact_continuity/latest.json"
     assert paths["contradiction_staleness_latest"] == "logs/qre_contradiction_staleness_intelligence/latest.json"
+    assert paths["lineage_graph_latest"] == "logs/qre_lineage_graph_v1/latest.json"
     assert paths["campaign_throughput_bottleneck_latest"] == "logs/qre_campaign_throughput_bottleneck_intelligence/latest.json"
     assert paths["experiment_dedup_novelty_latest"] == "logs/qre_experiment_dedup_novelty_enforcement/latest.json"
     assert paths["research_state_sequential_retrieval_latest"] == "logs/qre_research_state_sequential_retrieval/latest.json"

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -122,6 +122,17 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         },
     )
     monkeypatch.setattr(
+        packet_module.lineage_graph,
+        "build_qre_lineage_graph_v1",
+        lambda **_: {
+            "summary": {
+                "graph_status": "partial",
+                "candidate_count": 2,
+                "reason_record_count": 3,
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.throughput_bottlenecks,
         "build_campaign_throughput_bottleneck_intelligence",
         lambda **_: {
@@ -239,6 +250,9 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["artifact_continuity_ready"] is True
     assert packet["summary"]["artifact_continuity_exact_next_action"] == "preserve_current_read_only_artifacts"
     assert packet["summary"]["contradiction_staleness_ready"] is True
+    assert packet["summary"]["lineage_graph_status"] == "partial"
+    assert packet["summary"]["visible_lineage_candidate_count"] == 2
+    assert packet["summary"]["visible_lineage_reason_record_count"] == 3
     assert packet["summary"]["visible_contradiction_count"] == 0
     assert packet["summary"]["visible_stale_or_superseded_count"] == 0
     assert packet["summary"]["campaign_throughput_bottleneck_intelligence_ready"] is True
@@ -278,6 +292,7 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["evidence_inputs"]["trusted_loop_readiness"]["readiness_state"] == "operator_trusted"
     assert packet["evidence_inputs"]["structured_lineage_artifacts"]["summary"]["final_recommendation"] == "request_invalid_fails_closed"
     assert packet["evidence_inputs"]["structured_oos_artifacts"]["summary"]["final_recommendation"] == "request_invalid_fails_closed"
+    assert packet["evidence_inputs"]["lineage_graph"]["summary"]["candidate_count"] == 2
     assert packet["evidence_inputs"]["reason_record_normalization"]["summary"]["normalized_record_count"] == 7
 
 


### PR DESCRIPTION
## Summary
- extend qre_lineage_graph_v1 with candidate, structured-artifact, closure, and normalized reason-record evidence surfaces
- keep the lineage graph read-only while surfacing explicit candidate evidence links and orphan gaps
- integrate lineage-graph visibility into research-memory and trusted-loop operator surfaces

## Testing
- python -m pytest tests/unit/test_qre_lineage_graph_v1.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_trusted_loop_review_packet.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check