### PR TITLE
feat: add ADE-QRE-017 A20 decomposition

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -22,13 +22,16 @@
 
 The queue encodes:
 
+- ADE-QRE-017 wave-1 intake tasks (`ADE-QRE-017A` through
+  `ADE-QRE-017E`) for the trusted research intelligence maturity
+  program;
 - Roadmap v6 phases v3.15.16 → v3.15.20;
 - Addendum 1 (diagnostics + external-intelligence intake);
 - Addendum 2 (state / sequential / knowledge / retrieval
   intelligence) — repo-resident as of A23;
 - Addendum 3 (source identity / data quality / throughput
   intelligence) — repo-resident as of A23;
-- 8 `RoadmapTask` records, 54 `RoadmapRequirement` records, 37
+- 13 `RoadmapTask` records, 60 `RoadmapRequirement` records, 42
   `ImplementationUnit` records.
 
 A23 made Addendum 2 + 3 repo-resident by copying the
@@ -81,10 +84,13 @@ requirements) still follows the catalog-expansion-PR pattern in
 > **Authority:** development-governance read-only.
 > The roadmap task catalog is **not** the canonical product roadmap.
 > Current QRE implementation sequencing is governed by
-> [`docs/roadmap/qre_maturity_roadmap_to_100.md`](../roadmap/qre_maturity_roadmap_to_100.md).
+> [`docs/roadmap/qre_maturity_roadmap_to_100.md`](../roadmap/qre_maturity_roadmap_to_100.md)
+> together with the admitted ADE-QRE-017 campaign manifest
+> [`docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md`](../roadmap/qre_trusted_research_intelligence_roadmap_manifest.md).
 > Roadmap v6 ([`docs/roadmap/Roadmap v6.md`](../roadmap/Roadmap%20v6.md))
 > remains historical/supporting reference. This catalog is a
-> deterministic *seed* over that source plus the committed Addendum 1.
+> deterministic *seed* over those sources plus the committed
+> addenda and admitted queue sequence.
 >
 > The catalog grants **no** implementation, runtime, trading, paper,
 > shadow, broker, risk, or live authority to any agent. ADE remains
@@ -104,9 +110,10 @@ already gives ADE a path to pick up explicit
 documents must remain human-readable; bulk decomposition does not
 belong inline in those files.
 
-A20a fills the gap by hand-encoding the v3.15.16 → v3.15.20 phase
-tasks plus a cross-cutting Addendum 1 task and their normative
-requirements into a deterministic Python literal inside
+A20a fills the gap by hand-encoding the admitted ADE-QRE-017 wave-1
+trusted-research tasks, the v3.15.16 → v3.15.20 phase tasks, the
+cross-cutting Addendum tasks, and their normative requirements into a
+deterministic Python literal inside
 `reporting/roadmap_task_catalog.py`. The module emits a single
 read-only projection at `logs/roadmap_task_catalog/latest.json`.
 

