### PR TITLE
fix: close controlled evaluation feedback loop

### DIFF
--- a/research/campaign_launcher.py
+++ b/research/campaign_launcher.py
@@ -492,6 +492,99 @@ CANDIDATE_REGISTRY_V1_PATH: Path = Path(
 )
 
 
+def _load_owned_gate_diagnostics(
+    *,
+    campaign_id: str,
+    path: Path = SCREENING_EVIDENCE_PATH,
+) -> dict[str, Any] | None:
+    """Return compact gate diagnostics only for campaign-owned evidence.
+
+    The latest screening-evidence sidecar is consumed only when its
+    authoritative col_campaign_id exactly matches the campaign being
+    completed. Missing, malformed, stale, or differently owned evidence
+    fails closed.
+    """
+    if not path.exists():
+        return None
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    owner = payload.get("col_campaign_id")
+    if owner is None:
+        owner = payload.get("campaign_id")
+    if owner is None or str(owner) != str(campaign_id):
+        return None
+
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        return None
+
+    def _count(key: str) -> int:
+        try:
+            return max(0, int(summary.get(key) or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    total_candidates = _count("total_candidates")
+    passed_screening = _count("passed_screening")
+    rejected_screening = _count("rejected_screening")
+    promotion_grade_candidates = _count("promotion_grade_candidates")
+    exploratory_passes = _count("exploratory_passes")
+    near_passes = _count("near_passes")
+    sufficient_oos_evidence_candidates = _count(
+        "sufficient_oos_evidence_candidates"
+    )
+
+    if total_candidates == 0:
+        classification = "unknown_empty_evidence"
+        stage = "screening"
+    elif passed_screening == 0:
+        classification = "screening_rejected_all"
+        stage = "screening"
+    elif promotion_grade_candidates == 0:
+        classification = "promotion_gate_rejected_all"
+        stage = "promotion"
+    else:
+        classification = "promotion_candidates_present"
+        stage = "promotion"
+
+    raw_reasons = summary.get("dominant_failure_reasons")
+    dominant_failure_reasons = (
+        [str(reason) for reason in raw_reasons[:10]]
+        if isinstance(raw_reasons, list)
+        else []
+    )
+
+    return {
+        "schema_version": "1.0",
+        "classification": classification,
+        "stage": stage,
+        "source_artifact": path.as_posix(),
+        "source_run_id": payload.get("run_id"),
+        "source_artifact_fingerprint": payload.get("artifact_fingerprint"),
+        "campaign_id": str(campaign_id),
+        "owner_verified": True,
+        "counts": {
+            "total_candidates": total_candidates,
+            "passed_screening": passed_screening,
+            "rejected_screening": rejected_screening,
+            "promotion_grade_candidates": promotion_grade_candidates,
+            "exploratory_passes": exploratory_passes,
+            "near_passes": near_passes,
+            "sufficient_oos_evidence_candidates": (
+                sufficient_oos_evidence_candidates
+            ),
+        },
+        "dominant_failure_reasons": dominant_failure_reasons,
+    }
+
+
 def _classify_research_rejection(
     paper_readiness_path: Path,
     candidate_registry_path: Path,
@@ -1513,6 +1606,12 @@ def _apply_decision(
     # in ``tests/unit/test_v3_15_5_outcome_invariant.py`` is the
     # primary contract; this assert exists as a runtime documentation
     # / fail-fast signal in non-optimised builds.
+    gate_diagnostics = (
+        _load_owned_gate_diagnostics(campaign_id=cid)
+        if outcome == "completed_no_survivor"
+        else None
+    )
+
     assert outcome in LAUNCHER_EMITTABLE_OUTCOMES, (  # nosec B101
         f"v3.15.5 outcome invariant violated: {outcome!r} "
         f"not in LAUNCHER_EMITTABLE_OUTCOMES"
@@ -1539,11 +1638,19 @@ def _apply_decision(
         actual_runtime_seconds=int(elapsed),
         reason_code=reason_code,
     )
+    transition_extra_updates: dict[str, Any] | None = None
+    if gate_diagnostics is not None:
+        current_record = (registry.get("campaigns") or {}).get(cid) or {}
+        merged_extra = dict(current_record.get("extra") or {})
+        merged_extra["gate_diagnostics"] = gate_diagnostics
+        transition_extra_updates = {"extra": merged_extra}
+
     registry = transition_state(
         registry,
         campaign_id=cid,
         to_state=terminal_state,  # type: ignore[arg-type]
         at_utc=finished_at,
+        extra_updates=transition_extra_updates,
     )
     new_events.append(
         make_event(
@@ -1557,6 +1664,11 @@ def _apply_decision(
             reason_code=reason_code,
             outcome=outcome,
             meaningful_classification=meaningful,
+            extra=(
+                {"gate_diagnostics": gate_diagnostics}
+                if gate_diagnostics is not None
+                else None
+            ),
         )
     )
     queue = clear_lease(queue, campaign_id=cid, to_state=terminal_state)  # type: ignore[arg-type]

--- a/research/controlled_eval.py
+++ b/research/controlled_eval.py
@@ -31,6 +31,11 @@ from research.campaign_queue import (
     load_queue,
 )
 from research.campaign_registry import REGISTRY_ARTIFACT_PATH, load_registry
+from research.dead_zone_detection import DEAD_ZONES_PATH
+from research.funnel_spawn_proposer import write_spawn_proposals_artifact
+from research.research_evidence_ledger import write_research_evidence_artifact
+from research.stop_condition_engine import write_stop_conditions_artifact
+from research.viability_metrics import write_viability_artifact
 
 CONTROLLED_EVAL_SCHEMA_VERSION: Final[str] = "1.0"
 DEFAULT_REPORT_JSON_PATH: Final[Path] = Path("research/controlled_eval_latest.v1.json")
@@ -116,6 +121,73 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     except (OSError, json.JSONDecodeError):
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _refresh_post_completion_intelligence(
+    *,
+    campaign_id: str,
+    run_campaign_payload: dict[str, Any] | None,
+    screening_evidence_payload: dict[str, Any] | None,
+    campaign_registry: dict[str, Any],
+) -> dict[str, str]:
+    """Refresh advisory intelligence after terminal campaign state is visible.
+
+    ``run_research`` writes the first intelligence snapshot before the
+    campaign launcher records terminal campaign state. This bounded refresh
+    rebuilds only non-frozen advisory sidecars from the completed registry
+    and evidence ledger.
+    """
+    now = _now_utc()
+    run_payload = run_campaign_payload or {}
+    run_id_raw = run_payload.get("run_id")
+    run_id = str(run_id_raw) if run_id_raw else None
+    git_revision_raw = run_payload.get("git_revision")
+    git_revision = str(git_revision_raw) if git_revision_raw else None
+
+    evidence_payload = write_research_evidence_artifact(
+        run_id=run_id,
+        col_campaign_id=campaign_id,
+        as_of_utc=now,
+        git_revision=git_revision,
+    )
+
+    information_gain_payload = _read_json(INFORMATION_GAIN_PATH)
+    dead_zones_payload = _read_json(DEAD_ZONES_PATH)
+
+    stop_payload = write_stop_conditions_artifact(
+        run_id=run_id,
+        as_of_utc=now,
+        git_revision=git_revision,
+        evidence_ledger=evidence_payload,
+        information_gain_history=(
+            [information_gain_payload] if information_gain_payload else None
+        ),
+    )
+
+    viability_payload = write_viability_artifact(
+        run_id=run_id,
+        as_of_utc=now,
+        git_revision=git_revision,
+        evidence_ledger=evidence_payload,
+        information_gain_history=(
+            [information_gain_payload] if information_gain_payload else None
+        ),
+    )
+
+    write_spawn_proposals_artifact(
+        run_id=run_id,
+        as_of_utc=now,
+        git_revision=git_revision,
+        screening_evidence=screening_evidence_payload,
+        evidence_ledger=evidence_payload,
+        information_gain=information_gain_payload,
+        stop_conditions=stop_payload,
+        dead_zones=dead_zones_payload,
+        viability=viability_payload,
+        campaign_registry=campaign_registry,
+    )
+
+    return build_intelligence_artifact_status()
 
 
 def _tail_text(value: str | None, *, max_chars: int = 2000) -> str:
@@ -858,6 +930,25 @@ def run_controlled_eval(
     final_registry = ds.load_sprint_registry()
     campaign_registry = load_registry(REGISTRY_ARTIFACT_PATH)
     ledger_events = load_events(LEDGER_PATH)
+    run_campaign_payload = _read_json(RUN_CAMPAIGN_PATH)
+    screening_evidence_payload = _read_json(SCREENING_EVIDENCE_PATH)
+
+    completed_this_run = [
+        campaign_id
+        for tick in ticks
+        for campaign_id in tick.completed_campaign_ids
+    ]
+    if completed_this_run:
+        intelligence_artifact_status = _refresh_post_completion_intelligence(
+            campaign_id=completed_this_run[-1],
+            run_campaign_payload=run_campaign_payload,
+            screening_evidence_payload=screening_evidence_payload,
+            campaign_registry=campaign_registry,
+        )
+        ledger_events = load_events(LEDGER_PATH)
+    else:
+        intelligence_artifact_status = build_intelligence_artifact_status()
+
     report = build_report_payload(
         profile=profile,
         max_campaigns=max_campaigns,
@@ -870,11 +961,11 @@ def run_controlled_eval(
         sprint_progress=final_progress,
         registry=campaign_registry,
         ledger_events=ledger_events,
-        run_campaign_payload=_read_json(RUN_CAMPAIGN_PATH),
-        screening_evidence_payload=_read_json(SCREENING_EVIDENCE_PATH),
+        run_campaign_payload=run_campaign_payload,
+        screening_evidence_payload=screening_evidence_payload,
         latest_policy_decision_payload=_read_json(POLICY_DECISION_PATH),
         queue_payload=load_queue(QUEUE_ARTIFACT_PATH),
-        intelligence_artifact_status=build_intelligence_artifact_status(),
+        intelligence_artifact_status=intelligence_artifact_status,
         ticks=ticks,
     )
     write_sidecar_atomic(report_json, report)

--- a/research/research_state.py
+++ b/research/research_state.py
@@ -488,10 +488,13 @@ def build_research_state_payload(
         _append_unique(next_allowed_actions, "inspect_campaign_policy_filters")
     if has_degenerate and not drop_reasons_known:
         _append_unique(next_allowed_actions, "explain_screening_drop_reasons")
-    if has_completed_no_survivor:
+    if has_completed_no_survivor and not gate_diagnostics_known:
         _append_unique(next_allowed_actions, "inspect_gate_diagnostics")
     if "viability_window_misaligned" in instrumentation_states:
-        _append_unique(next_allowed_actions, "check_evidence_window_alignment")
+        _append_unique(
+            next_allowed_actions,
+            "evidence_window_alignment_check",
+        )
     if not next_allowed_actions:
         _append_unique(next_allowed_actions, "collect_campaign_level_evidence")
 
@@ -504,9 +507,12 @@ def build_research_state_payload(
     elif has_degenerate:
         synthesis_gate = "blocked_evaluability_primary"
         next_best_test = "run_bounded_controlled_eval_after_drop_reason_review"
-    elif has_completed_no_survivor:
+    elif has_completed_no_survivor and not gate_diagnostics_known:
         synthesis_gate = "blocked_insufficient_attribution"
         next_best_test = "inspect_gate_diagnostics"
+    elif has_completed_no_survivor:
+        synthesis_gate = "not_allowed_yet"
+        next_best_test = next_allowed_actions[0]
     else:
         synthesis_gate = "not_allowed_yet"
         next_best_test = next_allowed_actions[0]

--- a/tests/unit/test_campaign_launcher_gate_diagnostics.py
+++ b/tests/unit/test_campaign_launcher_gate_diagnostics.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+from research import campaign_launcher as launcher
+from research.campaign_policy import CampaignDecision, DecisionRecord
+from research.campaign_registry import build_campaign_id
+
+
+def _write_evidence(
+    path: Path,
+    *,
+    owner: str | None,
+    summary: dict,
+    campaign_alias: str | None = None,
+) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.1",
+                "run_id": "run-owned",
+                "campaign_id": campaign_alias,
+                "col_campaign_id": owner,
+                "artifact_fingerprint": "fingerprint-1",
+                "summary": summary,
+                "candidates": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_owned_evidence_builds_promotion_gate_diagnostics(
+    tmp_path: Path,
+) -> None:
+    campaign_id = "col-owned"
+    evidence = _write_evidence(
+        tmp_path / "screening.json",
+        owner=campaign_id,
+        summary={
+            "total_candidates": 15,
+            "passed_screening": 6,
+            "rejected_screening": 9,
+            "promotion_grade_candidates": 0,
+            "exploratory_passes": 0,
+            "near_passes": 0,
+            "sufficient_oos_evidence_candidates": 1,
+            "dominant_failure_reasons": ["insufficient_trades"],
+        },
+    )
+
+    diagnostic = launcher._load_owned_gate_diagnostics(
+        campaign_id=campaign_id,
+        path=evidence,
+    )
+
+    assert diagnostic is not None
+    assert diagnostic["owner_verified"] is True
+    assert diagnostic["classification"] == "promotion_gate_rejected_all"
+    assert diagnostic["stage"] == "promotion"
+    assert diagnostic["counts"]["total_candidates"] == 15
+    assert diagnostic["counts"]["passed_screening"] == 6
+    assert diagnostic["counts"]["promotion_grade_candidates"] == 0
+    assert diagnostic["dominant_failure_reasons"] == ["insufficient_trades"]
+
+
+def test_zero_screening_passes_are_attributed_to_screening(
+    tmp_path: Path,
+) -> None:
+    evidence = _write_evidence(
+        tmp_path / "screening.json",
+        owner="col-owned",
+        summary={
+            "total_candidates": 12,
+            "passed_screening": 0,
+            "rejected_screening": 12,
+            "promotion_grade_candidates": 0,
+            "dominant_failure_reasons": ["screening_criteria_not_met"],
+        },
+    )
+
+    diagnostic = launcher._load_owned_gate_diagnostics(
+        campaign_id="col-owned",
+        path=evidence,
+    )
+
+    assert diagnostic is not None
+    assert diagnostic["classification"] == "screening_rejected_all"
+    assert diagnostic["stage"] == "screening"
+
+
+def test_mismatched_authoritative_owner_fails_closed(
+    tmp_path: Path,
+) -> None:
+    evidence = _write_evidence(
+        tmp_path / "screening.json",
+        owner="col-other",
+        campaign_alias="col-current",
+        summary={
+            "total_candidates": 15,
+            "passed_screening": 6,
+            "promotion_grade_candidates": 0,
+        },
+    )
+
+    assert (
+        launcher._load_owned_gate_diagnostics(
+            campaign_id="col-current",
+            path=evidence,
+        )
+        is None
+    )
+
+
+def test_campaign_alias_is_fallback_when_col_owner_is_absent(
+    tmp_path: Path,
+) -> None:
+    evidence = _write_evidence(
+        tmp_path / "screening.json",
+        owner=None,
+        campaign_alias="col-current",
+        summary={
+            "total_candidates": 3,
+            "passed_screening": 1,
+            "rejected_screening": 2,
+            "promotion_grade_candidates": 0,
+        },
+    )
+
+    diagnostic = launcher._load_owned_gate_diagnostics(
+        campaign_id="col-current",
+        path=evidence,
+    )
+
+    assert diagnostic is not None
+    assert diagnostic["classification"] == "promotion_gate_rejected_all"
+
+
+def test_missing_malformed_and_missing_summary_fail_closed(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing.json"
+    malformed = tmp_path / "malformed.json"
+    missing_summary = tmp_path / "missing-summary.json"
+
+    malformed.write_text("{not-json", encoding="utf-8")
+    missing_summary.write_text(
+        json.dumps(
+            {
+                "col_campaign_id": "col-current",
+                "run_id": "run-owned",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    for path in (missing, malformed, missing_summary):
+        assert (
+            launcher._load_owned_gate_diagnostics(
+                campaign_id="col-current",
+                path=path,
+            )
+            is None
+        )
+
+
+def test_negative_and_non_numeric_counts_are_bounded_to_zero(
+    tmp_path: Path,
+) -> None:
+    evidence = _write_evidence(
+        tmp_path / "screening.json",
+        owner="col-owned",
+        summary={
+            "total_candidates": "4",
+            "passed_screening": -3,
+            "rejected_screening": "invalid",
+            "promotion_grade_candidates": 0,
+        },
+    )
+
+    diagnostic = launcher._load_owned_gate_diagnostics(
+        campaign_id="col-owned",
+        path=evidence,
+    )
+
+    assert diagnostic is not None
+    assert diagnostic["counts"]["total_candidates"] == 4
+    assert diagnostic["counts"]["passed_screening"] == 0
+    assert diagnostic["counts"]["rejected_screening"] == 0
+    assert diagnostic["classification"] == "screening_rejected_all"
+
+
+def test_terminal_completed_no_survivor_persists_owned_gate_diagnostics(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    Path("research").mkdir(parents=True, exist_ok=True)
+
+    now_utc = datetime(2026, 6, 20, 12, 0, 0, tzinfo=UTC)
+    fingerprint = "owned-screening-evidence-fingerprint"
+    preset_name = "trend_pullback_equities_4h"
+    template_id = "test-template"
+
+    campaign_id = build_campaign_id(
+        preset_name=preset_name,
+        now_utc=now_utc,
+        parent_or_lineage_root="",
+        input_artifact_fingerprint=fingerprint,
+    )
+
+    Path("research/screening_evidence_latest.v1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.1",
+                "run_id": "run-owned",
+                "campaign_id": campaign_id,
+                "col_campaign_id": campaign_id,
+                "artifact_fingerprint": "screening-fingerprint",
+                "summary": {
+                    "total_candidates": 15,
+                    "passed_screening": 6,
+                    "rejected_screening": 9,
+                    "promotion_grade_candidates": 0,
+                    "exploratory_passes": 0,
+                    "near_passes": 0,
+                    "sufficient_oos_evidence_candidates": 1,
+                    "dominant_failure_reasons": ["insufficient_trades"],
+                },
+                "candidates": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    decision = CampaignDecision(
+        decision=DecisionRecord(
+            action="spawn",
+            reason="test",
+            template_id=template_id,
+            preset_name=preset_name,
+            campaign_type="daily_primary",
+            priority_tier=2,
+            spawn_reason="test",
+            parent_campaign_id=None,
+            lineage_root_campaign_id="",
+            subtype=None,
+            estimate_seconds=10,
+            extra={"input_artifact_fingerprint": fingerprint},
+        ),
+        rules_evaluated=(),
+        candidates_considered=(),
+        tie_break_key=(),
+    )
+
+    monkeypatch.setattr(
+        launcher,
+        "build_campaign_id",
+        lambda **_kwargs: campaign_id,
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_invoke_subprocess",
+        lambda **_kwargs: (0, 7.0),
+    )
+    monkeypatch.setattr(
+        launcher,
+        "add_reservation",
+        lambda budget, **_kwargs: budget,
+    )
+    monkeypatch.setattr(
+        launcher,
+        "settle_reservation",
+        lambda budget, **_kwargs: budget,
+    )
+
+    registry, queue, events = launcher._apply_decision(
+        decision=decision,
+        registry={"campaigns": {}},
+        queue={"queue": []},
+        budget=object(),
+        events=[],
+        now_utc=now_utc,
+        config=SimpleNamespace(lease_ttl_seconds=300),
+        skip_subprocess=False,
+    )
+
+    record = registry["campaigns"][campaign_id]
+    diagnostic = record["extra"]["gate_diagnostics"]
+
+    assert record["state"] == "completed"
+    assert record["outcome"] == "completed_no_survivor"
+    assert diagnostic["owner_verified"] is True
+    assert diagnostic["classification"] == "promotion_gate_rejected_all"
+    assert diagnostic["counts"]["passed_screening"] == 6
+
+    terminal_event = next(event for event in events if event.event_type == "campaign_completed")
+
+    assert terminal_event.outcome == "completed_no_survivor"
+    assert terminal_event.extra["gate_diagnostics"] == diagnostic
+
+    queue_entry = next(entry for entry in queue["queue"] if entry["campaign_id"] == campaign_id)
+    assert queue_entry["state"] == "completed"

--- a/tests/unit/test_controlled_eval.py
+++ b/tests/unit/test_controlled_eval.py
@@ -660,3 +660,280 @@ def test_launcher_invariant_violation_is_technical_failure() -> None:
     assert "technical_failure" in markdown
     assert "launcher_invariant_violation" in markdown
 
+def test_completed_campaign_refreshes_post_completion_intelligence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    completed = _completed_campaign(
+        campaign_id="col-refresh",
+        outcome="completed_no_survivor",
+        reason_code="none",
+        meaningful="duplicate_low_value_run",
+    )
+    registry_snapshots = iter(
+        [
+            _registry(),
+            _registry(completed),
+            _registry(completed),
+        ]
+    )
+    refresh_calls: list[dict] = []
+    refreshed_status = {
+        "information_gain": "present",
+        "viability": "present",
+        "stop_conditions": "present",
+        "spawn_proposals": "present",
+    }
+
+    def fake_tick(**kwargs):
+        return ce.LauncherTick(
+            tick_index=int(kwargs["tick_index"]),
+            returncode=0,
+            timed_out=False,
+            elapsed_seconds=0,
+            stdout_tail="",
+            stderr_tail="",
+            completed_campaign_ids=("col-refresh",),
+        )
+
+    def fake_refresh(**kwargs):
+        refresh_calls.append(kwargs)
+        return refreshed_status
+
+    monkeypatch.setattr(ce, "_ensure_active_sprint", lambda _profile: (True, False))
+    monkeypatch.setattr(ce.ds, "update_sprint_progress", lambda: None)
+    monkeypatch.setattr(
+        ce.ds,
+        "load_sprint_progress",
+        lambda: {"observed_total": 1, "state": "active"},
+    )
+    monkeypatch.setattr(ce.ds, "load_sprint_registry", _sprint_registry)
+    monkeypatch.setattr(ce, "load_registry", lambda _path: next(registry_snapshots))
+    monkeypatch.setattr(ce, "load_queue", lambda _path: {"queue": []})
+    monkeypatch.setattr(
+        ce,
+        "load_events",
+        lambda _path: [
+            _ledger_event(
+                campaign_id="col-refresh",
+                meaningful="duplicate_low_value_run",
+            )
+        ],
+    )
+    monkeypatch.setattr(ce, "_read_json", lambda _path: None)
+    monkeypatch.setattr(ce, "_run_launcher_tick", fake_tick)
+    monkeypatch.setattr(ce, "_refresh_post_completion_intelligence", fake_refresh)
+
+    rc = ce.run_controlled_eval(
+        profile="crypto_exploratory_v1",
+        max_campaigns=1,
+        timeout_seconds_per_campaign=60,
+        poll_seconds=0,
+        report_json=tmp_path / "controlled.json",
+        report_md=tmp_path / "controlled.md",
+    )
+
+    assert rc == 0
+    assert len(refresh_calls) == 1
+    assert refresh_calls[0]["campaign_id"] == "col-refresh"
+    assert refresh_calls[0]["campaign_registry"] == _registry(completed)
+
+    report = json.loads(
+        (tmp_path / "controlled.json").read_text(encoding="utf-8")
+    )
+    assert report["campaigns_completed"] == 1
+    assert report["intelligence_artifact_status"] == refreshed_status
+
+
+def test_no_completed_campaign_does_not_refresh_intelligence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    refresh_calls: list[dict] = []
+    missing_status = {
+        "information_gain": "missing",
+        "viability": "missing",
+        "stop_conditions": "missing",
+        "spawn_proposals": "missing",
+    }
+
+    def fake_tick(**kwargs):
+        return ce.LauncherTick(
+            tick_index=int(kwargs["tick_index"]),
+            returncode=0,
+            timed_out=False,
+            elapsed_seconds=0,
+            stdout_tail="",
+            stderr_tail="",
+            completed_campaign_ids=(),
+        )
+
+    def fake_refresh(**kwargs):
+        refresh_calls.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(ce, "_ensure_active_sprint", lambda _profile: (True, False))
+    monkeypatch.setattr(ce.ds, "update_sprint_progress", lambda: None)
+    monkeypatch.setattr(
+        ce.ds,
+        "load_sprint_progress",
+        lambda: {"observed_total": 0, "state": "active"},
+    )
+    monkeypatch.setattr(ce.ds, "load_sprint_registry", _sprint_registry)
+    monkeypatch.setattr(ce, "load_registry", lambda _path: _registry())
+    monkeypatch.setattr(ce, "load_queue", lambda _path: {"queue": []})
+    monkeypatch.setattr(ce, "load_events", lambda _path: [])
+    monkeypatch.setattr(ce, "_read_json", lambda _path: None)
+    monkeypatch.setattr(ce, "_run_launcher_tick", fake_tick)
+    monkeypatch.setattr(ce, "_refresh_post_completion_intelligence", fake_refresh)
+    monkeypatch.setattr(
+        ce,
+        "build_intelligence_artifact_status",
+        lambda: missing_status,
+    )
+
+    rc = ce.run_controlled_eval(
+        profile="crypto_exploratory_v1",
+        max_campaigns=1,
+        timeout_seconds_per_campaign=60,
+        poll_seconds=0,
+        report_json=tmp_path / "controlled.json",
+        report_md=tmp_path / "controlled.md",
+    )
+
+    assert rc == 0
+    assert refresh_calls == []
+
+    report = json.loads(
+        (tmp_path / "controlled.json").read_text(encoding="utf-8")
+    )
+    assert report["campaigns_completed"] == 0
+    assert report["intelligence_artifact_status"] == missing_status
+
+def test_refresh_post_completion_intelligence_rebuilds_dependent_sidecars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    evidence_payload = {
+        "schema_version": "1.0",
+        "hypothesis_evidence": [{"campaign_id": "col-refresh"}],
+    }
+    information_gain_payload = {
+        "information_gain": {"bucket": "low", "score": 0.2}
+    }
+    dead_zones_payload = {"dead_zones": []}
+    stop_payload = {
+        "schema_version": "1.0",
+        "decisions": [],
+    }
+    viability_payload = {
+        "schema_version": "1.0",
+        "metrics": {"campaign_count": 1},
+        "verdict": {"status": "insufficient_data"},
+    }
+    registry_payload = _registry(
+        _completed_campaign(campaign_id="col-refresh")
+    )
+    refreshed_status = {
+        "information_gain": "present",
+        "viability": "present",
+        "stop_conditions": "present",
+        "spawn_proposals": "present",
+    }
+
+    def fake_read_json(path: Path):
+        if path == ce.INFORMATION_GAIN_PATH:
+            return information_gain_payload
+        if path == ce.DEAD_ZONES_PATH:
+            return dead_zones_payload
+        raise AssertionError(f"unexpected read path: {path}")
+
+    def fake_write_evidence(**kwargs):
+        calls.append(("evidence", kwargs))
+        return evidence_payload
+
+    def fake_write_stop(**kwargs):
+        calls.append(("stop", kwargs))
+        return stop_payload
+
+    def fake_write_viability(**kwargs):
+        calls.append(("viability", kwargs))
+        return viability_payload
+
+    def fake_write_spawn(**kwargs):
+        calls.append(("spawn", kwargs))
+        return {"summary": {"proposed_count": 0}}
+
+    monkeypatch.setattr(ce, "_read_json", fake_read_json)
+    monkeypatch.setattr(
+        ce,
+        "write_research_evidence_artifact",
+        fake_write_evidence,
+    )
+    monkeypatch.setattr(
+        ce,
+        "write_stop_conditions_artifact",
+        fake_write_stop,
+    )
+    monkeypatch.setattr(
+        ce,
+        "write_viability_artifact",
+        fake_write_viability,
+    )
+    monkeypatch.setattr(
+        ce,
+        "write_spawn_proposals_artifact",
+        fake_write_spawn,
+    )
+    monkeypatch.setattr(
+        ce,
+        "build_intelligence_artifact_status",
+        lambda: refreshed_status,
+    )
+
+    result = ce._refresh_post_completion_intelligence(
+        campaign_id="col-refresh",
+        run_campaign_payload={
+            "run_id": "run-refresh",
+            "git_revision": "abc123",
+        },
+        screening_evidence_payload={
+            "summary": {"total_candidates": 8}
+        },
+        campaign_registry=registry_payload,
+    )
+
+    assert result == refreshed_status
+    assert [name for name, _kwargs in calls] == [
+        "evidence",
+        "stop",
+        "viability",
+        "spawn",
+    ]
+
+    evidence_call = calls[0][1]
+    assert evidence_call["run_id"] == "run-refresh"
+    assert evidence_call["col_campaign_id"] == "col-refresh"
+    assert evidence_call["git_revision"] == "abc123"
+
+    stop_call = calls[1][1]
+    assert stop_call["evidence_ledger"] is evidence_payload
+    assert stop_call["information_gain_history"] == [
+        information_gain_payload
+    ]
+
+    viability_call = calls[2][1]
+    assert viability_call["evidence_ledger"] is evidence_payload
+    assert viability_call["information_gain_history"] == [
+        information_gain_payload
+    ]
+
+    spawn_call = calls[3][1]
+    assert spawn_call["evidence_ledger"] is evidence_payload
+    assert spawn_call["information_gain"] is information_gain_payload
+    assert spawn_call["stop_conditions"] is stop_payload
+    assert spawn_call["viability"] is viability_payload
+    assert spawn_call["dead_zones"] is dead_zones_payload
+    assert spawn_call["campaign_registry"] is registry_payload
+

--- a/tests/unit/test_research_state.py
+++ b/tests/unit/test_research_state.py
@@ -155,6 +155,38 @@ def test_completed_no_survivor_is_stronger_evidence_than_degenerate() -> None:
     assert completed["synthesis_gate"] == "blocked_insufficient_attribution"
 
 
+def test_known_gate_diagnostics_advance_beyond_reinspection() -> None:
+    record = _record(
+        campaign_id="col-complete",
+        outcome="completed_no_survivor",
+    )
+    record["extra"] = {
+        **dict(record.get("extra") or {}),
+        "gate_diagnostics": {
+            "classification": "promotion_gate_rejected_all",
+            "stage": "promotion",
+            "owner_verified": True,
+        },
+    }
+
+    payload = _payload(
+        _artifacts(
+            campaign_registry={
+                "campaigns": {
+                    "col-complete": record,
+                }
+            }
+        )
+    )
+
+    assert payload["failure_attribution"]["state"] == "gate_rejection_attributed"
+    assert payload["failure_attribution"]["attributed"] is True
+    assert "inspect_gate_diagnostics" not in payload["next_allowed_actions"]
+    assert "collect_campaign_level_evidence" in payload["next_allowed_actions"]
+    assert payload["synthesis_gate"] == "not_allowed_yet"
+    assert payload["next_best_test"] == "collect_campaign_level_evidence"
+
+
 def test_sprint_observed_total_with_zero_viability_count_is_misaligned() -> None:
     payload = _payload(
         _artifacts(
@@ -165,7 +197,8 @@ def test_sprint_observed_total_with_zero_viability_count_is_misaligned() -> None
 
     assert "viability_window_misaligned" in payload["instrumentation_states"]
     assert "viability_window_misaligned" in payload["instrumentation_gaps"]
-    assert "check_evidence_window_alignment" in payload["next_allowed_actions"]
+    assert "evidence_window_alignment_check" in payload["next_allowed_actions"]
+    assert "check_evidence_window_alignment" not in payload["next_allowed_actions"]
 
 
 def test_missing_artifacts_are_handled_gracefully(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes the controlled-evaluation feedback loop after campaign completion.

### Changes

- Refreshes QRE intelligence artifacts after terminal campaign completion.
- Reads only campaign-owned screening evidence for terminal gate diagnostics.
- Persists gate diagnostics in both the campaign registry record and terminal ledger event.
- Prevents repeated inspect_gate_diagnostics routing once attribution is already known.
- Normalizes the evidence-window action ID to evidence_window_alignment_check.
- Advances attributed no-survivor outcomes to the safe next action:
  collect_campaign_level_evidence.

## Safety

- No strategy, preset, template, screening-threshold, or promotion-criteria changes.
- No paper, shadow, live, broker, risk, or execution changes.
- No new campaign was run.
- Stale or differently owned screening evidence fails closed.

## Validation

- 56 targeted regression tests passed.
- 38 launcher-related tests passed.
- New and modified tests pass Ruff.
- git diff --check passed.
- Worktree was clean before push.

## Commits

- 