### PR TITLE
docs: record ADE-QRE-017A completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2741,6 +2741,14 @@ live, broker, risk, or execution work.
 - validation required:
   - capability classes are closed and repository-backed.
   - counts, blockers, and non-authoritative surfaces are explicit.
+- completion evidence: PR #620, merge SHA `92e7ba900a451e924ae98dfe51e37a838de6a518`;
+  PR checks green after the boundary/queue-test repair follow-up; post-merge
+  `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`,
+  and `python -m reporting.architecture_import_scan --format summary` passed on
+  `main`; `python -m reporting.roadmap_next_unit --status` selected
+  `u_ade_qre_017b_evidence_density_inventory_001` / `ADE-QRE-017B`; frozen
+  contracts unchanged; protected/execution paths untouched; paper/shadow/live,
+  broker, risk, and execution behavior remained inactive.
 - next dependency: `ADE-QRE-017B`.
 
 ### ADE-QRE-017B - Evidence-Density Population Plan


### PR DESCRIPTION
Add the missing completion-evidence line for ADE-QRE-017A in the canonical ADE queue doc. Scope is limited to docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md. Validation: pytest tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q; python -m reporting.ade_queue_status_self_audit --no-write; git diff --check; git diff -- research/research_latest.json research/strategy_matrix.csv.