--- a/reporting/roadmap_next_unit.py
+++ b/reporting/roadmap_next_unit.py
@@ -196,6 +196,11 @@ NEXT_UNIT_SELECTOR_MODE: Final[tuple[str, ...]] = ("default",)
 
 #: Roadmap-phase order as defined by A20a/A20b.
 _PHASE_ORDER: Final[tuple[str, ...]] = (
+    "ade_qre_017a",
+    "ade_qre_017b",
+    "ade_qre_017c",
+    "ade_qre_017d",
+    "ade_qre_017e",
     "v3.15.16",
     "v3.15.17",
     "v3.15.18",

--- a/reporting/roadmap_task_catalog.py
+++ b/reporting/roadmap_task_catalog.py
@@ -96,6 +96,11 @@ step5_implementation_allowed: Final[bool] = False
 #: committed to the repo at the time of this seed; their requirements
 #: remain empty and absence flags are emitted on every projection.
 PHASE: Final[tuple[str, ...]] = (
+    "ade_qre_017a",
+    "ade_qre_017b",
+    "ade_qre_017c",
+    "ade_qre_017d",
+    "ade_qre_017e",
     "v3.15.16",
     "v3.15.17",
     "v3.15.18",
@@ -111,6 +116,9 @@ PHASE: Final[tuple[str, ...]] = (
 #: Addendum 2 and Addendum 3 verbatim into ``docs/roadmap/``; their
 #: file paths are pinned here.
 SOURCE_DOCUMENT: Final[tuple[str, ...]] = (
+    "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md",
+    "docs/roadmap/qre_maturity_roadmap_to_100.md",
+    "docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md",
     "docs/roadmap/Roadmap v6.md",
     "docs/roadmap/Roadmap v6 Addendum.md",
     (
@@ -283,6 +291,90 @@ _DISCIPLINE_INVARIANTS: Final[dict[str, bool]] = {
 #: ``addendum_1`` task. Order matches ``PHASE`` declaration order;
 #: ``sort`` at projection time keeps the artefact stable regardless.
 _ROADMAP_TASKS_SEED: Final[tuple[dict[str, Any], ...]] = (
+    {
+        "id": "ade_qre_017a_baseline_reconciliation",
+        "title": "ADE-QRE-017A Baseline Reconciliation and Maturity Matrix",
+        "phase": "ade_qre_017a",
+        "source_documents": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md",
+            "docs/roadmap/qre_maturity_roadmap_to_100.md",
+            "docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md",
+        ),
+        "purpose": (
+            "Establish a repository-backed baseline reconciliation for the "
+            "trusted research intelligence program. Classify relevant QRE "
+            "capabilities by maturity, count current evidence-bearing "
+            "surfaces, and make blockers explicit without inferring trust "
+            "from scaffold presence alone."
+        ),
+        "status": "not_started",
+        "prerequisites": (),
+    },
+    {
+        "id": "ade_qre_017b_evidence_density_population",
+        "title": "ADE-QRE-017B Evidence-Density Population Plan",
+        "phase": "ade_qre_017b",
+        "source_documents": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md",
+            "docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md",
+        ),
+        "purpose": (
+            "Inventory required evidence classes, their producers and "
+            "consumers, and the population gaps that currently block "
+            "repeatable research decisions. Fail-closed blockers must be "
+            "named explicitly."
+        ),
+        "status": "not_started",
+        "prerequisites": ("ade_qre_017a_baseline_reconciliation",),
+    },
+    {
+        "id": "ade_qre_017c_reason_record_maturity",
+        "title": "ADE-QRE-017C Reason-Record Maturity",
+        "phase": "ade_qre_017c",
+        "source_documents": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md",
+            "docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md",
+        ),
+        "purpose": (
+            "Make reason records durable, normalized, and evidence-linked "
+            "when real evidence exists. Missing evidence must fail closed; "
+            "the program may not synthesize reasons or evidence."
+        ),
+        "status": "not_started",
+        "prerequisites": ("ade_qre_017b_evidence_density_population",),
+    },
+    {
+        "id": "ade_qre_017d_routing_sampling_readiness",
+        "title": "ADE-QRE-017D Routing and Sampling Readiness Population",
+        "phase": "ade_qre_017d",
+        "source_documents": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md",
+            "docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md",
+        ),
+        "purpose": (
+            "Promote routing-ready and sampling-ready signals from scaffold "
+            "status to repository-backed readiness based on actual evidence. "
+            "Readiness may not be inferred from module existence alone."
+        ),
+        "status": "not_started",
+        "prerequisites": ("ade_qre_017c_reason_record_maturity",),
+    },
+    {
+        "id": "ade_qre_017e_kpi_snapshot_completeness",
+        "title": "ADE-QRE-017E KPI Completeness and Historical Snapshots",
+        "phase": "ade_qre_017e",
+        "source_documents": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md",
+            "docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md",
+        ),
+        "purpose": (
+            "Materialize KPI completeness with numeric values or explicit "
+            "unavailability, and produce repeatable historical snapshots "
+            "that preserve evidence state over time."
+        ),
+        "status": "not_started",
+        "prerequisites": ("ade_qre_017d_routing_sampling_readiness",),
+    },
     {
         "id": "phase_v3_15_16",
         "title": "Intelligent Routing Layer",
@@ -483,7 +575,112 @@ _ROADMAP_TASKS_SEED: Final[tuple[dict[str, Any], ...]] = (
 # encoded here — their source documents are not in the repo.
 
 _ROADMAP_REQUIREMENTS_SEED: Final[tuple[dict[str, Any], ...]] = (
-    # ---- Addendum 1 — Core principles ----------------------------------
+    {
+        "id": "req_ade_qre_017a_maturity_matrix",
+        "roadmap_task_id": "ade_qre_017a_baseline_reconciliation",
+        "source_document": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md"
+        ),
+        "source_anchor": "ADE-QRE-017A - Baseline Reconciliation and Maturity Matrix",
+        "phase": "ade_qre_017a",
+        "addendum_link": "none",
+        "statement": (
+            "Produce a repository-backed maturity matrix that classifies "
+            "relevant QRE capabilities as scaffold, populated working "
+            "capability, integrated capability, repeatable evidence "
+            "capability, decision-useful capability, operator-trusted "
+            "capability, or evidence-authoritative capability."
+        ),
+        "target_layer": "governance",
+        "status": "not_started",
+    },
+    {
+        "id": "req_ade_qre_017a_blocker_census",
+        "roadmap_task_id": "ade_qre_017a_baseline_reconciliation",
+        "source_document": (
+            "docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md"
+        ),
+        "source_anchor": "ADE-QRE-017A - Baseline Reconciliation and Maturity Matrix",
+        "phase": "ade_qre_017a",
+        "addendum_link": "none",
+        "statement": (
+            "Baseline reconciliation must count relevant artifacts and make "
+            "current blockers explicit without inferring evidence authority "
+            "from file existence."
+        ),
+        "target_layer": "reporting",
+        "status": "not_started",
+    },
+    {
+        "id": "req_ade_qre_017b_evidence_inventory",
+        "roadmap_task_id": "ade_qre_017b_evidence_density_population",
+        "source_document": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md"
+        ),
+        "source_anchor": "ADE-QRE-017B - Evidence-Density Population Plan",
+        "phase": "ade_qre_017b",
+        "addendum_link": "none",
+        "statement": (
+            "Inventory required evidence classes, their producers, their "
+            "consumers, current population state, and the fail-closed "
+            "blockers that prevent evidence density from becoming decision "
+            "useful."
+        ),
+        "target_layer": "evidence",
+        "status": "not_started",
+    },
+    {
+        "id": "req_ade_qre_017c_reason_record_linkage",
+        "roadmap_task_id": "ade_qre_017c_reason_record_maturity",
+        "source_document": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md"
+        ),
+        "source_anchor": "ADE-QRE-017C - Reason-Record Maturity",
+        "phase": "ade_qre_017c",
+        "addendum_link": "none",
+        "statement": (
+            "Reason records must be non-empty when real evidence exists, "
+            "durable across runs, normalized to a closed representation, "
+            "and explicitly linked to evidence references."
+        ),
+        "target_layer": "evidence",
+        "status": "not_started",
+    },
+    {
+        "id": "req_ade_qre_017d_readiness_population",
+        "roadmap_task_id": "ade_qre_017d_routing_sampling_readiness",
+        "source_document": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md"
+        ),
+        "source_anchor": "ADE-QRE-017D - Routing and Sampling Readiness Population",
+        "phase": "ade_qre_017d",
+        "addendum_link": "none",
+        "statement": (
+            "Routing-ready and sampling-ready status must be derived from "
+            "real repository evidence. Scaffold-only presence may not be "
+            "promoted to readiness."
+        ),
+        "target_layer": "reporting",
+        "status": "not_started",
+    },
+    {
+        "id": "req_ade_qre_017e_kpi_snapshots",
+        "roadmap_task_id": "ade_qre_017e_kpi_snapshot_completeness",
+        "source_document": (
+            "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md"
+        ),
+        "source_anchor": "ADE-QRE-017E - KPI Completeness and Historical Snapshots",
+        "phase": "ade_qre_017e",
+        "addendum_link": "none",
+        "statement": (
+            "Every KPI must be present as a numeric value or an explicit "
+            "unavailable state, and the system must emit repeatable "
+            "historical snapshots that preserve evidence time context."
+        ),
+        "target_layer": "reporting",
+        "status": "not_started",
+    },
+    # ---- Addendum 1 - Core principles ----------------------------------
     {
         "id": "req_addendum_1_diagnostics_do_not_trade",
         "roadmap_task_id": "addendum_1_diagnostics_intake",

--- a/reporting/roadmap_task_units.py
+++ b/reporting/roadmap_task_units.py
@@ -461,6 +461,214 @@ def _research_module_dod(target_path: str) -> tuple[str, ...]:
 # Unit seed records -------------------------------------------------------
 
 _UNIT_SEED: Final[tuple[dict[str, Any], ...]] = (
+    # -------------------- ADE-QRE-017 Trusted Research Intelligence -----
+    {
+        "id": "u_ade_qre_017a_maturity_matrix_reporter_001",
+        "roadmap_task_id": "ade_qre_017a_baseline_reconciliation",
+        "title": "Trusted research maturity matrix reporter",
+        "phase": "ade_qre_017a",
+        "unit_kind": "reporting_module",
+        "target_layer": "governance",
+        "source_requirement_ids": (
+            "req_ade_qre_017a_maturity_matrix",
+            "req_ade_qre_017a_blocker_census",
+        ),
+        "expected_files": (
+            "reporting/qre_trusted_research_maturity_matrix.py",
+            "tests/unit/test_qre_trusted_research_maturity_matrix.py",
+            "docs/governance/qre_trusted_research_maturity_matrix.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_qre_trusted_research_maturity_matrix.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.qre_trusted_research_maturity_matrix",
+            "logs/qre_trusted_research_maturity_matrix/",
+        )
+        + (
+            (
+                "matrix emits closed-vocab maturity classes and explicit "
+                "blockers for each capability row"
+            ),
+        ),
+        "extra_stop_conditions": (
+            (
+                "any attempt to infer trusted or evidence-authoritative "
+                "status from file presence alone -> STOP"
+            ),
+        ),
+        "prerequisites": (),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "ready",
+    },
+    {
+        "id": "u_ade_qre_017b_evidence_density_inventory_001",
+        "roadmap_task_id": "ade_qre_017b_evidence_density_population",
+        "title": "Evidence-density inventory and blocker reporter",
+        "phase": "ade_qre_017b",
+        "unit_kind": "reporting_module",
+        "target_layer": "evidence",
+        "source_requirement_ids": (
+            "req_ade_qre_017b_evidence_inventory",
+        ),
+        "expected_files": (
+            "reporting/qre_evidence_density_inventory.py",
+            "tests/unit/test_qre_evidence_density_inventory.py",
+            "docs/governance/qre_evidence_density_inventory.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_qre_evidence_density_inventory.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.qre_evidence_density_inventory",
+            "logs/qre_evidence_density_inventory/",
+        )
+        + (
+            (
+                "inventory records producers, consumers, population state, "
+                "and fail-closed blockers per evidence class"
+            ),
+        ),
+        "extra_stop_conditions": (
+            "any evidence class without a bounded status vocabulary -> STOP",
+        ),
+        "prerequisites": (
+            "u_ade_qre_017a_maturity_matrix_reporter_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_ade_qre_017c_reason_record_maturity_reporter_001",
+        "roadmap_task_id": "ade_qre_017c_reason_record_maturity",
+        "title": "Reason-record maturity and evidence-linkage reporter",
+        "phase": "ade_qre_017c",
+        "unit_kind": "reporting_module",
+        "target_layer": "evidence",
+        "source_requirement_ids": (
+            "req_ade_qre_017c_reason_record_linkage",
+        ),
+        "expected_files": (
+            "reporting/qre_reason_record_maturity.py",
+            "tests/unit/test_qre_reason_record_maturity.py",
+            "docs/governance/qre_reason_record_maturity.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_qre_reason_record_maturity.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.qre_reason_record_maturity",
+            "logs/qre_reason_record_maturity/",
+        )
+        + (
+            (
+                "reporter fails closed when reason records claim evidence "
+                "that is absent or unlinked"
+            ),
+        ),
+        "extra_stop_conditions": (
+            "any synthesized reason text without evidence reference -> STOP",
+        ),
+        "prerequisites": (
+            "u_ade_qre_017b_evidence_density_inventory_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_ade_qre_017d_readiness_population_reporter_001",
+        "roadmap_task_id": "ade_qre_017d_routing_sampling_readiness",
+        "title": "Routing and sampling readiness population reporter",
+        "phase": "ade_qre_017d",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": (
+            "req_ade_qre_017d_readiness_population",
+        ),
+        "expected_files": (
+            "reporting/qre_routing_sampling_readiness.py",
+            "tests/unit/test_qre_routing_sampling_readiness.py",
+            "docs/governance/qre_routing_sampling_readiness.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_qre_routing_sampling_readiness.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.qre_routing_sampling_readiness",
+            "logs/qre_routing_sampling_readiness/",
+        )
+        + (
+            (
+                "readiness status distinguishes scaffold from evidence-backed "
+                "readiness for routing and sampling surfaces"
+            ),
+        ),
+        "extra_stop_conditions": (
+            "any readiness row promoted from scaffold without evidence -> STOP",
+        ),
+        "prerequisites": (
+            "u_ade_qre_017c_reason_record_maturity_reporter_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_ade_qre_017e_kpi_snapshot_reporter_001",
+        "roadmap_task_id": "ade_qre_017e_kpi_snapshot_completeness",
+        "title": "KPI completeness and historical snapshot reporter",
+        "phase": "ade_qre_017e",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": (
+            "req_ade_qre_017e_kpi_snapshots",
+        ),
+        "expected_files": (
+            "reporting/qre_kpi_snapshot_completeness.py",
+            "tests/unit/test_qre_kpi_snapshot_completeness.py",
+            "docs/governance/qre_kpi_snapshot_completeness.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_qre_kpi_snapshot_completeness.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.qre_kpi_snapshot_completeness",
+            "logs/qre_kpi_snapshot_completeness/",
+        )
+        + (
+            (
+                "snapshot output records numeric KPI values or explicit "
+                "unavailable states with repeatable historical identity"
+            ),
+        ),
+        "extra_stop_conditions": (
+            "any KPI row omitted instead of marked unavailable -> STOP",
+        ),
+        "prerequisites": (
+            "u_ade_qre_017d_readiness_population_reporter_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
     # -------------------- v3.15.16 Intelligent Routing Layer ------------
     {
         "id": "u_v3_15_16_diagnostic_routing_signals_schema_001",

--- a/tests/unit/test_roadmap_next_unit.py
+++ b/tests/unit/test_roadmap_next_unit.py
@@ -49,6 +49,7 @@ import pytest
 
 from reporting import roadmap_next_unit as rnu
 from reporting import roadmap_task_units as rtu
+from reporting import roadmap_unit_authority as rua
 
 
 # ---------------------------------------------------------------------------
@@ -224,6 +225,11 @@ def test_phase_order_matches_a20a_phase_list() -> None:
     # A20a defines the canonical phase list. A20b mirrors it via
     # rtu.collect_snapshot()'s catalog cross-reference.
     for phase in (
+        "ade_qre_017a",
+        "ade_qre_017b",
+        "ade_qre_017c",
+        "ade_qre_017d",
+        "ade_qre_017e",
         "v3.15.16",
         "v3.15.17",
         "v3.15.18",
@@ -364,6 +370,39 @@ def test_auto_allowed_unit_is_selected(tmp_path: Path) -> None:
     assert sel["selected_authority_class"] == "AUTO_ALLOWED"
     assert sel["requires_operator_go"] is False
     assert sel["fail_closed"] is False
+
+
+def test_ade_qre_phase_is_preferred_over_legacy_phase(tmp_path: Path) -> None:
+    ade_unit = _baseline_unit(
+        id="u_ade_qre_017a_maturity_matrix_reporter_001",
+        roadmap_task_id="ade_qre_017a_baseline_reconciliation",
+        phase="ade_qre_017a",
+        title="ADE-QRE-017A baseline unit",
+    )
+    legacy_unit = _baseline_unit(
+        id="u_v3_15_16_legacy",
+        roadmap_task_id="phase_v3_15_16",
+        phase="v3.15.16",
+        title="legacy unit",
+    )
+    _write_units_artifact(tmp_path, [legacy_unit, ade_unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                implementation_unit_id=legacy_unit["id"],
+                roadmap_task_id=legacy_unit["roadmap_task_id"],
+                phase=legacy_unit["phase"],
+            ),
+            _baseline_decision(
+                implementation_unit_id=ade_unit["id"],
+                roadmap_task_id=ade_unit["roadmap_task_id"],
+                phase=ade_unit["phase"],
+            ),
+        ],
+    )
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selected_unit_id"] == ade_unit["id"]
 
 
 def test_eligibility_marker_on_candidate(tmp_path: Path) -> None:
@@ -553,6 +592,62 @@ def test_all_blocked_by_prerequisites_status(tmp_path: Path) -> None:
     )
     snap = _snap(tmp_path)
     assert snap["selection"]["selection_status"] == "ALL_BLOCKED_BY_PREREQUISITES"
+
+
+def test_ade_qre_future_units_are_blocked_until_prior_unit_is_merged(
+    tmp_path: Path,
+) -> None:
+    u_a = _baseline_unit(
+        id="u_ade_qre_017a_maturity_matrix_reporter_001",
+        roadmap_task_id="ade_qre_017a_baseline_reconciliation",
+        phase="ade_qre_017a",
+        status="ready",
+    )
+    u_b = _baseline_unit(
+        id="u_ade_qre_017b_evidence_density_inventory_001",
+        roadmap_task_id="ade_qre_017b_evidence_density_population",
+        phase="ade_qre_017b",
+        prerequisites=["u_ade_qre_017a_maturity_matrix_reporter_001"],
+    )
+    _write_units_artifact(tmp_path, [u_a, u_b])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                implementation_unit_id=u_a["id"],
+                roadmap_task_id=u_a["roadmap_task_id"],
+                phase=u_a["phase"],
+            ),
+            _baseline_decision(
+                implementation_unit_id=u_b["id"],
+                roadmap_task_id=u_b["roadmap_task_id"],
+                phase=u_b["phase"],
+            ),
+        ],
+    )
+    snap = _snap(tmp_path)
+    by_id = {c["implementation_unit_id"]: c for c in snap["candidates"]}
+    assert snap["selection"]["selected_unit_id"] == u_a["id"]
+    assert by_id[u_b["id"]]["eligibility"] == "BLOCKED"
+    assert "unsatisfied_prerequisite" in by_id[u_b["id"]]["block_reasons"]
+
+
+def test_materialized_current_a20_stack_selects_ade_qre_017a_first(
+    tmp_path: Path,
+) -> None:
+    units_path = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    units_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path = tmp_path / "logs" / "roadmap_unit_authority" / "latest.json"
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+
+    units_payload = rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    auth_payload = rua.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    units_path.write_text(json.dumps(units_payload, sort_keys=True), encoding="utf-8")
+    auth_path.write_text(json.dumps(auth_payload, sort_keys=True), encoding="utf-8")
+
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selected_unit_id"] == "u_ade_qre_017a_maturity_matrix_reporter_001"
+    assert snap["selection"]["selected_phase"] == "ade_qre_017a"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_roadmap_task_catalog.py
+++ b/tests/unit/test_roadmap_task_catalog.py
@@ -53,6 +53,11 @@ def snap() -> dict:
 
 def test_phase_vocabulary_is_closed_and_complete() -> None:
     assert rtc.PHASE == (
+        "ade_qre_017a",
+        "ade_qre_017b",
+        "ade_qre_017c",
+        "ade_qre_017d",
+        "ade_qre_017e",
         "v3.15.16",
         "v3.15.17",
         "v3.15.18",
@@ -68,6 +73,9 @@ def test_source_document_vocabulary_includes_addenda_2_and_3() -> None:
     """A23 made Addendum 2 + 3 repo-resident. SOURCE_DOCUMENT now
     pins both files alongside Roadmap v6 and Addendum 1."""
     assert rtc.SOURCE_DOCUMENT == (
+        "docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md",
+        "docs/roadmap/qre_maturity_roadmap_to_100.md",
+        "docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md",
         "docs/roadmap/Roadmap v6.md",
         "docs/roadmap/Roadmap v6 Addendum.md",
         (
@@ -260,6 +268,15 @@ def test_phase_v3_15_16_task_present(snap: dict) -> None:
     assert "Intelligent Routing Layer" in t["title"]
 
 
+def test_ade_qre_017a_to_017e_tasks_present(snap: dict) -> None:
+    tasks = _tasks_by_phase(snap)
+    assert tasks["ade_qre_017a"]["id"] == "ade_qre_017a_baseline_reconciliation"
+    assert tasks["ade_qre_017b"]["id"] == "ade_qre_017b_evidence_density_population"
+    assert tasks["ade_qre_017c"]["id"] == "ade_qre_017c_reason_record_maturity"
+    assert tasks["ade_qre_017d"]["id"] == "ade_qre_017d_routing_sampling_readiness"
+    assert tasks["ade_qre_017e"]["id"] == "ade_qre_017e_kpi_snapshot_completeness"
+
+
 def test_phase_v3_15_17_task_present(snap: dict) -> None:
     t = _tasks_by_phase(snap)["v3.15.17"]
     assert t["id"] == "phase_v3_15_17"
@@ -308,6 +325,11 @@ def test_addendum_2_and_3_have_tasks_after_a23(snap: dict) -> None:
 def test_v3_15_16_to_v3_15_20_all_present_in_order(snap: dict) -> None:
     phases = [t["phase"] for t in snap["roadmap_tasks"]]
     for expected in (
+        "ade_qre_017a",
+        "ade_qre_017b",
+        "ade_qre_017c",
+        "ade_qre_017d",
+        "ade_qre_017e",
         "v3.15.16",
         "v3.15.17",
         "v3.15.18",

--- a/tests/unit/test_roadmap_task_units.py
+++ b/tests/unit/test_roadmap_task_units.py
@@ -382,6 +382,18 @@ def test_every_catalog_task_has_at_least_one_unit(
         assert by_task.get(t["id"]), t["id"]
 
 
+def test_ade_qre_017a_to_017e_each_have_one_seed_unit(snap: dict) -> None:
+    by_phase = _units_by_phase(snap)
+    for phase in (
+        "ade_qre_017a",
+        "ade_qre_017b",
+        "ade_qre_017c",
+        "ade_qre_017d",
+        "ade_qre_017e",
+    ):
+        assert len(by_phase.get(phase, [])) == 1, phase
+
+
 @pytest.mark.parametrize(
     "phase",
     ["v3.15.16", "v3.15.17", "v3.15.18", "v3.15.19", "v3.15.20"],
@@ -1040,6 +1052,37 @@ def test_downstream_v3_15_16_units_still_reference_merged_unit(
     assert len(downstream) == 2
     for u in downstream:
         assert _ROUTING_SIGNALS_SCHEMA_UNIT_ID in u["prerequisites"], u["id"]
+
+
+def test_ade_qre_017_wave_prerequisites_form_linear_chain(snap: dict) -> None:
+    by_id = {u["id"]: u for u in snap["implementation_units"]}
+    assert by_id["u_ade_qre_017a_maturity_matrix_reporter_001"]["prerequisites"] == []
+    assert by_id["u_ade_qre_017b_evidence_density_inventory_001"]["prerequisites"] == [
+        "u_ade_qre_017a_maturity_matrix_reporter_001"
+    ]
+    assert by_id["u_ade_qre_017c_reason_record_maturity_reporter_001"]["prerequisites"] == [
+        "u_ade_qre_017b_evidence_density_inventory_001"
+    ]
+    assert by_id["u_ade_qre_017d_readiness_population_reporter_001"]["prerequisites"] == [
+        "u_ade_qre_017c_reason_record_maturity_reporter_001"
+    ]
+    assert by_id["u_ade_qre_017e_kpi_snapshot_reporter_001"]["prerequisites"] == [
+        "u_ade_qre_017d_readiness_population_reporter_001"
+    ]
+
+
+def test_ade_qre_017a_unit_is_ready_and_future_wave_units_not_started(
+    snap: dict,
+) -> None:
+    by_id = {u["id"]: u for u in snap["implementation_units"]}
+    assert by_id["u_ade_qre_017a_maturity_matrix_reporter_001"]["status"] == "ready"
+    for unit_id in (
+        "u_ade_qre_017b_evidence_density_inventory_001",
+        "u_ade_qre_017c_reason_record_maturity_reporter_001",
+        "u_ade_qre_017d_readiness_population_reporter_001",
+        "u_ade_qre_017e_kpi_snapshot_reporter_001",
+    ):
+        assert by_id[unit_id]["status"] == "not_started", unit_id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add ADE-QRE-017A through ADE-QRE-017E to the A20 roadmap task catalog and requirement seed
- add one PR-sized implementation unit per new ADE-QRE-017 wave-1 task and make A20e prefer the new phase order
- extend the A20 governance doc and pin tests so refreshed artifacts select `u_ade_qre_017a_maturity_matrix_reporter_001` first

## Dependencies
- depends on PR #618 / merge `686730655068b747b1d18011c5e950de5f5ebec4`
- no runtime, broker, risk, execution, paper, shadow, live, or frozen-contract scope

## Validation
- `python scripts/governance_lint.py`
- `python -m pytest tests/architecture -q`
- `python -m reporting.architecture_import_scan --format summary`
- `python -m pytest tests/unit/test_roadmap_task_catalog.py tests/unit/test_roadmap_task_units.py tests/unit/test_roadmap_unit_authority.py tests/unit/test_roadmap_next_unit.py -q`
- `python -m pytest tests/unit/test_autonomous_pr_runner.py tests/unit/test_roadmap_unit_status.py -q`
- `python -m reporting.roadmap_task_catalog --status`
- `python -m reporting.roadmap_task_units --status`
- `python -m reporting.roadmap_unit_authority --status`
- `python -m reporting.roadmap_next_unit --status`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Handoff
- refreshed A20 artifacts now classify 42 implementation units and select `ADE-QRE-017A` first
- next eligible execution unit after merge is `u_ade_qre_017a_maturity_matrix_reporter_001`
