### PR TITLE
feat: add generic campaign evidence loop

### DIFF
--- a/research/campaign_evidence_decision.py
+++ b/research/campaign_evidence_decision.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
 
+from research.presets import get_preset
 from research.qre_failure_to_action_mapper import map_failure_to_action
 
 SCHEMA_VERSION: Final[str] = "1.0"
@@ -40,6 +41,15 @@ ALLOWED_OUTPUT_PATHS: Final[tuple[str, ...]] = (
 
 def _text(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _preset_timeframe(preset_name: str) -> str:
+    try:
+        preset = get_preset(preset_name)
+    except KeyError:
+        return ""
+
+    return _text(preset.timeframe)
 
 
 def _unique_in_order(values: Sequence[Any]) -> list[str]:
@@ -138,13 +148,20 @@ def _campaign_scope(
         else []
     )
 
+    preset_name = (
+        _text(registry_record.get("preset_name"))
+        or _text(evidence_campaign.get("preset_name"))
+    )
+    timeframe = (
+        _text(registry_record.get("timeframe"))
+        or _preset_timeframe(preset_name)
+    )
+
     return {
         "campaign_id": campaign_id,
         "hypothesis_id": _text(registry_record.get("hypothesis_id")),
-        "preset_name": (
-            _text(registry_record.get("preset_name"))
-            or _text(evidence_campaign.get("preset_name"))
-        ),
+        "preset_name": preset_name,
+        "timeframe": timeframe,
         "template_id": _text(registry_record.get("template_id")),
         "strategy_family": (
             _text(registry_record.get("strategy_family"))

--- a/research/campaign_launcher.py
+++ b/research/campaign_launcher.py
@@ -215,30 +215,29 @@ def _cli_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _resolve_metadata_for_preset(
+def _resolve_scope_metadata_for_preset(
     preset_name: str,
-) -> tuple[str | None, str | None, str | None, tuple[str, ...]]:
-    """Resolve registry metadata for ``preset_name`` (v3.15.15.8).
+) -> tuple[
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    tuple[str, ...],
+]:
+    """Resolve immutable campaign scope from the canonical preset catalog.
 
-    Returns ``(hypothesis_id, strategy_family, asset_class, universe)``
-    derived from the preset catalog + the strategy hypothesis catalog.
-    Pure read; never raises. Unknown / mis-shaped presets, presets
-    without a ``hypothesis_id``, and hypothesis-ids the catalog doesn't
-    know about are all tolerated and produce ``None`` for the
-    corresponding field. ``universe`` is always a tuple — empty when
-    the preset is not resolvable.
-
-    Boundary rule (per the v3.15.15.8 audit): each return value is
-    (a) known at spawn time, (b) stable for the campaign's lifetime,
-    and (c) needed for failure clustering. Per-run detail does NOT
-    flow through this helper.
+    Returns hypothesis id, strategy family, asset class, timeframe and
+    universe. Unknown presets fail closed with null metadata and an empty
+    universe.
     """
     try:
         preset = get_preset(preset_name)
     except KeyError:
-        return None, None, None, ()
+        return None, None, None, None, ()
+
     hypothesis_id = preset.hypothesis_id
     strategy_family: str | None = None
+
     if hypothesis_id is not None:
         try:
             hypothesis = _hypothesis_get_by_id_from_catalog(
@@ -247,10 +246,35 @@ def _resolve_metadata_for_preset(
             )
         except KeyError:
             hypothesis = None
+
         if hypothesis is not None:
             strategy_family = hypothesis.strategy_family
+
     asset_class = infer_asset_class(tuple(preset.universe))
+    timeframe = str(preset.timeframe or "").strip() or None
     universe = tuple(preset.universe)
+
+    return (
+        hypothesis_id,
+        strategy_family,
+        asset_class,
+        timeframe,
+        universe,
+    )
+
+
+def _resolve_metadata_for_preset(
+    preset_name: str,
+) -> tuple[str | None, str | None, str | None, tuple[str, ...]]:
+    """Backward-compatible four-field registry metadata resolver."""
+    (
+        hypothesis_id,
+        strategy_family,
+        asset_class,
+        _timeframe,
+        universe,
+    ) = _resolve_scope_metadata_for_preset(preset_name)
+
     return hypothesis_id, strategy_family, asset_class, universe
 
 
@@ -270,9 +294,13 @@ def _build_record(
     subtype: str | None,
     extra: dict[str, Any] | None = None,
 ) -> CampaignRecord:
-    hypothesis_id, strategy_family, asset_class, universe = (
-        _resolve_metadata_for_preset(preset_name)
-    )
+    (
+        hypothesis_id,
+        strategy_family,
+        asset_class,
+        timeframe,
+        universe,
+    ) = _resolve_scope_metadata_for_preset(preset_name)
     return CampaignRecord(
         campaign_id=campaign_id,
         template_id=template_id,
@@ -290,6 +318,7 @@ def _build_record(
         hypothesis_id=hypothesis_id,
         strategy_family=strategy_family,
         asset_class=asset_class,
+        timeframe=timeframe,
         universe=universe,
         extra=dict(extra) if extra else {},
     )

--- a/research/campaign_preregistered_multiwindow_evidence_run.py
+++ b/research/campaign_preregistered_multiwindow_evidence_run.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_preregistered_multiwindow_evidence_run as multiwindow
+from research import qre_sampling_plan as sampling
+
+DEFAULT_CAMPAIGN_PLAN_PATH: Final[Path] = Path(
+    "research/campaign_preregistered_sampling_plan_latest.v1.json"
+)
+DEFAULT_APPROVAL_PATH: Final[Path] = multiwindow.DEFAULT_APPROVAL_PATH
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path.as_posix()}")
+    return payload
+
+
+def _proposal_scope(proposal: Mapping[str, Any]) -> dict[str, Any]:
+    scope = proposal.get("campaign_scope")
+    return dict(scope) if isinstance(scope, Mapping) else {}
+
+
+def validate_proposal_approval_binding(
+    *,
+    proposal: Mapping[str, Any],
+    approval_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate exact operator approval binding for a campaign proposal."""
+    if _text(proposal.get("proposal_status")) != "proposal_ready_coverage_required":
+        raise ValueError("campaign_sampling_proposal_not_coverage_ready")
+    authority = proposal.get("authority")
+    authority = authority if isinstance(authority, Mapping) else {}
+    if (
+        _text(authority.get("action_authority")) != "report_only"
+        or authority.get("approval_required_before_execution") is not True
+    ):
+        raise ValueError("invalid_campaign_sampling_proposal_authority")
+    safety = proposal.get("safety_invariants")
+    safety = safety if isinstance(safety, Mapping) else {}
+    if not safety or any(value is not False for value in safety.values()):
+        raise ValueError("unsafe_campaign_sampling_proposal")
+
+    scope = _proposal_scope(proposal)
+    approval_scope = approval_manifest.get("scope")
+    approval_scope = (
+        dict(approval_scope) if isinstance(approval_scope, Mapping) else {}
+    )
+    expected = {
+        "campaign_id": _text(scope.get("campaign_id")),
+        "proposal_id": _text(proposal.get("proposal_id")),
+        "proposal_hash": _text(proposal.get("hash")),
+        "preset_id": _text(scope.get("preset_name")),
+        "timeframe": _text(scope.get("timeframe")),
+    }
+    for field, expected_value in expected.items():
+        if not expected_value or _text(approval_scope.get(field)) != expected_value:
+            raise ValueError(f"campaign_proposal_approval_scope_mismatch:{field}")
+
+    expected_symbols = sorted(
+        {_text(value).upper() for value in scope.get("universe") or [] if _text(value)}
+    )
+    approved_symbols = sorted(
+        {
+            _text(value).upper()
+            for value in approval_scope.get("symbols") or []
+            if _text(value)
+        }
+    )
+    if not expected_symbols or approved_symbols != expected_symbols:
+        raise ValueError("campaign_proposal_approval_scope_mismatch:symbols")
+    if bool(approval_manifest.get("external_fetch_allowed", False)):
+        raise ValueError("campaign_proposal_external_fetch_not_allowed")
+    return scope
+
+
+def materialize_campaign_sampling_plan(
+    *,
+    proposal: Mapping[str, Any],
+    approval_manifest: Mapping[str, Any],
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    """Derive locked windows from local cache without changing research scope."""
+    scope = validate_proposal_approval_binding(
+        proposal=proposal,
+        approval_manifest=approval_manifest,
+    )
+    coverage = proposal.get("coverage_requirements")
+    coverage = coverage if isinstance(coverage, Mapping) else {}
+    source_plan = proposal.get("sampling_plan")
+    source_plan = source_plan if isinstance(source_plan, Mapping) else {}
+    if sampling.validate_sampling_plan(source_plan).get("valid") is not True:
+        raise ValueError("invalid_campaign_sampling_plan_contract")
+
+    symbols = sorted(
+        {_text(value).upper() for value in scope.get("universe") or [] if _text(value)}
+    )
+    timeframe = _text(scope.get("timeframe"))
+    common_dates = multiwindow._load_common_trading_dates(
+        repo_root,
+        symbols=symbols,
+        timeframe=timeframe,
+    )
+    window_count = int(coverage.get("window_count") or 0)
+    minimum_window_length = int(coverage.get("minimum_window_length") or 0)
+    minimum_warmup_period = int(coverage.get("minimum_warmup_period") or 0)
+    minimum_dates = int(coverage.get("minimum_common_trading_dates") or 0)
+    if len(common_dates) < minimum_dates:
+        raise ValueError("insufficient_common_local_trading_dates")
+
+    windows = sampling.derive_preregistered_windows(
+        trading_dates=common_dates,
+        window_count=window_count,
+        minimum_window_length=minimum_window_length,
+        minimum_warmup_period=minimum_warmup_period,
+    )
+    approval_scope = approval_manifest.get("scope")
+    approval_scope = approval_scope if isinstance(approval_scope, Mapping) else {}
+    plan = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref=_text(source_plan.get("hypothesis_ref")),
+        behavior_id=_text(source_plan.get("behavior_id")),
+        preset_id=_text(source_plan.get("preset_id")),
+        timeframe=timeframe,
+        bounded_source_data_availability={
+            "status": "materialized_from_local_cache",
+            "local_only": True,
+            "source_data_ref": _text(approval_scope.get("source_data_ref")),
+            "symbols": symbols,
+            "common_trading_date_count": len(common_dates),
+            "timeframe": timeframe,
+        },
+        proposed_total_validation_range={
+            "status": "materialized",
+            "start": common_dates[0],
+            "end": common_dates[-1],
+            "common_trading_date_count": len(common_dates),
+            "window_count": window_count,
+        },
+        minimum_window_length=minimum_window_length,
+        minimum_warmup_period=minimum_warmup_period,
+        required_oos_evidence_types=list(
+            source_plan.get("required_oos_evidence_types") or []
+        ),
+        null_control_definitions=list(
+            source_plan.get("null_control_definitions") or []
+        ),
+        known_previous_failed_windows=list(
+            source_plan.get("known_previous_failed_windows") or []
+        ),
+        regime_buckets=list(source_plan.get("regime_buckets") or []),
+        window_definitions=windows,
+        preregistration_timestamp=_text(
+            source_plan.get("preregistration_timestamp")
+        ),
+        minimum_trade_requirement=int(
+            source_plan.get("minimum_trade_requirement") or 1
+        ),
+        selection_policy=_text(source_plan.get("selection_policy")),
+        forbidden_adaptations=list(
+            source_plan.get("forbidden_adaptations") or []
+        ),
+    )
+    validation = sampling.validate_sampling_plan(plan)
+    if validation.get("valid") is not True:
+        raise ValueError("materialized_sampling_plan_contract_invalid")
+    if _text(plan.get("status")) != "sampling_plan_ready_context_only":
+        raise ValueError("materialized_sampling_plan_not_ready")
+    return plan
+
+
+def build_campaign_preregistered_multiwindow_evidence_run(
+    *,
+    proposal: Mapping[str, Any],
+    approval_manifest: Mapping[str, Any],
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    """Execute only the locked plan derived from the approved proposal."""
+    scope = validate_proposal_approval_binding(
+        proposal=proposal,
+        approval_manifest=approval_manifest,
+    )
+    plan = materialize_campaign_sampling_plan(
+        proposal=proposal,
+        approval_manifest=approval_manifest,
+        repo_root=repo_root,
+    )
+    return multiwindow.build_preregistered_multiwindow_evidence_run(
+        approval_manifest=approval_manifest,
+        repo_root=repo_root,
+        sampling_plan_payload=plan,
+        campaign_scope=scope,
+        proposal_id=_text(proposal.get("proposal_id")),
+        proposal_hash=_text(proposal.get("hash")),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.campaign_preregistered_multiwindow_evidence_run",
+        description="Execute an operator-approved campaign sampling proposal.",
+    )
+    parser.add_argument(
+        "--campaign-plan-file",
+        default=DEFAULT_CAMPAIGN_PLAN_PATH.as_posix(),
+    )
+    parser.add_argument(
+        "--approval-file",
+        default=DEFAULT_APPROVAL_PATH.as_posix(),
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_campaign_preregistered_multiwindow_evidence_run(
+        proposal=_read_json(Path(args.campaign_plan_file)),
+        approval_manifest=_read_json(Path(args.approval_file)),
+    )
+    if args.write:
+        report["_artifact_paths"] = multiwindow.write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/campaign_preregistered_sampling_plan.py
+++ b/research/campaign_preregistered_sampling_plan.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_sampling_plan as sampling
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "campaign_preregistered_sampling_plan"
+DECISION_PATH: Final[Path] = Path(
+    "research/campaign_evidence_decision_latest.v1.json"
+)
+DEFAULT_JSON_OUTPUT_PATH: Final[Path] = Path(
+    "research/campaign_preregistered_sampling_plan_latest.v1.json"
+)
+DEFAULT_MARKDOWN_OUTPUT_PATH: Final[Path] = Path(
+    "research/campaign_preregistered_sampling_plan_latest.md"
+)
+REQUIRED_RECOMMENDATION: Final[str] = "create_preregistered_sampling_plan"
+REQUIRED_ACTION_AUTHORITY: Final[str] = "report_only"
+SAFETY_KEYS: Final[tuple[str, ...]] = (
+    "can_execute",
+    "can_spawn_campaigns",
+    "can_mutate_queue",
+    "can_change_policy",
+    "can_change_presets",
+    "can_change_strategy",
+    "can_access_paper_shadow_live",
+)
+REQUIRED_SCOPE_FIELDS: Final[tuple[str, ...]] = (
+    "campaign_id",
+    "hypothesis_id",
+    "preset_name",
+    "timeframe",
+    "template_id",
+    "strategy_family",
+    "asset_class",
+)
+FAILURE_POLICIES: Final[dict[str, dict[str, Any]]] = {
+    "insufficient_window_length": {
+        "window_count": 2,
+        "minimum_window_length": 20,
+        "minimum_warmup_period": 10,
+        "minimum_trade_requirement": 1,
+        "required_oos_evidence_types": [
+            "structured_lineage_artifact",
+            "structured_oos_artifact",
+        ],
+        "null_control_definitions": [
+            {
+                "control_id": "null_preregistered_holdout",
+                "control_kind": "holdout",
+                "required_for_evidence_complete": True,
+                "required_for_fail_closed_rejection": False,
+            }
+        ],
+    }
+}
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _unique_in_order(values: Sequence[Any]) -> list[str]:
+    return list(dict.fromkeys(_text(value) for value in values if _text(value)))
+
+
+def _read_json(path: Path) -> tuple[str, dict[str, Any] | None]:
+    if not path.exists():
+        return "missing", None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "malformed", None
+    if not isinstance(payload, dict):
+        return "malformed", None
+    return "present", payload
+
+
+def _report_hash(report: Mapping[str, Any]) -> str:
+    canonical = {
+        key: value
+        for key, value in report.items()
+        if key not in {"hash", "proposal_id", "_artifact_paths"}
+    }
+    blob = json.dumps(
+        canonical,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return hashlib.sha256(blob.encode()).hexdigest()
+
+
+def _finalize(report: dict[str, Any]) -> dict[str, Any]:
+    digest = _report_hash(report)
+    report["proposal_id"] = f"cpsp_{digest[:16]}"
+    report["hash"] = _report_hash(report)
+    return report
+
+
+def _base_report(
+    *,
+    decision: Mapping[str, Any] | None,
+    preregistration_timestamp: str,
+    decision_input_status: str,
+) -> dict[str, Any]:
+    payload = decision if isinstance(decision, Mapping) else {}
+    scope = payload.get("campaign_scope")
+    scope = dict(scope) if isinstance(scope, Mapping) else {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "proposal_status": "blocked_malformed_decision",
+        "blocked_reasons": [],
+        "campaign_scope": scope,
+        "decision_trigger": {
+            "decision_status": _text(payload.get("decision_status")),
+            "recommended_action": _text(payload.get("recommended_action")),
+            "action_authority": _text(payload.get("action_authority")),
+            "failure_class": _text(payload.get("failure_class")),
+            "reason_codes": _unique_in_order(payload.get("reason_codes") or []),
+            "prerequisites": _unique_in_order(payload.get("prerequisites") or []),
+        },
+        "preregistration_timestamp": _text(preregistration_timestamp),
+        "coverage_requirements": {},
+        "sampling_plan": {},
+        "sampling_plan_validation": {},
+        "provenance": {
+            "decision_ref": DECISION_PATH.as_posix(),
+            "selected_source": _text(payload.get("selected_source")),
+            "evidence_refs": _unique_in_order(payload.get("evidence_refs") or []),
+        },
+        "artifact_inputs": {
+            "campaign_evidence_decision": {
+                "path": DECISION_PATH.as_posix(),
+                "status": decision_input_status,
+            }
+        },
+        "authority": {
+            "action_authority": REQUIRED_ACTION_AUTHORITY,
+            "approval_required_before_execution": True,
+            "evidence_authority": "context_only",
+        },
+        "safety_invariants": {key: False for key in SAFETY_KEYS},
+    }
+
+
+def build_campaign_preregistered_sampling_plan(
+    *,
+    decision: Mapping[str, Any] | None,
+    preregistration_timestamp: str,
+    decision_input_status: str = "present",
+) -> dict[str, Any]:
+    report = _base_report(
+        decision=decision,
+        preregistration_timestamp=preregistration_timestamp,
+        decision_input_status=decision_input_status,
+    )
+    if decision_input_status != "present":
+        report["proposal_status"] = f"blocked_{decision_input_status}_decision"
+        report["blocked_reasons"] = [
+            f"campaign_evidence_decision_{decision_input_status}"
+        ]
+        return _finalize(report)
+    if not isinstance(decision, Mapping):
+        report["proposal_status"] = "blocked_malformed_decision"
+        report["blocked_reasons"] = ["campaign_evidence_decision_malformed"]
+        return _finalize(report)
+
+    trigger = report["decision_trigger"]
+    if (
+        trigger["decision_status"] != "decision_ready"
+        or trigger["recommended_action"] != REQUIRED_RECOMMENDATION
+        or trigger["action_authority"] != REQUIRED_ACTION_AUTHORITY
+    ):
+        report["proposal_status"] = "blocked_unsupported_decision"
+        report["blocked_reasons"] = ["decision_not_sampling_plan_eligible"]
+        return _finalize(report)
+
+    input_safety = decision.get("safety_invariants")
+    input_safety = input_safety if isinstance(input_safety, Mapping) else {}
+    unsafe_keys = [key for key in SAFETY_KEYS if input_safety.get(key) is not False]
+    if unsafe_keys:
+        report["proposal_status"] = "blocked_unsafe_decision_authority"
+        report["blocked_reasons"] = [
+            f"decision_safety_invariant_not_false:{key}" for key in unsafe_keys
+        ]
+        return _finalize(report)
+
+    scope = report["campaign_scope"]
+    missing_scope = [field for field in REQUIRED_SCOPE_FIELDS if not _text(scope.get(field))]
+    if scope.get("registry_record_present") is not True:
+        missing_scope.append("registry_record_present")
+    universe = scope.get("universe")
+    if not isinstance(universe, list) or not _unique_in_order(universe):
+        missing_scope.append("universe")
+    if missing_scope:
+        report["proposal_status"] = "blocked_incomplete_campaign_scope"
+        report["blocked_reasons"] = [
+            f"missing_campaign_scope:{field}" for field in _unique_in_order(missing_scope)
+        ]
+        return _finalize(report)
+
+    if not _text(preregistration_timestamp):
+        report["proposal_status"] = "blocked_missing_preregistration_timestamp"
+        report["blocked_reasons"] = ["missing_preregistration_timestamp"]
+        return _finalize(report)
+
+    failure_class = trigger["failure_class"]
+    policy = FAILURE_POLICIES.get(failure_class)
+    if policy is None:
+        report["proposal_status"] = "blocked_unsupported_failure_class"
+        report["blocked_reasons"] = [f"unsupported_failure_class:{failure_class}"]
+        return _finalize(report)
+
+    window_count = int(policy["window_count"])
+    minimum_window_length = int(policy["minimum_window_length"])
+    minimum_warmup_period = int(policy["minimum_warmup_period"])
+    universe = _unique_in_order(universe)
+    report["campaign_scope"]["universe"] = sorted(universe)
+    report["coverage_requirements"] = {
+        "local_only": True,
+        "window_count": window_count,
+        "minimum_window_length": minimum_window_length,
+        "minimum_warmup_period": minimum_warmup_period,
+        "minimum_common_trading_dates": window_count * minimum_window_length,
+        "window_derivation_policy": "deterministic_non_overlapping_partition",
+        "regime_assignment_policy": "unclassified_unless_explicitly_preregistered",
+        "required_oos_evidence_types": list(policy["required_oos_evidence_types"]),
+    }
+    plan = sampling.build_preregistered_sampling_plan(
+        hypothesis_ref=_text(scope.get("hypothesis_id")),
+        behavior_id=_text(scope.get("strategy_family")),
+        preset_id=_text(scope.get("preset_name")),
+        timeframe=_text(scope.get("timeframe")),
+        bounded_source_data_availability={
+            "status": "not_materialized",
+            "local_only": True,
+            "symbols": sorted(universe),
+            "timeframe": _text(scope.get("timeframe")),
+        },
+        proposed_total_validation_range={
+            "status": "coverage_required",
+            "minimum_common_trading_dates": window_count * minimum_window_length,
+            "window_count": window_count,
+        },
+        minimum_window_length=minimum_window_length,
+        minimum_warmup_period=minimum_warmup_period,
+        required_oos_evidence_types=policy["required_oos_evidence_types"],
+        null_control_definitions=policy["null_control_definitions"],
+        window_count=window_count,
+        preregistration_timestamp=_text(preregistration_timestamp),
+        minimum_trade_requirement=int(policy["minimum_trade_requirement"]),
+    )
+    validation = sampling.validate_sampling_plan(plan)
+    report["sampling_plan"] = plan
+    report["sampling_plan_validation"] = validation
+    if validation.get("valid") is not True:
+        report["proposal_status"] = "blocked_invalid_sampling_plan_contract"
+        report["blocked_reasons"] = list(validation.get("rejection_reasons") or [])
+        return _finalize(report)
+
+    report["proposal_status"] = "proposal_ready_coverage_required"
+    report["blocked_reasons"] = []
+    return _finalize(report)
+
+
+def build_from_current_decision(
+    *,
+    preregistration_timestamp: str,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    status, decision = _read_json(repo_root / DECISION_PATH)
+    return build_campaign_preregistered_sampling_plan(
+        decision=decision,
+        preregistration_timestamp=preregistration_timestamp,
+        decision_input_status=status,
+    )
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    scope = report.get("campaign_scope")
+    scope = scope if isinstance(scope, Mapping) else {}
+    coverage = report.get("coverage_requirements")
+    coverage = coverage if isinstance(coverage, Mapping) else {}
+    safety = report.get("safety_invariants")
+    safety = safety if isinstance(safety, Mapping) else {}
+    lines = [
+        "# Campaign Preregistered Sampling Plan",
+        "",
+        f"- proposal_status: {report.get('proposal_status', '')}",
+        f"- proposal_id: {report.get('proposal_id', '')}",
+        f"- campaign_id: {scope.get('campaign_id', '')}",
+        f"- hypothesis_id: {scope.get('hypothesis_id', '')}",
+        f"- preset_name: {scope.get('preset_name', '')}",
+        f"- timeframe: {scope.get('timeframe', '')}",
+        f"- window_count: {coverage.get('window_count', '')}",
+        f"- minimum_common_trading_dates: {coverage.get('minimum_common_trading_dates', '')}",
+        f"- action_authority: {(report.get('authority') or {}).get('action_authority', '')}",
+        f"- can_execute: {safety.get('can_execute', False)}",
+        "",
+        "## Blocked reasons",
+        "",
+    ]
+    reasons = list(report.get("blocked_reasons") or [])
+    lines.extend(f"- {reason}" for reason in reasons)
+    if not reasons:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _validate_write_target(path: Path, *, repo_root: Path) -> None:
+    allowed = {
+        (repo_root / DEFAULT_JSON_OUTPUT_PATH).resolve(),
+        (repo_root / DEFAULT_MARKDOWN_OUTPUT_PATH).resolve(),
+    }
+    if path.resolve() not in allowed:
+        raise ValueError(f"{REPORT_KIND}: refusing write outside allowlist: {path!r}")
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(content, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    json_path = repo_root / DEFAULT_JSON_OUTPUT_PATH
+    markdown_path = repo_root / DEFAULT_MARKDOWN_OUTPUT_PATH
+    for target in (json_path, markdown_path):
+        _validate_write_target(target, repo_root=repo_root)
+    _atomic_write_text(
+        json_path,
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+    )
+    _atomic_write_text(markdown_path, render_markdown(report))
+    return {
+        "json": DEFAULT_JSON_OUTPUT_PATH.as_posix(),
+        "markdown": DEFAULT_MARKDOWN_OUTPUT_PATH.as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.campaign_preregistered_sampling_plan",
+        description="Build a report-only campaign-scoped sampling-plan proposal.",
+    )
+    parser.add_argument("--from-current-decision", action="store_true", required=True)
+    parser.add_argument("--preregistered-at", required=True)
+    parser.add_argument("--no-write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_from_current_decision(
+        preregistration_timestamp=args.preregistered_at,
+    )
+    if not args.no_write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/campaign_registry.py
+++ b/research/campaign_registry.py
@@ -177,7 +177,7 @@ class CampaignRecord:
     asset_class: str | None = None
     reason_code: str | None = None
     # v3.15.15.8 — registry metadata enrichment. Populated at spawn time
-    # by ``campaign_launcher._resolve_metadata_for_preset`` from the
+    # by ``campaign_launcher._resolve_scope_metadata_for_preset`` from the
     # preset + hypothesis catalog. Defaults preserve backward-compat for
     # legacy records loaded via ``load_registry`` (those records simply
     # lack these keys; consumers use ``dict.get`` with null-tolerance).
@@ -187,6 +187,7 @@ class CampaignRecord:
     # failure clustering / dead-zone detection. Per-run / per-candidate
     # detail does NOT belong here — it lives in evidence sidecars.
     hypothesis_id: str | None = None
+    timeframe: str | None = None
     universe: tuple[str, ...] = ()
     extra: dict[str, Any] = field(default_factory=dict)
 

--- a/research/qre_approved_bounded_evidence_materialization.py
+++ b/research/qre_approved_bounded_evidence_materialization.py
@@ -18,7 +18,7 @@ from research import qre_bounded_current_basket_generation_runner as runner
 from research import qre_bounded_generation_artifact_acceptance_verifier as verifier
 from research import qre_bounded_validation_approval_gate as approval_gate
 from research import qre_evidence_complete_basket_closure as closure
-
+from research.presets import get_preset, resolve_preset_bundle
 
 SCHEMA_VERSION: Final[str] = "1.0"
 REPORT_KIND: Final[str] = "qre_approved_bounded_evidence_materialization"
@@ -46,11 +46,39 @@ ALLOWED_OUTPUT_PATHS: Final[tuple[str, ...]] = (
 )
 TIMEFRAME_TO_INTERVAL: Final[dict[str, str]] = {
     "daily_v1": "1d",
+    "1d": "1d",
+    "1h": "1h",
+    "4h": "4h",
 }
 
 
 class ApprovedBoundedEvidenceError(RuntimeError):
     pass
+
+
+def _resolve_single_preset_strategy(preset_id: str) -> tuple[str, Any]:
+    """Resolve one executable strategy from the canonical preset catalog."""
+    try:
+        preset = get_preset(preset_id)
+    except KeyError as exc:
+        raise ApprovedBoundedEvidenceError(
+            f"unsupported preset for campaign validation: {preset_id}"
+        ) from exc
+
+    strategies = resolve_preset_bundle(preset)
+    if len(strategies) != 1:
+        raise ApprovedBoundedEvidenceError(
+            "campaign validation requires exactly one executable preset strategy"
+        )
+
+    strategy = strategies[0]
+    strategy_name = str(strategy.get("name") or "").strip()
+    factory = strategy.get("factory")
+    if not strategy_name or not callable(factory):
+        raise ApprovedBoundedEvidenceError(
+            "campaign validation preset strategy is not executable"
+        )
+    return strategy_name, factory
 
 
 @dataclass(frozen=True)
@@ -235,6 +263,14 @@ def _normalize_window_bounds(window: Mapping[str, Any], *, field_name: str) -> t
     return start, end
 
 
+def _is_date_only_bound(value: str) -> bool:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return False
+    return True
+
+
 def _restrict_frame_to_approval_window(
     *,
     frame: pd.DataFrame,
@@ -243,12 +279,33 @@ def _restrict_frame_to_approval_window(
     bounded_window = approval.get("bounded_input_window")
     if not isinstance(bounded_window, Mapping) or not bounded_window:
         return frame.copy()
-    start_text, end_text = _normalize_window_bounds(bounded_window, field_name="bounded_input_window")
+
+    start_text, end_text = _normalize_window_bounds(
+        bounded_window,
+        field_name="bounded_input_window",
+    )
     start = pd.Timestamp(start_text)
     end = pd.Timestamp(end_text)
-    restricted = frame.loc[(frame.index >= start) & (frame.index <= end)].copy()
+
+    if _is_date_only_bound(end_text):
+        end_exclusive = end + pd.Timedelta(days=1)
+        mask = (
+            (frame.index >= start)
+            & (frame.index < end_exclusive)
+        )
+    else:
+        mask = (
+            (frame.index >= start)
+            & (frame.index <= end)
+        )
+
+    restricted = frame.loc[mask].copy()
+
     if restricted.empty:
-        raise ApprovedBoundedEvidenceError("approved bounded_input_window produced empty local frame")
+        raise ApprovedBoundedEvidenceError(
+            "approved bounded_input_window produced empty local frame"
+        )
+
     return restricted
 
 
@@ -298,14 +355,22 @@ def _evaluate_symbol_with_local_cache(
     frame: pd.DataFrame,
     source_ref: str,
     approval: Mapping[str, Any],
+    preset_id: str | None = None,
+    interval: str = "1d",
 ) -> LocalEvaluation:
-    strategy = trend_pullback_v1_strategie()
+    if preset_id:
+        _strategy_name, strategy_factory = _resolve_single_preset_strategy(
+            preset_id
+        )
+        strategy = strategy_factory()
+    else:
+        strategy = trend_pullback_v1_strategie()
     engine = BacktestEngine(
         start_datum=frame.index.min().strftime("%Y-%m-%d"),
         eind_datum=frame.index.max().strftime("%Y-%m-%d"),
         evaluation_config={"mode": "single_split", "train_ratio": 0.7},
     )
-    engine.interval = "1d"
+    engine.interval = interval
     expected_start, expected_end = _expected_oos_window(frame=frame, engine=engine)
     _validate_expected_oos_window(
         approval=approval,

--- a/research/qre_multiwindow_evidence_closure.py
+++ b/research/qre_multiwindow_evidence_closure.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from typing import Any, Final
 
 from research import qre_failure_to_action_mapper as failure_mapper
-from research import qre_preregistered_multiwindow_evidence_run as campaign_run
-
 
 SCHEMA_VERSION: Final[str] = "1.0"
 REPORT_KIND: Final[str] = "qre_multiwindow_evidence_closure"
@@ -29,20 +27,46 @@ def _unique_in_order(values: Sequence[Any]) -> list[str]:
 
 
 def compute_multiwindow_closure_hash(report: Mapping[str, Any]) -> str:
+    campaign_scope = report.get("campaign_scope")
     canonical = {
         "schema_version": report.get("schema_version", SCHEMA_VERSION),
         "report_kind": report.get("report_kind", REPORT_KIND),
         "closure_status": report.get("closure_status", ""),
         "campaign_ref": report.get("campaign_ref", ""),
+        "source_campaign_id": report.get("source_campaign_id", ""),
+        "campaign_scope": (
+            dict(campaign_scope)
+            if isinstance(campaign_scope, Mapping)
+            else {}
+        ),
+        "proposal_id": report.get("proposal_id", ""),
+        "proposal_hash": report.get("proposal_hash", ""),
         "sampling_plan_ref": report.get("sampling_plan_ref", ""),
-        "accepted_lineage_count": int(report.get("accepted_lineage_count", 0) or 0),
-        "accepted_oos_count": int(report.get("accepted_oos_count", 0) or 0),
-        "evidence_complete_count": int(report.get("evidence_complete_count", 0) or 0),
-        "hypothesis_disposition": report.get("hypothesis_disposition", ""),
+        "sampling_plan_hash": report.get("sampling_plan_hash", ""),
+        "campaign_outcome": report.get("campaign_outcome", ""),
+        "positive_oos_trade_count_total": int(
+            report.get("positive_oos_trade_count_total", 0) or 0
+        ),
+        "accepted_lineage_count": int(
+            report.get("accepted_lineage_count", 0) or 0
+        ),
+        "accepted_oos_count": int(
+            report.get("accepted_oos_count", 0) or 0
+        ),
+        "evidence_complete_count": int(
+            report.get("evidence_complete_count", 0) or 0
+        ),
+        "hypothesis_disposition": report.get(
+            "hypothesis_disposition",
+            "",
+        ),
         "blockers_cleared": list(report.get("blockers_cleared", [])),
         "blockers_remaining": list(report.get("blockers_remaining", [])),
         "reason_records": list(report.get("reason_records", [])),
-        "recommended_next_action": report.get("recommended_next_action", ""),
+        "recommended_next_action": report.get(
+            "recommended_next_action",
+            "",
+        ),
         "authority": dict(report.get("authority", {})),
     }
     raw = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
@@ -59,7 +83,19 @@ def _reason_record(*, record_id: str, reason_code: str, evidence_refs: Sequence[
     }
 
 
-def build_multiwindow_evidence_closure(campaign_report: Mapping[str, Any]) -> dict[str, Any]:
+def build_multiwindow_evidence_closure(
+    campaign_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    campaign_scope_payload = campaign_report.get("campaign_scope")
+    campaign_scope = (
+        dict(campaign_scope_payload)
+        if isinstance(campaign_scope_payload, Mapping)
+        else {}
+    )
+    source_campaign_id = (
+        _text(campaign_report.get("source_campaign_id"))
+        or _text(campaign_scope.get("campaign_id"))
+    )
     window_results = list(campaign_report.get("window_results") or [])
     accepted_lineage_count = int(campaign_report.get("accepted_lineage_count") or 0)
     accepted_oos_count = int(campaign_report.get("accepted_oos_count") or 0)
@@ -113,17 +149,44 @@ def build_multiwindow_evidence_closure(campaign_report: Mapping[str, Any]) -> di
                 message="Null/control requirements failed, so completion is blocked fail-closed.",
             )
         )
-    elif null_control_status in {"controls_not_run", "controls_incomplete", ""}:
+    elif campaign_outcome == "all_windows_non_positive_trade_count":
+        closure_status = "all_windows_no_oos_trades"
+        hypothesis_disposition = "fail_closed_rejected"
+        recommended_next_action = failure_mapper.map_failure_to_action(
+            failure_class="all_preregistered_windows_failed"
+        )["recommended_action"]
+        reason_records.append(
+            _reason_record(
+                record_id="rr_multiwindow_all_zero",
+                reason_code="all_windows_non_positive_trade_count",
+                evidence_refs=[_text(campaign_report.get("campaign_id"))],
+                message=(
+                    "Every preregistered window completed with "
+                    "non-positive OOS trade count."
+                ),
+            )
+        )
+    elif null_control_status in {
+        "controls_not_run",
+        "controls_incomplete",
+        "",
+    }:
         closure_status = "blocked_missing_null_controls"
         hypothesis_disposition = "insufficient_for_completion"
-        recommended_next_action = _text(null_control_payload.get("recommended_next_action")) or "materialize_missing_preregistered_controls"
+        recommended_next_action = (
+            _text(null_control_payload.get("recommended_next_action"))
+            or "materialize_missing_preregistered_controls"
+        )
         blockers_remaining.append("null_controls_incomplete")
         reason_records.append(
             _reason_record(
                 record_id="rr_multiwindow_null_control_incomplete",
                 reason_code="null_controls_incomplete",
                 evidence_refs=[_text(campaign_report.get("campaign_id"))],
-                message="Preregistered null/control requirements are still incomplete, so evidence completion remains blocked.",
+                message=(
+                    "Preregistered null/control requirements are still "
+                    "incomplete, so evidence completion remains blocked."
+                ),
             )
         )
     elif campaign_outcome == "accepted_multiwindow_oos_evidence" and accepted_lineage_count > 0 and accepted_oos_count > 0:
@@ -148,20 +211,6 @@ def build_multiwindow_evidence_closure(campaign_report: Mapping[str, Any]) -> di
                 reason_code="evidence_partial",
                 evidence_refs=[_text(campaign_report.get("campaign_id"))],
                 message="Some accepted OOS evidence exists, but the preregistered completion criteria were not met.",
-            )
-        )
-    elif campaign_outcome == "all_windows_non_positive_trade_count":
-        closure_status = "all_windows_no_oos_trades"
-        hypothesis_disposition = "fail_closed_rejected"
-        recommended_next_action = failure_mapper.map_failure_to_action(
-            failure_class="all_preregistered_windows_failed"
-        )["recommended_action"]
-        reason_records.append(
-            _reason_record(
-                record_id="rr_multiwindow_all_zero",
-                reason_code="all_windows_non_positive_trade_count",
-                evidence_refs=[_text(campaign_report.get("campaign_id"))],
-                message="Every preregistered window completed with non-positive OOS trade count.",
             )
         )
     elif campaign_outcome == "insufficient_total_oos_trades":
@@ -203,7 +252,14 @@ def build_multiwindow_evidence_closure(campaign_report: Mapping[str, Any]) -> di
         "report_kind": REPORT_KIND,
         "closure_status": closure_status,
         "campaign_ref": _text(campaign_report.get("campaign_id")),
+        "source_campaign_id": source_campaign_id,
+        "campaign_scope": campaign_scope,
+        "proposal_id": _text(campaign_report.get("proposal_id")),
+        "proposal_hash": _text(campaign_report.get("proposal_hash")),
         "sampling_plan_ref": _text(campaign_report.get("sampling_plan_id")),
+        "sampling_plan_hash": _text(
+            campaign_report.get("sampling_plan_hash")
+        ),
         "accepted_lineage_count": accepted_lineage_count,
         "accepted_oos_count": accepted_oos_count,
         "evidence_complete_count": 1 if closure_status == "evidence_complete" else 0,

--- a/research/qre_preregistered_multiwindow_evidence_run.py
+++ b/research/qre_preregistered_multiwindow_evidence_run.py
@@ -19,7 +19,6 @@ from research import qre_null_control_falsification_suite as null_suite
 from research import qre_preregistered_multiwindow_validation as campaign_builder
 from research import qre_sampling_plan as sampling
 
-
 SCHEMA_VERSION: Final[str] = "1.0"
 REPORT_KIND: Final[str] = "qre_preregistered_multiwindow_evidence_run"
 DEFAULT_APPROVAL_PATH: Final[Path] = Path(
@@ -35,7 +34,7 @@ ALLOWED_OUTPUT_PATHS: Final[tuple[str, ...]] = (
     "logs/qre_bounded_generation_artifact_acceptance_verifier/",
     "logs/qre_evidence_complete_basket_closure/",
 )
-TIMEFRAME_TO_INTERVAL: Final[dict[str, str]] = {"daily_v1": "1d"}
+TIMEFRAME_TO_INTERVAL: Final[dict[str, str]] = approved.TIMEFRAME_TO_INTERVAL
 
 
 def _text(value: Any) -> str:
@@ -88,7 +87,9 @@ def _candidate_scope(repo_root: Path, *, symbols: Sequence[str], preset_id: str)
 
 
 def _load_common_trading_dates(repo_root: Path, *, symbols: Sequence[str], timeframe: str) -> list[str]:
-    interval = TIMEFRAME_TO_INTERVAL[timeframe]
+    interval = TIMEFRAME_TO_INTERVAL.get(timeframe)
+    if not interval:
+        raise ValueError(f"unsupported_campaign_timeframe:{timeframe}")
     date_sets: list[set[str]] = []
     for symbol in symbols:
         frame = approved._load_stitched_local_cache_frame(repo_root=repo_root, symbol=symbol, interval=interval)
@@ -178,9 +179,18 @@ def build_campaign_for_multiwindow_approval(
         sampling_plan_payload=sampling_plan_payload,
         approval_manifest=approval_manifest,
         local_source_ref=_text(scope.get("source_data_ref")),
-        minimum_required_windows=2,
-        minimum_total_oos_trades=1,
-        per_window_minimum_oos_trades=1,
+        minimum_required_windows=max(
+            1,
+            len(list(sampling_plan_payload.get("window_definitions") or [])),
+        ),
+        minimum_total_oos_trades=max(
+            1,
+            int(sampling_plan_payload.get("minimum_trade_requirement") or 1),
+        ),
+        per_window_minimum_oos_trades=max(
+            1,
+            int(sampling_plan_payload.get("minimum_trade_requirement") or 1),
+        ),
         null_control_requirements=list(suite.get("control_definitions") or []),
     )
 
@@ -220,6 +230,8 @@ def _source_payload_for_window(
     *,
     approval_payload: Mapping[str, Any],
     repo_root: Path,
+    sampling_plan_payload: Mapping[str, Any] | None = None,
+    campaign_scope: Mapping[str, Any] | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     normalized = approved._normalize_approval_payload(approval_payload)
     request = approved._build_request_payload(
@@ -228,13 +240,36 @@ def _source_payload_for_window(
     )
     symbol = list(normalized["symbols"])[0]
     timeframe = _text(normalized["timeframe"])
-    interval = TIMEFRAME_TO_INTERVAL[timeframe]
-    candidate_ids = approved._candidate_ids_from_queue(
-        repo_root=repo_root,
-        symbols=[symbol],
-        preset_id=_text(normalized["preset_id"]),
-        timeframe=timeframe,
-    )
+    interval = TIMEFRAME_TO_INTERVAL.get(timeframe)
+    if not interval:
+        raise ValueError(f"unsupported_campaign_timeframe:{timeframe}")
+    scope = campaign_scope if isinstance(campaign_scope, Mapping) else {}
+    source_campaign_id = _text(scope.get("campaign_id"))
+    if source_campaign_id:
+        candidate_seed = {
+            "campaign_id": source_campaign_id,
+            "sampling_plan_id": _text(
+                (sampling_plan_payload or {}).get("sampling_plan_id")
+            ),
+            "preset_id": _text(normalized["preset_id"]),
+            "symbol": symbol.upper(),
+        }
+        candidate_id = "ccand_" + hashlib.sha256(
+            json.dumps(
+                candidate_seed,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("utf-8")
+        ).hexdigest()[:16]
+    else:
+        candidate_ids = approved._candidate_ids_from_queue(
+            repo_root=repo_root,
+            symbols=[symbol],
+            preset_id=_text(normalized["preset_id"]),
+            timeframe=timeframe,
+        )
+        candidate_id = candidate_ids[symbol.upper()]
     frame = approved._load_stitched_local_cache_frame(repo_root=repo_root, symbol=symbol, interval=interval)
     bounded_frame = approved._restrict_frame_to_approval_window(frame=frame, approval=normalized)
     source_ref = (
@@ -243,11 +278,13 @@ def _source_payload_for_window(
     )
     evaluation = approved._evaluate_symbol_with_local_cache(
         symbol=symbol,
-        candidate_id=candidate_ids[symbol.upper()],
+        candidate_id=candidate_id,
         generation_run_id=f"{approval_payload['approval_id']}::generation",
         frame=bounded_frame,
         source_ref=source_ref,
         approval=normalized,
+        preset_id=_text(normalized["preset_id"]) if source_campaign_id else None,
+        interval=interval,
     )
     source_payload = {
         "schema_version": approved.SCHEMA_VERSION,
@@ -264,6 +301,7 @@ def _source_payload_for_window(
             {
                 "symbol": evaluation.symbol,
                 "candidate_id": evaluation.candidate_id,
+                "campaign_id": source_campaign_id,
                 "generation_run_id": evaluation.generation_run_id,
                 "validation_status": "accepted",
                 "reason_record_refs": evaluation.reason_record_refs,
@@ -318,6 +356,8 @@ def _classify_window_symbol(
     window_spec: Mapping[str, Any],
     symbol: str,
     repo_root: Path,
+    sampling_plan_payload: Mapping[str, Any] | None = None,
+    campaign_scope: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     approval_payload = _window_approval(
         approval_manifest=approval_manifest,
@@ -327,6 +367,8 @@ def _classify_window_symbol(
     request, source_payload = _source_payload_for_window(
         approval_payload=approval_payload,
         repo_root=repo_root,
+        sampling_plan_payload=sampling_plan_payload,
+        campaign_scope=campaign_scope,
     )
     adapter_result = adapter.build_controlled_validation_adapter_result(
         request,
@@ -369,6 +411,9 @@ def compute_campaign_run_hash(report: Mapping[str, Any]) -> str:
         "schema_version": report.get("schema_version", SCHEMA_VERSION),
         "report_kind": report.get("report_kind", REPORT_KIND),
         "campaign_id": report.get("campaign_id", ""),
+        "source_campaign_id": report.get("source_campaign_id", ""),
+        "proposal_id": report.get("proposal_id", ""),
+        "proposal_hash": report.get("proposal_hash", ""),
         "sampling_plan_id": report.get("sampling_plan_id", ""),
         "campaign_plan_hash": report.get("campaign_plan_hash", ""),
         "accepted_lineage_count": int(report.get("accepted_lineage_count", 0) or 0),
@@ -387,10 +432,19 @@ def build_preregistered_multiwindow_evidence_run(
     *,
     approval_manifest: Mapping[str, Any],
     repo_root: Path = Path("."),
+    sampling_plan_payload: Mapping[str, Any] | None = None,
+    campaign_scope: Mapping[str, Any] | None = None,
+    proposal_id: str = "",
+    proposal_hash: str = "",
 ) -> dict[str, Any]:
-    sampling_plan_payload = build_sampling_plan_for_multiwindow_approval(
-        approval_manifest=approval_manifest,
-        repo_root=repo_root,
+    if sampling_plan_payload is None:
+        sampling_plan_payload = build_sampling_plan_for_multiwindow_approval(
+            approval_manifest=approval_manifest,
+            repo_root=repo_root,
+        )
+    sampling_plan_payload = dict(sampling_plan_payload)
+    campaign_scope = (
+        dict(campaign_scope) if isinstance(campaign_scope, Mapping) else {}
     )
     campaign_plan = build_campaign_for_multiwindow_approval(
         approval_manifest=approval_manifest,
@@ -413,6 +467,10 @@ def build_preregistered_multiwindow_evidence_run(
             "schema_version": SCHEMA_VERSION,
             "report_kind": REPORT_KIND,
             "campaign_id": campaign_plan["campaign_id"],
+            "source_campaign_id": _text(campaign_scope.get("campaign_id")),
+            "campaign_scope": campaign_scope,
+            "proposal_id": _text(proposal_id),
+            "proposal_hash": _text(proposal_hash),
             "sampling_plan_id": sampling_plan_payload["sampling_plan_id"],
             "campaign_plan_hash": campaign_plan["hash"],
             "window_results": [],
@@ -440,6 +498,8 @@ def build_preregistered_multiwindow_evidence_run(
                 window_spec=window_spec,
                 symbol=symbol,
                 repo_root=repo_root,
+                sampling_plan_payload=sampling_plan_payload,
+                campaign_scope=campaign_scope,
             )
             for symbol in window_spec["symbols"]
         ]
@@ -535,6 +595,10 @@ def build_preregistered_multiwindow_evidence_run(
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
         "campaign_id": campaign_plan["campaign_id"],
+        "source_campaign_id": _text(campaign_scope.get("campaign_id")),
+        "campaign_scope": campaign_scope,
+        "proposal_id": _text(proposal_id),
+        "proposal_hash": _text(proposal_hash),
         "sampling_plan_id": sampling_plan_payload["sampling_plan_id"],
         "sampling_plan_hash": sampling_plan_payload["hash"],
         "campaign_plan_hash": campaign_plan["hash"],

--- a/tests/unit/test_campaign_evidence_decision.py
+++ b/tests/unit/test_campaign_evidence_decision.py
@@ -117,6 +117,7 @@ def test_no_matching_plan_creates_sampling_plan() -> None:
         == "create_preregistered_sampling_plan"
     )
     assert report["action_authority"] == "report_only"
+    assert report["campaign_scope"]["timeframe"] == "4h"
     assert report["safety_invariants"]["can_execute"] is False
     assert len(report["ignored_artifacts"]) == 2
     assert {
@@ -364,3 +365,17 @@ def test_module_contains_no_trading_runtime_imports() -> None:
     for token in forbidden:
         assert f"import {token}" not in source
         assert f"from {token}" not in source
+
+
+def test_registry_timeframe_overrides_preset_fallback() -> None:
+    registry = _registry()
+    registry["campaigns"][CAMPAIGN_ID]["timeframe"] = "1h"
+
+    report = decision.build_campaign_evidence_decision(
+        campaign_evidence=_campaign_evidence(),
+        campaign_registry=registry,
+        multiwindow_run=None,
+        multiwindow_closure=None,
+    )
+
+    assert report["campaign_scope"]["timeframe"] == "1h"

--- a/tests/unit/test_campaign_evidence_decision.py
+++ b/tests/unit/test_campaign_evidence_decision.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from research import campaign_evidence_decision as decision
+from research import qre_multiwindow_evidence_closure as closure
 
 CAMPAIGN_ID = (
     "col-20260605T122346491432Z-"
@@ -379,3 +380,77 @@ def test_registry_timeframe_overrides_preset_fallback() -> None:
     )
 
     assert report["campaign_scope"]["timeframe"] == "1h"
+
+
+def test_generated_campaign_closure_is_terminal_decision_source() -> None:
+    source_campaign_id = "col-fixture-campaign-001"
+    campaign_scope = {
+        "campaign_id": source_campaign_id,
+        "hypothesis_id": "fixture_hypothesis_v1",
+        "preset_name": "trend_pullback_equities_4h",
+        "timeframe": "4h",
+        "template_id": "daily_primary__trend_pullback_equities_4h",
+        "strategy_family": "trend_pullback",
+        "asset_class": "equity",
+        "universe": ["AAPL", "MSFT", "NVDA"],
+        "lineage_root_campaign_id": source_campaign_id,
+        "parent_campaign_id": "",
+        "registry_record_present": True,
+    }
+    run = {
+        "campaign_id": "qmwv-fixture-001",
+        "source_campaign_id": source_campaign_id,
+        "campaign_scope": campaign_scope,
+        "proposal_id": "cpsp-fixture-001",
+        "proposal_hash": "proposal-hash-fixture",
+        "sampling_plan_id": "qsp-fixture-001",
+        "sampling_plan_hash": "sampling-hash-fixture",
+        "accepted_lineage_count": 6,
+        "accepted_oos_count": 0,
+        "positive_oos_trade_count_total": 0,
+        "campaign_outcome": "all_windows_non_positive_trade_count",
+        "window_results": [
+            {"window_id": "window_01", "accepted_oos_count": 0},
+            {"window_id": "window_02", "accepted_oos_count": 0},
+        ],
+        "null_control_results": {"status": "controls_incomplete"},
+    }
+    generated_closure = closure.build_multiwindow_evidence_closure(run)
+    evidence = {
+        "evidence_status": "attributed_with_artifact_gaps",
+        "campaign": {
+            "campaign_id": source_campaign_id,
+            "preset_name": "trend_pullback_equities_4h",
+            "strategy_family": "trend_pullback",
+            "asset_class": "equity",
+        },
+        "failure_attribution": {"attributed": True},
+        "screening_evidence": {"owner_verified": True},
+        "interpretation": {"primary_limitation": "insufficient_trades"},
+    }
+    registry = {
+        "campaigns": {
+            source_campaign_id: {
+                **campaign_scope,
+                "parent_campaign_id": None,
+            }
+        }
+    }
+
+    report = decision.build_campaign_evidence_decision(
+        campaign_evidence=evidence,
+        campaign_registry=registry,
+        multiwindow_run=run,
+        multiwindow_closure=generated_closure,
+        run_status="present",
+        closure_status="present",
+    )
+
+    assert report["scope_match_status"] == "matching_multiwindow_closure"
+    assert report["selected_source"] == (
+        "logs/qre_multiwindow_evidence_closure/latest.json"
+    )
+    assert report["failure_class"] == "all_preregistered_windows_failed"
+    assert report["recommended_action"] == "reject_hypothesis"
+    assert report["action_authority"] == "report_only"
+    assert report["safety_invariants"]["can_execute"] is False

--- a/tests/unit/test_campaign_launcher_metadata_resolver.py
+++ b/tests/unit/test_campaign_launcher_metadata_resolver.py
@@ -16,7 +16,11 @@ unit tests; here we pin the pure mapping.
 
 from __future__ import annotations
 
-from research.campaign_launcher import _resolve_metadata_for_preset
+from research.campaign_launcher import (
+    _build_record,
+    _resolve_metadata_for_preset,
+    _resolve_scope_metadata_for_preset,
+)
 
 
 def test_resolver_populates_all_four_fields_for_active_discovery_preset():
@@ -97,3 +101,42 @@ def test_resolver_is_pure_does_not_mutate_global_state():
     a1 = _resolve_metadata_for_preset("trend_pullback_crypto_1h")
     a2 = _resolve_metadata_for_preset("trend_pullback_crypto_1h")
     assert a1 == a2
+
+
+def test_scope_resolver_uses_canonical_preset_timeframe():
+    h, f, a, timeframe, universe = (
+        _resolve_scope_metadata_for_preset(
+            "trend_pullback_equities_4h"
+        )
+    )
+
+    assert h == "trend_pullback_v1"
+    assert f == "trend_pullback"
+    assert a == "equity"
+    assert timeframe == "4h"
+    assert "NVDA" in universe
+
+    unknown = _resolve_scope_metadata_for_preset(
+        "not_a_real_preset_anywhere"
+    )
+    assert unknown == (None, None, None, None, ())
+
+
+def test_build_record_persists_timeframe_in_registry_payload():
+    record = _build_record(
+        campaign_id="campaign-test-001",
+        template_id="daily_primary__trend_pullback_equities_4h",
+        preset_name="trend_pullback_equities_4h",
+        campaign_type="daily_primary",
+        priority_tier=2,
+        spawned_at_utc="2026-06-23T12:00:00Z",
+        spawn_reason="unit_test",
+        parent_campaign_id=None,
+        lineage_root_campaign_id="campaign-test-001",
+        input_artifact_fingerprint="fixture-fingerprint",
+        estimate_seconds=1800,
+        subtype=None,
+    )
+
+    assert record.timeframe == "4h"
+    assert record.to_payload()["timeframe"] == "4h"

--- a/tests/unit/test_campaign_preregistered_multiwindow_evidence_run.py
+++ b/tests/unit/test_campaign_preregistered_multiwindow_evidence_run.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import campaign_preregistered_multiwindow_evidence_run as campaign_run
+from research import campaign_preregistered_sampling_plan as campaign_sampling
+from research import qre_sampling_plan as sampling
+
+
+def _proposal() -> dict[str, object]:
+    return campaign_sampling.build_campaign_preregistered_sampling_plan(
+        decision={
+            "decision_status": "decision_ready",
+            "recommended_action": "create_preregistered_sampling_plan",
+            "action_authority": "report_only",
+            "failure_class": "insufficient_window_length",
+            "reason_codes": ["insufficient_window_length"],
+            "prerequisites": ["larger_preregistered_local_range"],
+            "selected_source": (
+                "research/campaign_level_evidence_latest.v1.json"
+            ),
+            "evidence_refs": [
+                "research/campaign_level_evidence_latest.v1.json"
+            ],
+            "campaign_scope": {
+                "campaign_id": "campaign-source-001",
+                "hypothesis_id": "trend_pullback_v1",
+                "preset_name": "trend_pullback_equities_4h",
+                "timeframe": "4h",
+                "template_id": (
+                    "daily_primary__trend_pullback_equities_4h"
+                ),
+                "strategy_family": "trend_pullback",
+                "asset_class": "equity",
+                "universe": ["AAA", "BBB"],
+                "registry_record_present": True,
+            },
+            "safety_invariants": {
+                "can_execute": False,
+                "can_spawn_campaigns": False,
+                "can_mutate_queue": False,
+                "can_change_policy": False,
+                "can_change_presets": False,
+                "can_change_strategy": False,
+                "can_access_paper_shadow_live": False,
+            },
+        },
+        preregistration_timestamp="2026-06-24T17:58:20Z",
+    )
+
+
+def _approval(proposal: dict[str, object]) -> dict[str, object]:
+    scope = proposal["campaign_scope"]
+    assert isinstance(scope, dict)
+    return {
+        "approval_id": "approval-campaign-plan-001",
+        "approved_by": "operator:local",
+        "approved_at_utc": "2026-06-24T18:00:00Z",
+        "expiry_utc": "2026-06-25T18:00:00Z",
+        "scope": {
+            "campaign_id": scope["campaign_id"],
+            "proposal_id": proposal["proposal_id"],
+            "proposal_hash": proposal["hash"],
+            "symbols": list(scope["universe"]),
+            "preset_id": scope["preset_name"],
+            "timeframe": scope["timeframe"],
+            "source_data_ref": "data/cache/market",
+        },
+        "allowed_command_class": "bounded_controlled_validation",
+        "allowed_output_paths": list(
+            campaign_run.multiwindow.ALLOWED_OUTPUT_PATHS
+        ),
+        "forbidden_capabilities": [
+            "strategy_synthesis",
+            "parameter_optimization",
+            "external_fetch",
+        ],
+        "dry_run_allowed": True,
+        "real_run_allowed": True,
+        "evidence_acceptance_allowed": True,
+        "external_fetch_allowed": False,
+    }
+
+
+def _common_dates() -> list[str]:
+    return [f"2026-01-{day:02d}" for day in range(1, 29)] + [
+        f"2026-02-{day:02d}" for day in range(1, 29)
+    ]
+
+
+def test_materializes_locked_windows_from_local_cache(monkeypatch) -> None:
+    proposal = _proposal()
+    approval = _approval(proposal)
+    monkeypatch.setattr(
+        campaign_run.multiwindow,
+        "_load_common_trading_dates",
+        lambda *_args, **_kwargs: _common_dates(),
+    )
+
+    plan = campaign_run.materialize_campaign_sampling_plan(
+        proposal=proposal,
+        approval_manifest=approval,
+    )
+
+    assert plan["status"] == "sampling_plan_ready_context_only"
+    assert plan["timeframe"] == "4h"
+    assert len(plan["window_definitions"]) == 2
+    assert all(
+        window["locked"] is True
+        for window in plan["window_definitions"]
+    )
+    assert all(
+        window["regime_label"] == "unclassified"
+        for window in plan["window_definitions"]
+    )
+    assert sampling.validate_sampling_plan(plan)["valid"] is True
+
+
+def test_requires_exact_operator_approval_binding() -> None:
+    proposal = _proposal()
+    approval = _approval(proposal)
+    approval_scope = approval["scope"]
+    assert isinstance(approval_scope, dict)
+    approval_scope["proposal_hash"] = "wrong-hash"
+
+    try:
+        campaign_run.validate_proposal_approval_binding(
+            proposal=proposal,
+            approval_manifest=approval,
+        )
+    except ValueError as exc:
+        assert str(exc) == (
+            "campaign_proposal_approval_scope_mismatch:proposal_hash"
+        )
+    else:  # pragma: no cover
+        raise AssertionError("proposal hash mismatch must fail closed")
+
+
+def test_build_passes_only_materialized_plan_and_scope(monkeypatch) -> None:
+    proposal = _proposal()
+    approval = _approval(proposal)
+    monkeypatch.setattr(
+        campaign_run.multiwindow,
+        "_load_common_trading_dates",
+        lambda *_args, **_kwargs: _common_dates(),
+    )
+    captured: dict[str, object] = {}
+
+    def fake_build(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"campaign_outcome": "all_windows_non_positive_trade_count"}
+
+    monkeypatch.setattr(
+        campaign_run.multiwindow,
+        "build_preregistered_multiwindow_evidence_run",
+        fake_build,
+    )
+
+    report = campaign_run.build_campaign_preregistered_multiwindow_evidence_run(
+        proposal=proposal,
+        approval_manifest=approval,
+    )
+
+    plan = captured["sampling_plan_payload"]
+    scope = captured["campaign_scope"]
+    assert isinstance(plan, dict)
+    assert isinstance(scope, dict)
+    assert plan["status"] == "sampling_plan_ready_context_only"
+    assert scope["campaign_id"] == "campaign-source-001"
+    assert captured["proposal_id"] == proposal["proposal_id"]
+    assert captured["proposal_hash"] == proposal["hash"]
+    assert report["campaign_outcome"] == (
+        "all_windows_non_positive_trade_count"
+    )
+
+
+def test_campaign_runner_contains_no_campaign_or_symbol_hardcoding() -> None:
+    source = Path(
+        "research/campaign_preregistered_multiwindow_evidence_run.py"
+    ).read_text(encoding="utf-8")
+
+    assert "col-20260605" not in source
+    assert "AAPL" not in source
+    assert "NVDA" not in source

--- a/tests/unit/test_campaign_preregistered_sampling_plan.py
+++ b/tests/unit/test_campaign_preregistered_sampling_plan.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import campaign_preregistered_sampling_plan as proposal
+
+TIMESTAMP = "2026-06-24T08:00:00Z"
+
+
+def _decision() -> dict[str, object]:
+    return {
+        "decision_status": "decision_ready",
+        "recommended_action": "create_preregistered_sampling_plan",
+        "action_authority": "report_only",
+        "failure_class": "insufficient_window_length",
+        "reason_codes": ["insufficient_window_length"],
+        "prerequisites": ["larger_preregistered_local_range"],
+        "selected_source": "research/campaign_level_evidence_latest.v1.json",
+        "evidence_refs": [
+            "research/campaign_level_evidence_latest.v1.json",
+            "research/campaign_registry_latest.v1.json",
+        ],
+        "campaign_scope": {
+            "campaign_id": "campaign-alpha",
+            "hypothesis_id": "behavior_alpha_v1",
+            "preset_name": "alpha_equities_4h",
+            "timeframe": "4h",
+            "template_id": "daily_primary__alpha_equities_4h",
+            "strategy_family": "behavior_alpha",
+            "asset_class": "equity",
+            "universe": ["MSFT", "AAPL"],
+            "lineage_root_campaign_id": "campaign-alpha",
+            "parent_campaign_id": "",
+            "registry_record_present": True,
+        },
+        "safety_invariants": {
+            key: False for key in proposal.SAFETY_KEYS
+        },
+    }
+
+
+def test_eligible_decision_builds_report_only_coverage_proposal() -> None:
+    report = proposal.build_campaign_preregistered_sampling_plan(
+        decision=_decision(),
+        preregistration_timestamp=TIMESTAMP,
+    )
+
+    assert report["proposal_status"] == "proposal_ready_coverage_required"
+    assert report["campaign_scope"]["campaign_id"] == "campaign-alpha"
+    assert report["campaign_scope"]["universe"] == ["AAPL", "MSFT"]
+    assert report["coverage_requirements"]["minimum_common_trading_dates"] == 40
+    assert report["sampling_plan"]["behavior_id"] == "behavior_alpha"
+    assert report["sampling_plan"]["preset_id"] == "alpha_equities_4h"
+    assert report["sampling_plan"]["timeframe"] == "4h"
+    assert report["sampling_plan"]["status"] == "blocked_insufficient_range"
+    assert report["sampling_plan_validation"]["valid"] is True
+    assert report["authority"]["action_authority"] == "report_only"
+    assert report["safety_invariants"]["can_execute"] is False
+
+
+def test_proposal_is_deterministic_and_campaign_agnostic() -> None:
+    first = proposal.build_campaign_preregistered_sampling_plan(
+        decision=_decision(),
+        preregistration_timestamp=TIMESTAMP,
+    )
+    second = proposal.build_campaign_preregistered_sampling_plan(
+        decision=_decision(),
+        preregistration_timestamp=TIMESTAMP,
+    )
+    assert first == second
+
+    other = _decision()
+    other["campaign_scope"] = {
+        "campaign_id": "campaign-beta",
+        "hypothesis_id": "behavior_beta_v2",
+        "preset_name": "beta_crypto_1h",
+        "timeframe": "1h",
+        "template_id": "weekly_retest__beta_crypto_1h",
+        "strategy_family": "behavior_beta",
+        "asset_class": "crypto",
+        "universe": ["ETH-USD", "BTC-USD"],
+        "lineage_root_campaign_id": "campaign-beta",
+        "parent_campaign_id": "campaign-parent",
+        "registry_record_present": True,
+    }
+    other_report = proposal.build_campaign_preregistered_sampling_plan(
+        decision=other,
+        preregistration_timestamp=TIMESTAMP,
+    )
+
+    assert other_report["campaign_scope"]["campaign_id"] == "campaign-beta"
+    assert other_report["sampling_plan"]["behavior_id"] == "behavior_beta"
+    assert other_report["sampling_plan"]["preset_id"] == "beta_crypto_1h"
+    assert other_report["sampling_plan"]["timeframe"] == "1h"
+    assert other_report["proposal_id"] != first["proposal_id"]
+
+
+def test_unsupported_or_unsafe_decisions_fail_closed() -> None:
+    unsupported = _decision()
+    unsupported["recommended_action"] = "operator_review"
+    report = proposal.build_campaign_preregistered_sampling_plan(
+        decision=unsupported,
+        preregistration_timestamp=TIMESTAMP,
+    )
+    assert report["proposal_status"] == "blocked_unsupported_decision"
+    assert report["sampling_plan"] == {}
+
+    unsafe = _decision()
+    unsafe["safety_invariants"]["can_execute"] = True
+    report = proposal.build_campaign_preregistered_sampling_plan(
+        decision=unsafe,
+        preregistration_timestamp=TIMESTAMP,
+    )
+    assert report["proposal_status"] == "blocked_unsafe_decision_authority"
+    assert "decision_safety_invariant_not_false:can_execute" in report["blocked_reasons"]
+
+
+def test_missing_scope_and_failure_policy_fail_closed() -> None:
+    incomplete = _decision()
+    incomplete["campaign_scope"]["timeframe"] = ""
+    report = proposal.build_campaign_preregistered_sampling_plan(
+        decision=incomplete,
+        preregistration_timestamp=TIMESTAMP,
+    )
+    assert report["proposal_status"] == "blocked_incomplete_campaign_scope"
+    assert "missing_campaign_scope:timeframe" in report["blocked_reasons"]
+
+    unknown = _decision()
+    unknown["failure_class"] = "unknown_failure"
+    report = proposal.build_campaign_preregistered_sampling_plan(
+        decision=unknown,
+        preregistration_timestamp=TIMESTAMP,
+    )
+    assert report["proposal_status"] == "blocked_unsupported_failure_class"
+    assert report["sampling_plan"] == {}
+
+
+def test_current_artifact_status_and_sidecar_writes(tmp_path: Path) -> None:
+    missing = proposal.build_from_current_decision(
+        preregistration_timestamp=TIMESTAMP,
+        repo_root=tmp_path,
+    )
+    assert missing["proposal_status"] == "blocked_missing_decision"
+
+    decision_path = tmp_path / proposal.DECISION_PATH
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text("not-json", encoding="utf-8")
+    malformed = proposal.build_from_current_decision(
+        preregistration_timestamp=TIMESTAMP,
+        repo_root=tmp_path,
+    )
+    assert malformed["proposal_status"] == "blocked_malformed_decision"
+
+    decision_path.write_text(json.dumps(_decision()), encoding="utf-8")
+    report = proposal.build_from_current_decision(
+        preregistration_timestamp=TIMESTAMP,
+        repo_root=tmp_path,
+    )
+    paths = proposal.write_outputs(report, repo_root=tmp_path)
+    json_payload = json.loads((tmp_path / paths["json"]).read_text(encoding="utf-8"))
+    markdown = (tmp_path / paths["markdown"]).read_text(encoding="utf-8")
+
+    assert json_payload["proposal_id"] == report["proposal_id"]
+    assert "proposal_ready_coverage_required" in markdown
+    assert "can_execute: False" in markdown
+
+
+def test_module_has_no_runtime_or_mutation_imports() -> None:
+    source = Path(
+        "research/campaign_preregistered_sampling_plan.py"
+    ).read_text(encoding="utf-8")
+    forbidden = (
+        "qre_preregistered_multiwindow_evidence_run",
+        "campaign_queue",
+        "campaign_launcher",
+        "agent.execution",
+        "agent.risk",
+        "qre_paper",
+        "qre_shadow",
+        "qre_live",
+    )
+    assert all(value not in source for value in forbidden)

--- a/tests/unit/test_qre_approved_bounded_evidence_materialization.py
+++ b/tests/unit/test_qre_approved_bounded_evidence_materialization.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from research import qre_approved_bounded_evidence_materialization as approved
 
@@ -198,3 +199,95 @@ def test_validate_expected_oos_window_rejects_manifest_mismatch() -> None:
         assert "approved oos_window does not match" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("expected oos window mismatch to fail closed")
+
+def test_campaign_timeframe_mapping_supports_canonical_presets() -> None:
+    assert approved.TIMEFRAME_TO_INTERVAL["1d"] == "1d"
+    assert approved.TIMEFRAME_TO_INTERVAL["1h"] == "1h"
+    assert approved.TIMEFRAME_TO_INTERVAL["4h"] == "4h"
+
+
+def test_campaign_strategy_resolution_uses_single_preset_bundle() -> None:
+    strategy_name, factory = approved._resolve_single_preset_strategy(
+        "trend_pullback_equities_4h"
+    )
+
+    assert strategy_name == "trend_pullback_v1"
+    assert callable(factory)
+
+
+def test_campaign_strategy_resolution_blocks_ambiguous_bundle() -> None:
+    with pytest.raises(
+        approved.ApprovedBoundedEvidenceError,
+        match="exactly one executable preset strategy",
+    ):
+        approved._resolve_single_preset_strategy(
+            "trend_equities_4h_baseline"
+        )
+
+
+def test_restrict_frame_includes_full_intraday_end_date() -> None:
+    frame = pd.DataFrame(
+        {
+            "open": list(range(8)),
+            "high": list(range(8)),
+            "low": list(range(8)),
+            "close": list(range(8)),
+            "volume": [10] * 8,
+        },
+        index=pd.date_range(
+            "2026-04-10T00:00:00",
+            periods=8,
+            freq="4h",
+        ),
+    )
+
+    restricted = approved._restrict_frame_to_approval_window(
+        frame=frame,
+        approval={
+            "bounded_input_window": {
+                "start": "2026-04-10",
+                "end": "2026-04-10",
+            }
+        },
+    )
+
+    assert len(restricted) == 6
+    assert restricted.index.min() == pd.Timestamp(
+        "2026-04-10T00:00:00"
+    )
+    assert restricted.index.max() == pd.Timestamp(
+        "2026-04-10T20:00:00"
+    )
+
+
+def test_restrict_frame_preserves_exact_timestamp_end_bound() -> None:
+    frame = pd.DataFrame(
+        {
+            "open": list(range(8)),
+            "high": list(range(8)),
+            "low": list(range(8)),
+            "close": list(range(8)),
+            "volume": [10] * 8,
+        },
+        index=pd.date_range(
+            "2026-04-10T00:00:00",
+            periods=8,
+            freq="4h",
+        ),
+    )
+
+    restricted = approved._restrict_frame_to_approval_window(
+        frame=frame,
+        approval={
+            "bounded_input_window": {
+                "start": "2026-04-10T04:00:00",
+                "end": "2026-04-10T12:00:00",
+            }
+        },
+    )
+
+    assert list(restricted.index) == [
+        pd.Timestamp("2026-04-10T04:00:00"),
+        pd.Timestamp("2026-04-10T08:00:00"),
+        pd.Timestamp("2026-04-10T12:00:00"),
+    ]

--- a/tests/unit/test_qre_multiwindow_evidence_closure.py
+++ b/tests/unit/test_qre_multiwindow_evidence_closure.py
@@ -7,8 +7,25 @@ from research import qre_multiwindow_evidence_closure as closure
 
 def _campaign(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
-        "campaign_id": "camp-001",
+        "campaign_id": "qmwv-001",
+        "source_campaign_id": "source-campaign-001",
+        "campaign_scope": {
+            "campaign_id": "source-campaign-001",
+            "hypothesis_id": "hypothesis-001",
+            "preset_name": "preset-4h",
+            "timeframe": "4h",
+            "template_id": "template-001",
+            "strategy_family": "trend_pullback",
+            "asset_class": "equity",
+            "universe": ["AAA", "BBB"],
+            "lineage_root_campaign_id": "source-campaign-001",
+            "parent_campaign_id": "",
+            "registry_record_present": True,
+        },
+        "proposal_id": "proposal-001",
+        "proposal_hash": "proposal-hash-001",
         "sampling_plan_id": "plan-001",
+        "sampling_plan_hash": "sampling-hash-001",
         "accepted_lineage_count": 2,
         "accepted_oos_count": 0,
         "positive_oos_trade_count_total": 0,
@@ -114,3 +131,35 @@ def test_core_closure_has_no_symbol_hardcoding() -> None:
     source = Path("research/qre_multiwindow_evidence_closure.py").read_text(encoding="utf-8")
     assert "AAPL" not in source
     assert "NVDA" not in source
+
+
+def test_all_zero_windows_override_incomplete_controls() -> None:
+    report = closure.build_multiwindow_evidence_closure(
+        _campaign(
+            null_control_results={"status": "controls_incomplete"},
+        )
+    )
+
+    assert report["closure_status"] == "all_windows_no_oos_trades"
+    assert report["hypothesis_disposition"] == "fail_closed_rejected"
+    assert report["recommended_next_action"] == "reject_hypothesis"
+    assert "null_controls_incomplete" not in report["blockers_remaining"]
+    assert "no_oos_evidence" in report["blockers_remaining"]
+
+
+def test_closure_preserves_source_scope_and_hash_lineage() -> None:
+    report = closure.build_multiwindow_evidence_closure(_campaign())
+
+    assert report["campaign_ref"] == "qmwv-001"
+    assert report["source_campaign_id"] == "source-campaign-001"
+    assert report["campaign_scope"]["timeframe"] == "4h"
+    assert report["campaign_scope"]["universe"] == ["AAA", "BBB"]
+    assert report["proposal_id"] == "proposal-001"
+    assert report["proposal_hash"] == "proposal-hash-001"
+    assert report["sampling_plan_ref"] == "plan-001"
+    assert report["sampling_plan_hash"] == "sampling-hash-001"
+    assert report["hash"] == closure.compute_multiwindow_closure_hash(report)
+
+    tampered = dict(report)
+    tampered["proposal_hash"] = "tampered"
+    assert closure.compute_multiwindow_closure_hash(tampered) != report["hash"]


### PR DESCRIPTION
﻿## Summary

- add deterministic campaign-scoped preregistered sampling-plan proposals
- bind approved multiwindow evidence runs to campaign, proposal, timeframe, preset, universe, and local cache scope
- preserve original campaign lineage through closure and terminal evidence decisions
- reject hypotheses fail-closed after all preregistered windows complete without OOS trades

## Validation

- 104 integrated targeted tests passed
- repository Ruff gate passed
- changed clean/new files passed targeted Ruff validation
- 30 of 30 preregistered OOS alignment checks passed
- bounded local run evaluated 2 windows across 15 symbols
- protected and frozen artifacts remained unchanged
- complete PR diff passed whitespace and Python compile checks

## Research outcome

The bounded preregistered run produced verifier-acceptable lineage for all 30 evaluations but zero accepted OOS trade evidence.

The evidence loop therefore closes with:

- `all_windows_no_oos_trades`
- `fail_closed_rejected`
- `all_preregistered_windows_failed`
- `reject_hypothesis`
- `report_only`

No additional unregistered window is requested.

## Safety

The change does not authorize or perform:

- external data fetches
- queue mutation
- campaign spawning
- strategy, preset, or policy mutation
- paper, shadow, or live trading
- broker execution
- candidate promotion
- deployment activation

All execution and deployment safety authorities remain disabled.
