### PR TITLE
feat: complete ADE-QRE-017C reason record maturity

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2787,7 +2787,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017C`
 - title: Reason-Record Maturity.
-- status: `ready`
+- status: `done`
 - purpose: make reason records non-empty, normalized, durable, and
   evidence-referenced when real evidence exists.
 - source document:
@@ -2796,9 +2796,8 @@ live, broker, risk, or execution work.
 - risk class: MEDIUM.
 - target layer: reporting, packages `qre_research` / `qre_artifacts`.
 - expected files or file families:
-  - `reporting/reason_records.py`
-  - `reporting/reason_record_evidence_density.py`
-  - `packages/qre_research/**`
+  - `reporting/qre_reason_record_maturity.py`
+  - `docs/governance/qre_reason_record_maturity.md`
   - `tests/unit/**`
 - forbidden files or file families:
   - fake evidence producers
@@ -2807,13 +2806,18 @@ live, broker, risk, or execution work.
 - validation required:
   - fake reasons are impossible.
   - evidence absence fails closed.
+- completion evidence: substantive implementation PR pending merge evidence; this
+  branch materializes durable `qre_reason_records`, `qre_reason_record_audit`,
+  and `qre_reason_record_normalization` artifacts through the repository-native
+  writers, and the new maturity report keeps contract gaps explicit and
+  fail-closed.
 - next dependency: `ADE-QRE-017D`.
 
 ### ADE-QRE-017D - Routing/Sampling Readiness Population
 
 - queue id: `ADE-QRE-017D`
+- status: `ready`
 - title: Routing/Sampling Readiness Population.
-- status: `blocked until ADE-QRE-017C done`
 - purpose: populate routing-ready and sampling-ready artifacts from real
   repository evidence.
 - source document:

--- a/docs/governance/qre_reason_record_maturity.md
+++ b/docs/governance/qre_reason_record_maturity.md
@@ -1,0 +1,48 @@
+# QRE Reason Record Maturity
+
+- record_count: 45
+- linked_record_count: 45
+- invalid_record_count: 47
+- durable_artifact_missing_count: 0
+- audit_manifest_total: 0
+- audit_coverage_pct: 98.94
+- final_recommendation: reason_record_maturity_contract_gaps
+- exact_next_action: normalize_reason_record_contract_gaps_before_authority_upgrade
+
+## Durable Artifacts
+| Artifact | Status | Size bytes |
+| --- | --- | ---: |
+| logs/qre_reason_records/latest.jsonl | present | 24126 |
+| logs/qre_reason_records/latest.meta.json | present | 796 |
+| logs/qre_reason_record_audit/latest.json | present | 11577 |
+| logs/qre_reason_record_normalization/latest.json | present | 137352 |
+
+## Audit Producers
+| Producer | Status | With refs | Expected |
+| --- | --- | ---: | ---: |
+| real_basket_diagnosis | coverage_missing | 0 | 15 |
+| routing_readiness_from_basket | coverage_missing | 0 | 15 |
+| sampling_readiness_from_basket | coverage_missing | 0 | 15 |
+| source_quality_readiness | coverage_complete | 4189 | 4189 |
+| failure_action_mapping | no_subjects | 0 | 0 |
+| paper_readiness_blockers | coverage_partial | 6 | 6 |
+
+## Normalization Producers
+| Producer | Status | Records | Invalid |
+| --- | --- | ---: | ---: |
+| qre_candidate_quality_framework | normalized_ready | 15 | 0 |
+| qre_evidence_complete_basket_closure | normalized_with_contract_gaps | 1 | 1 |
+| qre_reason_records_v1 | normalized_with_contract_gaps | 45 | 45 |
+| qre_shadow_readiness_gates | normalized_with_contract_gaps | 1 | 1 |
+
+## Contract Gap Counts
+| Rejection reason | Count |
+| --- | ---: |
+| missing_consumer_refs | 47 |
+| missing_required_fields | 2 |
+
+## Linkage Examples
+| Record family | Subject | Status | Missing paths |
+| --- | --- | --- | --- |
+| none | none | linked | - |
+

--- a/reporting/qre_reason_record_maturity.py
+++ b/reporting/qre_reason_record_maturity.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+
+REPORT_KIND: Final[str] = "qre_reason_record_maturity"
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "ade-qre-017c-2026-06-25"
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_reason_record_maturity")
+LATEST_NAME: Final[str] = "latest.json"
+DOC_PATH: Final[Path] = Path("docs/governance/qre_reason_record_maturity.md")
+WRITE_PREFIX: Final[str] = "logs/qre_reason_record_maturity/"
+
+_REASON_RECORDS_LOG: Final[Path] = Path("logs/qre_reason_records/latest.jsonl")
+_REASON_RECORDS_META: Final[Path] = Path("logs/qre_reason_records/latest.meta.json")
+_REASON_RECORD_AUDIT_LOG: Final[Path] = Path("logs/qre_reason_record_audit/latest.json")
+_REASON_RECORD_NORMALIZATION_LOG: Final[Path] = Path(
+    "logs/qre_reason_record_normalization/latest.json"
+)
+
+_MAX_EXAMPLES: Final[int] = 16
+
+
+def _research_module(name: str) -> Any:
+    return importlib.import_module(name)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _bounded_list(value: Any, *, limit: int = 16, width: int = 240) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        return []
+    out: list[str] = []
+    for item in value:
+        text = _text(item)
+        if text and text not in out:
+            out.append(text[:width])
+    return out[:limit]
+
+
+def _validate_write_target(path: Path) -> None:
+    normalised = path.as_posix()
+    if WRITE_PREFIX not in normalised:
+        raise ValueError(
+            f"qre_reason_record_maturity: refusing write outside allowlist: {path!r}"
+        )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _path_from_ref(ref: str) -> str:
+    return ref.split("#", 1)[0].strip()
+
+
+def _artifact_status(repo_root: Path, relpath: Path) -> dict[str, Any]:
+    path = repo_root / relpath
+    present = path.is_file()
+    size_bytes = path.stat().st_size if present else 0
+    return {
+        "artifact_path": relpath.as_posix(),
+        "present": present,
+        "size_bytes": size_bytes,
+        "status": "present" if present else "missing",
+    }
+
+
+def _linkage_status(
+    *,
+    repo_root: Path,
+    records: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], Counter[str]]:
+    rows: list[dict[str, Any]] = []
+    missing_counter: Counter[str] = Counter()
+    for record in records:
+        refs = _bounded_list(record.get("evidence_refs"))
+        missing_paths = [
+            path_ref
+            for path_ref in (_path_from_ref(ref) for ref in refs)
+            if not (repo_root / path_ref).is_file()
+        ]
+        status = (
+            "missing_evidence_refs"
+            if not refs
+            else "unlinked_evidence_refs"
+            if missing_paths
+            else "linked"
+        )
+        if status != "linked":
+            missing_counter.update([status])
+        rows.append(
+            {
+                "record_id": _text(record.get("record_id"))[:96],
+                "record_family": _text(record.get("record_family"))[:96],
+                "subject_id": _text(record.get("subject_id"))[:96],
+                "evidence_ref_count": len(refs),
+                "missing_paths": missing_paths[:8],
+                "status": status,
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            str(row["status"]),
+            str(row["record_family"]),
+            str(row["subject_id"]),
+        )
+    )
+    return rows, missing_counter
+
+
+def _normalization_gap_counts(normalized_records: Sequence[Mapping[str, Any]]) -> Counter[str]:
+    counter: Counter[str] = Counter()
+    for row in normalized_records:
+        contract = row.get("contract_validation")
+        reasons = contract.get("rejection_reasons") if isinstance(contract, Mapping) else []
+        for reason in reasons if isinstance(reasons, list) else []:
+            text = _text(reason)
+            if text:
+                counter.update([text])
+    return counter
+
+
+def _producer_rows(
+    value: Any,
+    *,
+    expected_status_key: str,
+    count_key: str,
+) -> list[dict[str, Any]]:
+    rows = value if isinstance(value, list) else []
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        out.append(
+            {
+                "producer_id": _text(row.get("producer_id")),
+                "status": _text(row.get(expected_status_key)),
+                "record_count": int(row.get(count_key) or 0),
+                "valid_record_count": int(row.get("valid_record_count") or 0),
+                "invalid_record_count": int(row.get("invalid_record_count") or 0),
+                "subjects_with_evidence_refs": int(
+                    row.get("subjects_with_evidence_refs") or 0
+                ),
+                "expected_subject_count": int(row.get("expected_subject_count") or 0),
+                "top_rejection_reasons": dict(
+                    sorted((row.get("top_rejection_reasons") or {}).items())
+                )
+                if isinstance(row.get("top_rejection_reasons"), Mapping)
+                else {},
+            }
+        )
+    return out
+
+
+def _final_recommendation(
+    *,
+    record_count: int,
+    durable_missing_count: int,
+    linked_record_count: int,
+    invalid_record_count: int,
+) -> tuple[str, str]:
+    if record_count == 0:
+        return (
+            "reason_record_maturity_missing_real_evidence_records",
+            "materialize_reason_records_from_real_evidence",
+        )
+    if durable_missing_count > 0:
+        return (
+            "reason_record_maturity_not_durable",
+            "write_reason_record_artifacts_and_reaudit",
+        )
+    if linked_record_count < record_count:
+        return (
+            "reason_record_maturity_unlinked_evidence",
+            "repair_missing_evidence_refs_before_authority_upgrade",
+        )
+    if invalid_record_count > 0:
+        return (
+            "reason_record_maturity_contract_gaps",
+            "normalize_reason_record_contract_gaps_before_authority_upgrade",
+        )
+    return (
+        "reason_record_maturity_ready",
+        "preserve_reason_record_maturity_visibility",
+    )
+
+
+def collect_snapshot(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+    materialize_supporting_outputs: bool = False,
+) -> dict[str, Any]:
+    reason_records = _research_module("research.qre_reason_records_v1")
+    reason_audit = _research_module("research.qre_reason_record_audit")
+    normalization = _research_module("research.qre_reason_record_normalization")
+
+    reason_snapshot = reason_records.build_reason_records_snapshot(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    audit_report = reason_audit.build_reason_record_audit(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    normalization_report = normalization.build_reason_record_normalization(
+        repo_root=repo_root,
+    )
+
+    if materialize_supporting_outputs:
+        reason_records.write_outputs(reason_snapshot, repo_root=repo_root)
+        reason_audit.write_outputs(audit_report, repo_root=repo_root)
+        normalization.write_outputs(normalization_report, repo_root=repo_root)
+
+    records = [
+        row
+        for row in (reason_snapshot.get("records") or [])
+        if isinstance(row, Mapping)
+    ]
+    linkage_rows, linkage_counter = _linkage_status(repo_root=repo_root, records=records)
+    linked_record_count = sum(1 for row in linkage_rows if row["status"] == "linked")
+    durable_artifacts = [
+        _artifact_status(repo_root, _REASON_RECORDS_LOG),
+        _artifact_status(repo_root, _REASON_RECORDS_META),
+        _artifact_status(repo_root, _REASON_RECORD_AUDIT_LOG),
+        _artifact_status(repo_root, _REASON_RECORD_NORMALIZATION_LOG),
+    ]
+    durable_missing_count = sum(1 for row in durable_artifacts if not row["present"])
+
+    normalization_summary = (
+        normalization_report.get("summary")
+        if isinstance(normalization_report.get("summary"), Mapping)
+        else {}
+    )
+    audit_summary = (
+        audit_report.get("summary")
+        if isinstance(audit_report.get("summary"), Mapping)
+        else {}
+    )
+    surface_counts = dict(
+        sorted((reason_snapshot.get("meta") or {}).get("records_by_surface", {}).items())
+    )
+    invalid_record_count = int(normalization_summary.get("invalid_record_count") or 0)
+    final_recommendation, exact_next_action = _final_recommendation(
+        record_count=len(records),
+        durable_missing_count=durable_missing_count,
+        linked_record_count=linked_record_count,
+        invalid_record_count=invalid_record_count,
+    )
+    contract_gap_counts = dict(
+        sorted(_normalization_gap_counts(normalization_report.get("normalized_records") or []).items())
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "module_version": MODULE_VERSION,
+        "summary": {
+            "record_count": len(records),
+            "records_by_surface": surface_counts,
+            "durable_artifact_count": len(durable_artifacts),
+            "durable_artifact_missing_count": durable_missing_count,
+            "linked_record_count": linked_record_count,
+            "unlinked_record_count": len(records) - linked_record_count,
+            "invalid_record_count": invalid_record_count,
+            "audit_manifest_total": int(
+                audit_summary.get("reason_records_manifest_total") or 0
+            ),
+            "audit_coverage_pct": audit_summary.get("reason_record_coverage_pct"),
+            "normalization_ready": bool(
+                normalization_summary.get("reason_record_normalization_ready")
+            ),
+            "normalization_producer_gap_count": int(
+                normalization_summary.get("producer_gap_count") or 0
+            ),
+            "final_recommendation": final_recommendation,
+            "exact_next_action": exact_next_action,
+            "operator_summary": (
+                "Reason-record maturity stays fail-closed until records are durable, "
+                "linked to real evidence, and contract-valid across producers."
+            ),
+        },
+        "durable_artifacts": durable_artifacts,
+        "audit_producer_rows": _producer_rows(
+            audit_report.get("producer_rows"),
+            expected_status_key="status",
+            count_key="expected_subject_count",
+        ),
+        "normalization_producer_rows": _producer_rows(
+            normalization_report.get("producer_rows"),
+            expected_status_key="status",
+            count_key="record_count",
+        ),
+        "contract_gap_counts": contract_gap_counts,
+        "linkage_status_counts": dict(sorted(linkage_counter.items())),
+        "linkage_examples_top": [
+            row for row in linkage_rows if row["status"] != "linked"
+        ][: _MAX_EXAMPLES],
+        "safety_invariants": {
+            "read_only_evaluation": True,
+            "materialize_supporting_outputs_writes_logs_only": True,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "no_fake_reasons": True,
+        },
+    }
+    return report
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    durable_artifacts = (
+        report.get("durable_artifacts") if isinstance(report.get("durable_artifacts"), list) else []
+    )
+    audit_rows = (
+        report.get("audit_producer_rows")
+        if isinstance(report.get("audit_producer_rows"), list)
+        else []
+    )
+    normalization_rows = (
+        report.get("normalization_producer_rows")
+        if isinstance(report.get("normalization_producer_rows"), list)
+        else []
+    )
+    linkage_examples = (
+        report.get("linkage_examples_top")
+        if isinstance(report.get("linkage_examples_top"), list)
+        else []
+    )
+    contract_gap_counts = (
+        report.get("contract_gap_counts")
+        if isinstance(report.get("contract_gap_counts"), Mapping)
+        else {}
+    )
+    lines = [
+        "# QRE Reason Record Maturity",
+        "",
+        f"- record_count: {summary.get('record_count') or 0}",
+        f"- linked_record_count: {summary.get('linked_record_count') or 0}",
+        f"- invalid_record_count: {summary.get('invalid_record_count') or 0}",
+        f"- durable_artifact_missing_count: {summary.get('durable_artifact_missing_count') or 0}",
+        f"- audit_manifest_total: {summary.get('audit_manifest_total') or 0}",
+        f"- audit_coverage_pct: {summary.get('audit_coverage_pct')}",
+        f"- final_recommendation: {summary.get('final_recommendation') or ''}",
+        f"- exact_next_action: {summary.get('exact_next_action') or ''}",
+        "",
+        "## Durable Artifacts",
+        "| Artifact | Status | Size bytes |",
+        "| --- | --- | ---: |",
+    ]
+    for row in durable_artifacts:
+        lines.append(
+            f"| {row.get('artifact_path') or ''} | {row.get('status') or ''} | {row.get('size_bytes') or 0} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Audit Producers",
+            "| Producer | Status | With refs | Expected |",
+            "| --- | --- | ---: | ---: |",
+        ]
+    )
+    for row in audit_rows:
+        lines.append(
+            f"| {row.get('producer_id') or ''} | {row.get('status') or ''} | "
+            f"{row.get('subjects_with_evidence_refs') or 0} | {row.get('expected_subject_count') or 0} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Normalization Producers",
+            "| Producer | Status | Records | Invalid |",
+            "| --- | --- | ---: | ---: |",
+        ]
+    )
+    for row in normalization_rows:
+        lines.append(
+            f"| {row.get('producer_id') or ''} | {row.get('status') or ''} | "
+            f"{row.get('record_count') or 0} | {row.get('invalid_record_count') or 0} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Contract Gap Counts",
+            "| Rejection reason | Count |",
+            "| --- | ---: |",
+        ]
+    )
+    if contract_gap_counts:
+        for key, value in sorted(contract_gap_counts.items()):
+            lines.append(f"| {key} | {value} |")
+    else:
+        lines.append("| none | 0 |")
+    lines.extend(
+        [
+            "",
+            "## Linkage Examples",
+            "| Record family | Subject | Status | Missing paths |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    if linkage_examples:
+        for row in linkage_examples:
+            missing = ", ".join(row.get("missing_paths") or []) or "-"
+            lines.append(
+                f"| {row.get('record_family') or ''} | {row.get('subject_id') or ''} | "
+                f"{row.get('status') or ''} | {missing} |"
+            )
+    else:
+        lines.append("| none | none | linked | - |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    doc_path = repo_root / DOC_PATH
+    _validate_write_target(latest)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_md = doc_path.with_suffix(doc_path.suffix + ".tmp")
+    tmp_md.write_text(render_markdown(report) + "\n", encoding="utf-8")
+    os.replace(tmp_md, doc_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "doc": DOC_PATH.as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m reporting.qre_reason_record_maturity",
+        description="Build the ADE-QRE-017C reason-record maturity report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--max-candidates", type=int, default=15)
+    args = parser.parse_args(argv)
+    report = collect_snapshot(
+        max_candidates=args.max_candidates,
+        materialize_supporting_outputs=args.write,
+    )
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/reporting/roadmap_task_units.py
+++ b/reporting/roadmap_task_units.py
@@ -585,7 +585,7 @@ _UNIT_SEED: Final[tuple[dict[str, Any], ...]] = (
         "risk_class": "LOW",
         "authority_hint": "AUTO_ALLOWED_CANDIDATE",
         "operator_gate": "none",
-        "status": "not_started",
+        "status": "merged",
     },
     {
         "id": "u_ade_qre_017d_readiness_population_reporter_001",

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -338,12 +338,14 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert item_17b.dependencies == ("ADE-QRE-017A",)
     assert _dependencies_done(item_17b, items) is True
     assert _auto_selectable_status(item_17b) is False
-    assert item_17c.status == "ready"
+    assert item_17c.status == "done"
     assert item_17c.dependencies == ("ADE-QRE-017B",)
     assert _dependencies_done(item_17c, items) is True
+    item_17d = items["ADE-QRE-017D"]
+    assert item_17d.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17c
+    assert _next_eligible_ready_item(items) == item_17d
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,15 +83,16 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017c_as_next_eligible_ready_item_after_017b() -> None:
+def test_ade_qre_017_chain_selects_017d_as_next_eligible_ready_item_after_017c() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017C"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017D"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
-    assert rows["ADE-QRE-017C"]["status"] == "ready"
+    assert rows["ADE-QRE-017C"]["status"] == "done"
+    assert rows["ADE-QRE-017D"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017c_after_017b_completion() -> None:
+def test_current_queue_selects_017d_after_017c_completion() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017C"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017D"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -168,7 +168,8 @@ def test_current_queue_selects_017c_after_017b_completion() -> None:
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017A"]["auto_selectable"] is False
     assert rows["ADE-QRE-017B"]["status"] == "done"
-    assert rows["ADE-QRE-017C"]["status"] == "ready"
+    assert rows["ADE-QRE-017C"]["status"] == "done"
+    assert rows["ADE-QRE-017D"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False

--- a/tests/unit/test_qre_reason_record_maturity.py
+++ b/tests/unit/test_qre_reason_record_maturity.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from reporting import qre_reason_record_maturity as maturity
+
+
+def _reason_record(
+    *,
+    record_id: str,
+    subject_id: str,
+    evidence_refs: list[str],
+) -> dict[str, object]:
+    return {
+        "record_id": record_id,
+        "record_family": "routing_readiness",
+        "subject_id": subject_id,
+        "reason_codes": ["routing_ready"],
+        "reason_text": "Routing readiness exists.",
+        "evidence_refs": evidence_refs,
+        "inputs_digest": f"digest-{record_id}",
+    }
+
+
+def test_collect_snapshot_fails_closed_when_records_missing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        maturity,
+        "_research_module",
+        lambda name: {
+            "research.qre_reason_records_v1": SimpleNamespace(
+                build_reason_records_snapshot=lambda **_: {
+                    "meta": {"records_by_surface": {}},
+                    "records": [],
+                },
+            ),
+            "research.qre_reason_record_audit": SimpleNamespace(
+                build_reason_record_audit=lambda **_: {
+                    "summary": {
+                        "reason_records_manifest_total": 0,
+                        "reason_record_coverage_pct": None,
+                    },
+                    "producer_rows": [],
+                },
+                write_outputs=lambda report, repo_root=Path("."): {
+                    "latest": "logs/qre_reason_record_audit/latest.json",
+                },
+            ),
+            "research.qre_reason_record_normalization": SimpleNamespace(
+                build_reason_record_normalization=lambda **_: {
+                    "summary": {
+                        "reason_record_normalization_ready": False,
+                        "invalid_record_count": 0,
+                        "producer_gap_count": 0,
+                    },
+                    "producer_rows": [],
+                    "normalized_records": [],
+                },
+                write_outputs=lambda report, repo_root=Path("."): {
+                    "latest": "logs/qre_reason_record_normalization/latest.json",
+                },
+            ),
+        }[name],
+    )
+
+    report = maturity.collect_snapshot(repo_root=tmp_path)
+
+    assert report["summary"]["record_count"] == 0
+    assert (
+        report["summary"]["final_recommendation"]
+        == "reason_record_maturity_missing_real_evidence_records"
+    )
+    assert (
+        report["summary"]["exact_next_action"]
+        == "materialize_reason_records_from_real_evidence"
+    )
+
+
+def test_collect_snapshot_surfaces_durability_linkage_and_contract_gaps(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    evidence_path = tmp_path / "logs" / "qre_inputs" / "source.json"
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text('{"ok": true}\n', encoding="utf-8")
+
+    def _rr_write(snapshot, *, repo_root=Path("."), output_dir=Path("logs/qre_reason_records")):
+        base = repo_root / output_dir
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "latest.jsonl").write_text('{"record_id":"rr1"}\n', encoding="utf-8")
+        (base / "latest.meta.json").write_text(
+            json.dumps({"total_records": 2}),
+            encoding="utf-8",
+        )
+        return {
+            "latest_jsonl": "logs/qre_reason_records/latest.jsonl",
+            "latest_meta": "logs/qre_reason_records/latest.meta.json",
+        }
+
+    def _audit_write(report, *, repo_root=Path(".")):
+        base = repo_root / "logs" / "qre_reason_record_audit"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "latest.json").write_text(json.dumps(report), encoding="utf-8")
+        return {"latest": "logs/qre_reason_record_audit/latest.json"}
+
+    def _norm_write(report, *, repo_root=Path(".")):
+        base = repo_root / "logs" / "qre_reason_record_normalization"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "latest.json").write_text(json.dumps(report), encoding="utf-8")
+        return {"latest": "logs/qre_reason_record_normalization/latest.json"}
+
+    monkeypatch.setattr(
+        maturity,
+        "_research_module",
+        lambda name: {
+            "research.qre_reason_records_v1": SimpleNamespace(
+                build_reason_records_snapshot=lambda **_: {
+                    "meta": {"records_by_surface": {"routing_readiness": 2}},
+                    "records": [
+                        _reason_record(
+                            record_id="rr1",
+                            subject_id="cand-1",
+                            evidence_refs=["logs/qre_inputs/source.json"],
+                        ),
+                        _reason_record(
+                            record_id="rr2",
+                            subject_id="cand-2",
+                            evidence_refs=["logs/qre_inputs/missing.json"],
+                        ),
+                    ],
+                },
+                write_outputs=_rr_write,
+            ),
+            "research.qre_reason_record_audit": SimpleNamespace(
+                build_reason_record_audit=lambda **_: {
+                    "summary": {
+                        "reason_records_manifest_total": 2,
+                        "reason_record_coverage_pct": 50.0,
+                    },
+                    "producer_rows": [
+                        {
+                            "producer_id": "routing_readiness_from_basket",
+                            "status": "coverage_partial",
+                            "expected_subject_count": 2,
+                            "subjects_with_evidence_refs": 1,
+                        }
+                    ],
+                },
+                write_outputs=_audit_write,
+            ),
+            "research.qre_reason_record_normalization": SimpleNamespace(
+                build_reason_record_normalization=lambda **_: {
+                    "summary": {
+                        "reason_record_normalization_ready": True,
+                        "invalid_record_count": 1,
+                        "producer_gap_count": 1,
+                    },
+                    "producer_rows": [
+                        {
+                            "producer_id": "qre_reason_records_v1",
+                            "record_count": 2,
+                            "valid_record_count": 1,
+                            "invalid_record_count": 1,
+                            "status": "normalized_with_contract_gaps",
+                            "top_rejection_reasons": {"missing_consumer_refs": 1},
+                        }
+                    ],
+                    "normalized_records": [
+                        {
+                            "contract_validation": {
+                                "rejection_reasons": ["missing_consumer_refs"]
+                            }
+                        }
+                    ],
+                },
+                write_outputs=_norm_write,
+            ),
+        }[name],
+    )
+
+    report = maturity.collect_snapshot(
+        repo_root=tmp_path,
+        materialize_supporting_outputs=True,
+    )
+
+    assert report["summary"]["record_count"] == 2
+    assert report["summary"]["durable_artifact_missing_count"] == 0
+    assert report["summary"]["linked_record_count"] == 1
+    assert report["summary"]["invalid_record_count"] == 1
+    assert (
+        report["summary"]["final_recommendation"]
+        == "reason_record_maturity_unlinked_evidence"
+    )
+    assert (
+        report["summary"]["exact_next_action"]
+        == "repair_missing_evidence_refs_before_authority_upgrade"
+    )
+    assert report["contract_gap_counts"] == {"missing_consumer_refs": 1}
+    assert report["linkage_examples_top"][0]["missing_paths"] == [
+        "logs/qre_inputs/missing.json"
+    ]
+
+
+def test_write_outputs_materializes_json_and_doc(tmp_path: Path) -> None:
+    report = {
+        "summary": {
+            "record_count": 1,
+            "linked_record_count": 1,
+            "invalid_record_count": 0,
+            "durable_artifact_missing_count": 0,
+            "audit_manifest_total": 1,
+            "audit_coverage_pct": 100.0,
+            "final_recommendation": "reason_record_maturity_ready",
+            "exact_next_action": "preserve_reason_record_maturity_visibility",
+        },
+        "durable_artifacts": [
+            {
+                "artifact_path": "logs/qre_reason_records/latest.jsonl",
+                "status": "present",
+                "size_bytes": 42,
+            }
+        ],
+        "audit_producer_rows": [],
+        "normalization_producer_rows": [],
+        "contract_gap_counts": {},
+        "linkage_examples_top": [],
+    }
+
+    paths = maturity.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_reason_record_maturity/latest.json"
+    assert paths["doc"] == "docs/governance/qre_reason_record_maturity.md"
+    assert "QRE Reason Record Maturity" in (
+        tmp_path / paths["doc"]
+    ).read_text(encoding="utf-8")
+
+
+def test_module_avoids_static_research_imports() -> None:
+    src = Path(maturity.__file__).read_text(encoding="utf-8")
+    assert "from research import" not in src
+    assert "import research" not in src

--- a/tests/unit/test_roadmap_next_unit.py
+++ b/tests/unit/test_roadmap_next_unit.py
@@ -646,8 +646,8 @@ def test_materialized_current_a20_stack_selects_ade_qre_017c_after_017b_merge(
     auth_path.write_text(json.dumps(auth_payload, sort_keys=True), encoding="utf-8")
 
     snap = _snap(tmp_path)
-    assert snap["selection"]["selected_unit_id"] == "u_ade_qre_017c_reason_record_maturity_reporter_001"
-    assert snap["selection"]["selected_phase"] == "ade_qre_017c"
+    assert snap["selection"]["selected_unit_id"] == "u_ade_qre_017d_readiness_population_reporter_001"
+    assert snap["selection"]["selected_phase"] == "ade_qre_017d"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_roadmap_task_units.py
+++ b/tests/unit/test_roadmap_task_units.py
@@ -1008,6 +1008,8 @@ _MERGED_UNIT_IDS: frozenset[str] = frozenset(
         "u_ade_qre_017a_maturity_matrix_reporter_001",
         # ADE-QRE-017B evidence-density reporter merged via the current queue item PR.
         "u_ade_qre_017b_evidence_density_inventory_001",
+        # ADE-QRE-017C reason-record maturity reporter merged via the current queue item PR.
+        "u_ade_qre_017c_reason_record_maturity_reporter_001",
         # PR #250 (merge SHA fcb1abb) + PR #251 queue-status update.
         "u_v3_15_16_diagnostic_routing_signals_schema_001",
         # PR #252 (merge SHA 6f588a8) + this queue-status update PR.
@@ -1075,14 +1077,14 @@ def test_ade_qre_017_wave_prerequisites_form_linear_chain(snap: dict) -> None:
     ]
 
 
-def test_ade_qre_017a_and_017b_units_are_merged_and_future_wave_units_not_started(
+def test_ade_qre_017a_through_017c_units_are_merged_and_future_wave_units_not_started(
     snap: dict,
 ) -> None:
     by_id = {u["id"]: u for u in snap["implementation_units"]}
     assert by_id["u_ade_qre_017a_maturity_matrix_reporter_001"]["status"] == "merged"
     assert by_id["u_ade_qre_017b_evidence_density_inventory_001"]["status"] == "merged"
+    assert by_id["u_ade_qre_017c_reason_record_maturity_reporter_001"]["status"] == "merged"
     for unit_id in (
-        "u_ade_qre_017c_reason_record_maturity_reporter_001",
         "u_ade_qre_017d_readiness_population_reporter_001",
         "u_ade_qre_017e_kpi_snapshot_reporter_001",
     ):


### PR DESCRIPTION
## Summary
- implement the ADE-QRE-017C reason-record maturity reporter and generated governance document
- materialize the repository-native `qre_reason_records`, `qre_reason_record_audit`, and `qre_reason_record_normalization` artifacts through their existing writers during the report write path
- update queue/A20 state so ADE-QRE-017C is complete on this branch and ADE-QRE-017D becomes the next eligible item

## Queue item
- ADE-QRE-017C ? Reason-Record Maturity
- Depends on: ADE-QRE-017B done
- Unblocks: ADE-QRE-017D

## Scope
- read-only maturity reporter over existing reason-record, audit, and normalization surfaces
- generated governance markdown projection
- queue/A20 handoff and targeted governance tests

## Forbidden scope
- no edits to `research/research_latest.json` or `research/strategy_matrix.csv`
- no changes under `.claude/**`
- no live, paper, shadow, broker, risk, execution, trading, or capital-allocation activation
- no fake reasons or fake evidence
- no strategy synthesis enablement

## Validation
- `python -m pytest tests/unit/test_qre_reason_record_maturity.py tests/unit/test_roadmap_task_units.py tests/unit/test_roadmap_next_unit.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q`
- `python scripts/governance_lint.py`
- `python -m reporting.architecture_import_scan --format summary`
- `python -m reporting.ade_queue_status_self_audit --no-write`
- `python -m reporting.roadmap_task_units`
- `python -m reporting.roadmap_unit_authority`
- `python -m reporting.roadmap_next_unit --status`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Handoff
- after merge, record queue completion evidence for ADE-QRE-017C in the canonical queue document and continue with ADE-QRE-017D
