### PR TITLE
fix: align research action plan with attributed state

### DIFF
--- a/research/research_action_plan.py
+++ b/research/research_action_plan.py
@@ -48,6 +48,7 @@ AUTOMATIC_ACTION_IDS: Final[tuple[str, ...]] = (
     "inspect_campaign_policy_filters",
     "explain_screening_drop_reasons",
     "inspect_gate_diagnostics",
+    "collect_campaign_level_evidence",
     "controlled_eval_bounded",
     "disposable_workspace_eval",
     "evidence_window_alignment_check",
@@ -272,7 +273,6 @@ def _automatic_actions(
 ) -> list[dict[str, Any]]:
     actions: list[dict[str, Any]] = []
     policy_state = state.get("policy_state")
-    preset_state = state.get("preset_state")
     failure_attribution = _dict_value(state.get("failure_attribution"))
     failure_state = failure_attribution.get("state")
     evidence_quality = _dict_value(state.get("evidence_quality"))
@@ -324,7 +324,11 @@ def _automatic_actions(
             ),
         )
 
-    if preset_state == "completed_no_survivor":
+    next_allowed_actions = state.get("next_allowed_actions")
+    if not isinstance(next_allowed_actions, list):
+        next_allowed_actions = []
+
+    if "inspect_gate_diagnostics" in next_allowed_actions:
         _append_unique(
             actions,
             _action(
@@ -332,12 +336,36 @@ def _automatic_actions(
                 action_type="diagnostic",
                 priority=3 if policy_state == "blocked_no_candidates" else 2,
                 allowed_mode="automatic_bounded",
-                reason_codes=["preset_completed_no_survivor"],
+                reason_codes=["gate_diagnostics_requested_by_research_state"],
                 expected_outputs=["gate diagnostic summary from existing campaign evidence"],
                 max_scope="Inspect validation and promotion gate evidence without changing gates.",
                 stop_conditions=[
                     "gate diagnostics are absent",
                     "next step would require changing promotion criteria",
+                ],
+            ),
+        )
+
+    if "collect_campaign_level_evidence" in next_allowed_actions:
+        _append_unique(
+            actions,
+            _action(
+                action_id="collect_campaign_level_evidence",
+                action_type="evidence_collection",
+                priority=2,
+                allowed_mode="automatic_bounded",
+                reason_codes=["campaign_level_evidence_requested_by_research_state"],
+                expected_outputs=[
+                    "campaign-level evidence summary from existing research artifacts"
+                ],
+                max_scope=(
+                    "Collect and summarize existing campaign-level evidence "
+                    "without changing presets, gates, budgets, or strategies."
+                ),
+                stop_conditions=[
+                    "required campaign evidence is unavailable",
+                    "collection would require launching a new campaign",
+                    "next step would require changing research criteria",
                 ],
             ),
         )

--- a/tests/unit/test_research_action_plan.py
+++ b/tests/unit/test_research_action_plan.py
@@ -126,6 +126,7 @@ def test_completed_no_survivor_adds_gate_diagnostics() -> None:
                 "primary_blocker": "validation_or_promotion_gate",
                 "missing": ["gate_diagnostics"],
             },
+            next_allowed_actions=["inspect_gate_diagnostics"],
             synthesis_gate="blocked_insufficient_attribution",
             next_best_test="inspect_gate_diagnostics",
         )
@@ -133,6 +134,31 @@ def test_completed_no_survivor_adds_gate_diagnostics() -> None:
 
     assert payload["next_best_action"]["action_id"] == "inspect_gate_diagnostics"
     assert "inspect_gate_diagnostics" in _action_ids(payload)
+
+
+def test_attributed_gate_rejection_collects_campaign_evidence() -> None:
+    payload = _payload(
+        _state(
+            policy_state="can_spawn",
+            failure_attribution={
+                "state": "gate_rejection_attributed",
+                "attributed": True,
+                "primary_blocker": "validation_or_promotion_gate",
+                "missing": [],
+            },
+            next_allowed_actions=["collect_campaign_level_evidence"],
+            synthesis_gate="not_allowed_yet",
+            next_best_test="collect_campaign_level_evidence",
+        )
+    )
+
+    automatic_ids = _action_ids(payload)
+
+    assert payload["next_best_action"]["action_id"] == (
+        "collect_campaign_level_evidence"
+    )
+    assert "collect_campaign_level_evidence" in automatic_ids
+    assert "inspect_gate_diagnostics" not in automatic_ids
 
 
 def test_synthesis_blocked_state_prevents_automatic_synthesis() -> None:
@@ -157,12 +183,17 @@ def test_forbidden_trading_actions_are_always_present() -> None:
     assert {"broker_changes", "risk_changes", "execution_changes"} <= forbidden
 
 
-def test_missing_research_state_is_handled_gracefully(tmp_path: Path) -> None:
+def test_missing_research_state_is_handled_gracefully(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
     payload = _payload(None, _statuses(research_state_status="missing"))
 
     assert payload["state_summary"]["source_research_state_status"] == "missing"
     assert payload["next_best_action"]["action_id"] == "inspect_gate_diagnostics"
     assert payload["synthesis_status"]["status"] == "blocked"
+
+    monkeypatch.chdir(tmp_path)
 
     rc = rap.main(
         [


### PR DESCRIPTION
## Summary

Aligns the research action plan with the authoritative routing already produced by research state.

## Changes

- Adds collect_campaign_level_evidence as a bounded automatic action.
- Uses esearch_state.next_allowed_actions as the routing source.
- Adds inspect_gate_diagnostics only when research state explicitly requests it.
- Prevents repeated diagnostic inspection after gate rejection has already been attributed.
- Isolates the missing-state CLI test from local runtime artifacts.

## Validation

- 57 targeted regression tests passed.
- Ruff passed.
- git diff --check passed.
- End-to-end local artifact verification passed:
  - gate rejection attributed;
  - next state action is collect_campaign_level_evidence;
  - action plan selects the same action;
  - inspect_gate_diagnostics is absent.

## Safety

- No strategy, preset, template, budget, screening, or promotion criteria changes.
- No campaign launch.
- No paper, shadow, live, broker, risk, or execution changes.