### PR TITLE
feat: integrate qre source authority into operator surfaces

### DIFF
--- a/research/qre_daily_status_digest.py
+++ b/research/qre_daily_status_digest.py
@@ -411,6 +411,12 @@ def build_daily_status_packet(
             "research_memory_current_artifacts_status": research_memory_summary.get(
                 "final_recommendation"
             ),
+            "source_authority_blocked_scope_count": research_memory_summary.get(
+                "visible_source_authority_blocked_scope_count"
+            ),
+            "source_authority_exact_next_action": research_memory_summary.get(
+                "source_authority_exact_next_action"
+            ),
             "shadow_readiness_status": shadow_summary.get("readiness_status"),
             "shadow_readiness_blocker_count": shadow_summary.get("blocker_count"),
             "shadow_readiness_exact_next_action": shadow_summary.get("exact_next_action"),
@@ -529,6 +535,8 @@ def render_daily_status(packet: dict[str, Any]) -> str:
             f"- Trusted-loop exact next action: {summary['trusted_loop_exact_next_action']}",
             f"- Research-memory current artifacts ready: {summary['research_memory_current_artifacts_ready']}",
             f"- Research-memory current artifacts status: {summary['research_memory_current_artifacts_status']}",
+            f"- Source-authority blocked scope count: {summary['source_authority_blocked_scope_count']}",
+            f"- Source-authority exact next action: {summary['source_authority_exact_next_action']}",
             f"- Shadow readiness status: {summary['shadow_readiness_status']}",
             f"- Shadow readiness blocker count: {summary['shadow_readiness_blocker_count']}",
             f"- Shadow readiness exact next action: {summary['shadow_readiness_exact_next_action']}",

--- a/research/qre_research_memory_current_artifacts.py
+++ b/research/qre_research_memory_current_artifacts.py
@@ -17,6 +17,7 @@ from research import qre_read_only_artifact_continuity as artifact_continuity
 from research import qre_reason_record_normalization as reason_record_normalization
 from research import qre_research_state_sequential_retrieval as sequential_retrieval
 from research import qre_research_memory_coverage as memory_coverage
+from research import qre_source_identity_authority_normalization as source_authority
 
 
 REPORT_KIND: Final[str] = "qre_research_memory_current_artifacts"
@@ -114,6 +115,13 @@ def build_research_memory_current_artifacts(
     reason_record_normalization_ready = bool(
         reason_record_normalization_summary.get("reason_record_normalization_ready")
     )
+    source_authority_report = source_authority.build_source_identity_authority_report(repo_root=repo_root)
+    source_authority_summary = (
+        source_authority_report.get("summary")
+        if isinstance(source_authority_report.get("summary"), Mapping)
+        else {}
+    )
+    source_authority_ready = str(source_authority_summary.get("status") or "") == "ready"
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -168,6 +176,16 @@ def build_research_memory_current_artifacts(
             "reason_record_normalization_exact_next_action": str(
                 reason_record_normalization_summary.get("exact_next_action") or ""
             ),
+            "source_authority_ready": source_authority_ready,
+            "visible_source_authority_ready_scope_count": int(
+                source_authority_summary.get("ready_scope_count") or 0
+            ),
+            "visible_source_authority_blocked_scope_count": int(
+                source_authority_summary.get("blocked_scope_count") or 0
+            ),
+            "source_authority_exact_next_action": str(
+                source_authority_summary.get("exact_next_action") or ""
+            ),
             "incomplete_artifact_remediation_planning_ready": remediation_ready,
             "visible_incomplete_artifact_remediation_count": int(
                 remediation_summary.get("remediation_count") or 0
@@ -187,6 +205,7 @@ def build_research_memory_current_artifacts(
                 and novelty_ready
                 and sequential_ready
                 and reason_record_normalization_ready
+                and source_authority_ready
                 and remediation_ready
                 else "research_memory_current_artifacts_partial"
             ),
@@ -205,6 +224,7 @@ def build_research_memory_current_artifacts(
         "experiment_dedup_novelty_summary": dict(novelty_summary),
         "research_state_sequential_retrieval_summary": dict(sequential_summary),
         "reason_record_normalization_summary": dict(reason_record_normalization_summary),
+        "source_authority_summary": dict(source_authority_summary),
         "incomplete_artifact_remediation_planning_summary": dict(remediation_summary),
         "memory_artifacts": {
             "package_memory_path": str(package_status.get("path") or "logs/qre_research_memory/latest.json"),
@@ -217,6 +237,7 @@ def build_research_memory_current_artifacts(
             "experiment_dedup_novelty_path": "logs/qre_experiment_dedup_novelty_enforcement/latest.json",
             "research_state_sequential_retrieval_path": "logs/qre_research_state_sequential_retrieval/latest.json",
             "reason_record_normalization_path": "logs/qre_reason_record_normalization/latest.json",
+            "source_authority_path": "logs/qre_source_identity_authority_normalization/latest.json",
             "incomplete_artifact_remediation_planning_path": "logs/qre_incomplete_artifact_remediation_planning/latest.json",
         },
         "safety_invariants": {
@@ -270,6 +291,10 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["visible_reason_record_normalized_count", str(summary.get("visible_reason_record_normalized_count") or 0)],
                     ["visible_reason_record_invalid_count", str(summary.get("visible_reason_record_invalid_count") or 0)],
                     ["reason_record_normalization_exact_next_action", str(summary.get("reason_record_normalization_exact_next_action") or "")],
+                    ["source_authority_ready", str(summary.get("source_authority_ready") or False)],
+                    ["visible_source_authority_ready_scope_count", str(summary.get("visible_source_authority_ready_scope_count") or 0)],
+                    ["visible_source_authority_blocked_scope_count", str(summary.get("visible_source_authority_blocked_scope_count") or 0)],
+                    ["source_authority_exact_next_action", str(summary.get("source_authority_exact_next_action") or "")],
                     ["incomplete_artifact_remediation_planning_ready", str(summary.get("incomplete_artifact_remediation_planning_ready") or False)],
                     ["visible_incomplete_artifact_remediation_count", str(summary.get("visible_incomplete_artifact_remediation_count") or 0)],
                     ["incomplete_artifact_remediation_exact_next_action", str(summary.get("incomplete_artifact_remediation_exact_next_action") or "")],
@@ -291,6 +316,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
                     ["experiment_dedup_novelty_path", str(artifacts.get("experiment_dedup_novelty_path") or "")],
                     ["research_state_sequential_retrieval_path", str(artifacts.get("research_state_sequential_retrieval_path") or "")],
                     ["reason_record_normalization_path", str(artifacts.get("reason_record_normalization_path") or "")],
+                    ["source_authority_path", str(artifacts.get("source_authority_path") or "")],
                     ["incomplete_artifact_remediation_planning_path", str(artifacts.get("incomplete_artifact_remediation_planning_path") or "")],
                 ],
             ),
@@ -337,6 +363,8 @@ def write_outputs(
         reason_record_normalization_report,
         repo_root=repo_root,
     )
+    source_authority_report = source_authority.build_source_identity_authority_report(repo_root=repo_root)
+    source_authority_paths = source_authority.write_outputs(source_authority_report, repo_root=repo_root)
     remediation_report = remediation_planning.build_incomplete_artifact_remediation_planning(repo_root=repo_root)
     remediation_paths = remediation_planning.write_outputs(remediation_report, repo_root=repo_root)
 
@@ -368,6 +396,8 @@ def write_outputs(
         "research_state_sequential_retrieval_operator_summary": sequential_paths["operator_summary"],
         "reason_record_normalization_latest": reason_record_normalization_paths["latest"],
         "reason_record_normalization_operator_summary": reason_record_normalization_paths["operator_summary"],
+        "source_authority_latest": source_authority_paths["latest"],
+        "source_authority_operator_summary": source_authority_paths["operator_summary"],
         "incomplete_artifact_remediation_planning_latest": remediation_paths["latest"],
         "incomplete_artifact_remediation_planning_operator_summary": remediation_paths["operator_summary"],
         "latest": latest.relative_to(repo_root).as_posix(),

--- a/research/qre_research_memory_retrieval.py
+++ b/research/qre_research_memory_retrieval.py
@@ -213,6 +213,30 @@ def _recurring_failures(
     }
 
 
+def _source_authority_remaining_scope_gaps(source_authority: Mapping[str, Any] | None) -> dict[str, Any]:
+    authority_rows = (
+        source_authority.get("rows")
+        if isinstance(source_authority, Mapping) and isinstance(source_authority.get("rows"), list)
+        else []
+    )
+    rows = [
+        {
+            "scope_key": _text(row.get("scope_key")),
+            "symbol": _text(row.get("symbol")),
+            "authority_status": _text(row.get("authority_status")),
+            "authority_reasons": list(row.get("authority_reasons") or []),
+        }
+        for row in authority_rows
+        if isinstance(row, Mapping) and _text(row.get("authority_status")) not in {"", "normalized_context_ready"}
+    ]
+    return {
+        "query_id": "source_authority_remaining_scope_gaps",
+        "status": "matched" if rows else "not_found",
+        "rows": rows,
+        "provenance": [_provenance("logs/qre_source_identity_authority_normalization/latest.json")],
+    }
+
+
 def _novel_remaining_directions(router: Mapping[str, Any] | None) -> dict[str, Any]:
     rows = router.get("eligible_directions") if isinstance(router, Mapping) and isinstance(router.get("eligible_directions"), list) else []
     shaped = [
@@ -309,6 +333,7 @@ def build_research_memory_retrieval(
         _regimes_with_no_trades(disposition_index, campaign),
         _inadequate_sample_density_presets(breadth_rows),
         _recurring_failures(disposition_index, breadth_rows, source_authority),
+        _source_authority_remaining_scope_gaps(source_authority),
         _novel_remaining_directions(router),
         _contradictory_outcomes(disposition_index, breadth_rows),
         _stale_or_superseded_knowledge(artifacts, memory),
@@ -320,6 +345,9 @@ def build_research_memory_retrieval(
         "query_count": len(queries),
         "matched_query_count": sum(1 for row in queries if row.get("status") == "matched"),
         "memory_entry_count": int(memory.get("summary", {}).get("entry_count") or 0),
+        "source_authority_blocked_scope_count": len(
+            (_source_authority_remaining_scope_gaps(source_authority).get("rows") or [])
+        ),
         "contradiction_count": len((_contradictory_outcomes(disposition_index, breadth_rows)).get("rows") or []),
         "operator_summary": (
             "Research memory retrieval unifies tested-scope, failure, breadth, and next-cycle context with explicit provenance. "

--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -36,6 +36,7 @@ from research import qre_research_state_sequential_retrieval as sequential_retri
 from research import qre_routing_calibration_report as routing_calibration
 from research import qre_sampling_calibration_report as sampling_calibration
 from research import qre_shadow_readiness_gates as shadow_readiness_gates
+from research import qre_source_identity_authority_normalization as source_authority
 from research import qre_trusted_loop_operational_controls as operational_controls
 
 
@@ -293,6 +294,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     reason_record_normalization_packet = reason_record_normalization.build_reason_record_normalization(
         repo_root=repo_root
     )
+    source_authority_packet = source_authority.build_source_identity_authority_report(repo_root=repo_root)
     remediation_packet = remediation_planning.build_incomplete_artifact_remediation_planning(
         repo_root=repo_root
     )
@@ -347,6 +349,11 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
     reason_record_normalization_summary = (
         reason_record_normalization_packet.get("summary")
         if isinstance(reason_record_normalization_packet.get("summary"), Mapping)
+        else {}
+    )
+    source_authority_summary = (
+        source_authority_packet.get("summary")
+        if isinstance(source_authority_packet.get("summary"), Mapping)
         else {}
     )
     remediation_summary = (
@@ -451,6 +458,16 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "reason_record_normalization_exact_next_action": str(
                 reason_record_normalization_summary.get("exact_next_action") or ""
             ),
+            "source_authority_status": str(source_authority_summary.get("status") or ""),
+            "visible_source_authority_ready_scope_count": int(
+                source_authority_summary.get("ready_scope_count") or 0
+            ),
+            "visible_source_authority_blocked_scope_count": int(
+                source_authority_summary.get("blocked_scope_count") or 0
+            ),
+            "source_authority_exact_next_action": str(
+                source_authority_summary.get("exact_next_action") or ""
+            ),
             "incomplete_artifact_remediation_planning_ready": bool(
                 remediation_summary.get("remediation_planning_ready")
             ),
@@ -552,6 +569,7 @@ def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str
             "experiment_dedup_novelty_enforcement": novelty_packet,
             "research_state_sequential_retrieval": sequential_packet,
             "reason_record_normalization": reason_record_normalization_packet,
+            "source_authority": source_authority_packet,
             "incomplete_artifact_remediation_planning": remediation_packet,
             "operational_controls": operational_controls_packet,
             "shadow_readiness_gates": shadow_readiness_packet,
@@ -666,6 +684,10 @@ def render_operator_summary(packet: Mapping[str, Any]) -> str:
             f"- visible_reason_record_normalized_count: {summary.get('visible_reason_record_normalized_count')}",
             f"- visible_reason_record_invalid_count: {summary.get('visible_reason_record_invalid_count')}",
             f"- reason_record_normalization_exact_next_action: {summary.get('reason_record_normalization_exact_next_action')}",
+            f"- source_authority_status: {summary.get('source_authority_status')}",
+            f"- visible_source_authority_ready_scope_count: {summary.get('visible_source_authority_ready_scope_count')}",
+            f"- visible_source_authority_blocked_scope_count: {summary.get('visible_source_authority_blocked_scope_count')}",
+            f"- source_authority_exact_next_action: {summary.get('source_authority_exact_next_action')}",
             f"- incomplete_artifact_remediation_planning_ready: {summary.get('incomplete_artifact_remediation_planning_ready')}",
             f"- visible_incomplete_artifact_remediation_count: {summary.get('visible_incomplete_artifact_remediation_count')}",
             f"- incomplete_artifact_remediation_exact_next_action: {summary.get('incomplete_artifact_remediation_exact_next_action')}",

--- a/tests/unit/test_qre_daily_status_digest.py
+++ b/tests/unit/test_qre_daily_status_digest.py
@@ -261,6 +261,8 @@ def test_digest_surfaces_qre_trust_memory_and_shadow_state(tmp_path: Path) -> No
         {
             "summary": {
                 "final_recommendation": "research_memory_current_artifacts_ready",
+                "visible_source_authority_blocked_scope_count": 2,
+                "source_authority_exact_next_action": "resolve_provider_symbol_ambiguity_for_bounded_scope",
             }
         },
     )
@@ -285,12 +287,16 @@ def test_digest_surfaces_qre_trust_memory_and_shadow_state(tmp_path: Path) -> No
     assert packet["summary"]["trusted_loop_review_ready"] is False
     assert packet["summary"]["trusted_loop_trust_verdict"] == "read_only_context_fail_closed"
     assert packet["summary"]["research_memory_current_artifacts_ready"] is True
+    assert packet["summary"]["source_authority_blocked_scope_count"] == 2
     assert packet["summary"]["shadow_readiness_status"] == "shadow_readiness_deferred"
     assert packet["summary"]["qre_operator_authority"] == "working_read_only_fail_closed"
     assert packet["summary"]["qre_exact_next_action"] == "produce_accepted_oos_and_evidence_complete_scope"
     assert (
         packet["next_system_action"] == "produce_accepted_oos_and_evidence_complete_scope"
     )
+    rendered = digest.render_daily_status(packet)
+    assert "Source-authority blocked scope count: 2" in rendered
+    assert "Source-authority exact next action: resolve_provider_symbol_ambiguity_for_bounded_scope" in rendered
 
 
 def test_stale_no_safe_build_backend_configured_is_suppressed_after_successful_backend_result(tmp_path: Path) -> None:

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -114,6 +114,18 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
         },
     )
     monkeypatch.setattr(
+        current_artifacts.source_authority,
+        "build_source_identity_authority_report",
+        lambda **_: {
+            "summary": {
+                "status": "ready",
+                "ready_scope_count": 2,
+                "blocked_scope_count": 1,
+                "exact_next_action": "resolve_provider_symbol_ambiguity_for_bounded_scope",
+            }
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.remediation_planning,
         "build_incomplete_artifact_remediation_planning",
         lambda **_: {
@@ -137,6 +149,7 @@ def test_current_artifacts_report_summarizes_package_and_qre_memory(monkeypatch)
     assert report["summary"]["experiment_dedup_novelty_enforcement_ready"] is True
     assert report["summary"]["research_state_sequential_retrieval_ready"] is True
     assert report["summary"]["reason_record_normalization_ready"] is True
+    assert report["summary"]["source_authority_ready"] is True
     assert report["summary"]["incomplete_artifact_remediation_planning_ready"] is True
     assert report["summary"]["final_recommendation"] == "research_memory_current_artifacts_ready"
 
@@ -268,6 +281,26 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
         },
     )
     monkeypatch.setattr(
+        current_artifacts.source_authority,
+        "build_source_identity_authority_report",
+        lambda **_: {
+            "summary": {
+                "status": "ready",
+                "ready_scope_count": 2,
+                "blocked_scope_count": 1,
+                "exact_next_action": "resolve_provider_symbol_ambiguity_for_bounded_scope",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        current_artifacts.source_authority,
+        "write_outputs",
+        lambda report, repo_root: {
+            "latest": "logs/qre_source_identity_authority_normalization/latest.json",
+            "operator_summary": "logs/qre_source_identity_authority_normalization/operator_summary.md",
+        },
+    )
+    monkeypatch.setattr(
         current_artifacts.remediation_planning,
         "build_incomplete_artifact_remediation_planning",
         lambda **_: {
@@ -347,6 +380,7 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
     assert paths["experiment_dedup_novelty_latest"] == "logs/qre_experiment_dedup_novelty_enforcement/latest.json"
     assert paths["research_state_sequential_retrieval_latest"] == "logs/qre_research_state_sequential_retrieval/latest.json"
     assert paths["reason_record_normalization_latest"] == "logs/qre_reason_record_normalization/latest.json"
+    assert paths["source_authority_latest"] == "logs/qre_source_identity_authority_normalization/latest.json"
     assert paths["incomplete_artifact_remediation_planning_latest"] == "logs/qre_incomplete_artifact_remediation_planning/latest.json"
     assert "# QRE Research Memory Current Artifacts" in markdown
 

--- a/tests/unit/test_qre_research_memory_retrieval.py
+++ b/tests/unit/test_qre_research_memory_retrieval.py
@@ -101,6 +101,19 @@ def _seed_artifacts(tmp_path: Path) -> None:
         },
     )
     _write_json(
+        tmp_path / "logs" / "qre_source_identity_authority_normalization" / "latest.json",
+        {
+            "rows": [
+                {
+                    "scope_key": "seed::trend_pullback_continuation_daily_v1::AAPL",
+                    "symbol": "AAPL",
+                    "authority_status": "blocked_provider_symbol_ambiguity",
+                    "authority_reasons": ["provider_symbol_verification_required"],
+                }
+            ]
+        },
+    )
+    _write_json(
         tmp_path / "logs" / "qre_preregistered_multiwindow_evidence_run" / "latest.json",
         {
             "window_results": [
@@ -136,8 +149,13 @@ def test_build_research_memory_retrieval_answers_required_queries(tmp_path: Path
     assert queries["presets_with_inadequate_sample_density"]["rows"][0]["preset_id"] == "trend_pullback_continuation_daily_v1"
     assert queries["recurring_evidence_or_source_failures"]["rows"][0]["count"] >= 1
     assert queries["novel_remaining_research_directions"]["rows"][0]["direction_type"] == "different_behavior_family"
+    assert (
+        queries["source_authority_remaining_scope_gaps"]["rows"][0]["authority_status"]
+        == "blocked_provider_symbol_ambiguity"
+    )
     assert queries["stale_or_superseded_knowledge"]["status"] in {"matched", "not_found"}
     assert left["authority_boundary"]["retrieval_is_context_not_truth"] is True
+    assert left["summary"]["source_authority_blocked_scope_count"] == 1
     assert left["deterministic_hash"].startswith("sha256:")
 
 

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -178,6 +178,18 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
         },
     )
     monkeypatch.setattr(
+        packet_module.source_authority,
+        "build_source_identity_authority_report",
+        lambda **_: {
+            "summary": {
+                "status": "ready",
+                "ready_scope_count": 2,
+                "blocked_scope_count": 1,
+                "exact_next_action": "resolve_provider_symbol_ambiguity_for_bounded_scope",
+            }
+        },
+    )
+    monkeypatch.setattr(
         packet_module.remediation_planning,
         "build_incomplete_artifact_remediation_planning",
         lambda **_: {
@@ -266,6 +278,8 @@ def test_trusted_loop_review_packet_reports_operator_trusted_when_evidence_chain
     assert packet["summary"]["visible_reason_record_normalized_count"] == 7
     assert packet["summary"]["visible_reason_record_invalid_count"] == 2
     assert packet["summary"]["reason_record_normalization_exact_next_action"] == "normalize_reason_record_contract_gaps_before_authority_upgrade"
+    assert packet["summary"]["source_authority_status"] == "ready"
+    assert packet["summary"]["visible_source_authority_blocked_scope_count"] == 1
     assert packet["summary"]["incomplete_artifact_remediation_planning_ready"] is True
     assert packet["summary"]["visible_incomplete_artifact_remediation_count"] == 2
     assert packet["summary"]["incomplete_artifact_remediation_exact_next_action"] == "preserve_current_read_only_artifact_visibility"
@@ -372,6 +386,18 @@ def test_trusted_loop_review_packet_fails_closed_when_evidence_chain_is_incomple
                 "research_state_sequential_retrieval_ready": False,
                 "visible_sequence_row_count": 0,
                 "exact_next_action": "restore_current_run_artifacts",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        packet_module.source_authority,
+        "build_source_identity_authority_report",
+        lambda **_: {
+            "summary": {
+                "status": "ready",
+                "ready_scope_count": 2,
+                "blocked_scope_count": 1,
+                "exact_next_action": "resolve_provider_symbol_ambiguity_for_bounded_scope",
             }
         },
     )
@@ -589,6 +615,8 @@ def test_trusted_loop_review_packet_operator_summary_renders(
     assert "# QRE Trusted Loop Review Packet" in text
     assert "trust_level: 3" in text
     assert "maintain_operator_trusted_read_only_mode" in text
+    assert "source_authority_status: ready" in text
+    assert "visible_source_authority_blocked_scope_count: 1" in text
     assert "structured_lineage_artifact_status:" in text
     assert "Authority Boundary" in text
 


### PR DESCRIPTION
## Summary
- surface source-authority gaps in research-memory retrieval and current-artifact summaries
- propagate source-authority readiness into trusted-loop and daily operator status outputs
- extend unit coverage for the new read-only source-authority visibility

## Validation
- python -m pytest tests/unit/test_qre_research_memory_retrieval.py tests/unit/test_qre_research_memory_current_artifacts.py tests/unit/test_qre_trusted_loop_review_packet.py tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/smoke -q
- python scripts/governance_lint.py
- git diff --check