### PR TITLE
feat: complete ADE-QRE-017D readiness population

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2820,7 +2820,7 @@ live, broker, risk, or execution work.
 ### ADE-QRE-017D - Routing/Sampling Readiness Population
 
 - queue id: `ADE-QRE-017D`
-- status: `ready`
+- status: `done`
 - title: Routing/Sampling Readiness Population.
 - purpose: populate routing-ready and sampling-ready artifacts from real
   repository evidence.
@@ -2830,9 +2830,8 @@ live, broker, risk, or execution work.
 - risk class: MEDIUM.
 - target layer: reporting, packages `qre_research`, packages `qre_artifacts`.
 - expected files or file families:
-  - `reporting/qre_selection_route_materialization.py`
-  - `reporting/qre_selection_closed_loop_preflight.py`
-  - `reporting/sampling_intelligence_minimal.py`
+  - `reporting/qre_routing_sampling_readiness.py`
+  - `docs/governance/qre_routing_sampling_readiness.md`
   - `tests/unit/**`
 - forbidden files or file families:
   - inferred readiness from scaffold presence alone
@@ -2840,13 +2839,18 @@ live, broker, risk, or execution work.
   - frozen contracts and runtime paths listed under `ADE-QRE-017`.
 - validation required:
   - ready states must be evidence-derived and fail closed otherwise.
+- completion evidence: substantive implementation PR pending merge evidence; this
+  branch materializes repository-native routing and sampling readiness
+  artifacts from real basket evidence, verifies routing/sampling reason-record
+  coverage is complete for the populated basket, and keeps non-ready states
+  explicit instead of inferring readiness from scaffold presence.
 - next dependency: `ADE-QRE-017E`.
 
 ### ADE-QRE-017E - KPI Completeness and Historical Snapshots
 
 - queue id: `ADE-QRE-017E`
 - title: KPI Completeness and Historical Snapshots.
-- status: `blocked until ADE-QRE-017D done`
+- status: `ready`
 - purpose: produce complete numeric or explicitly unavailable KPI states and
   repeatable historical snapshots.
 - source document:

--- a/docs/governance/qre_routing_sampling_readiness.md
+++ b/docs/governance/qre_routing_sampling_readiness.md
@@ -1,0 +1,46 @@
+# QRE Routing and Sampling Readiness
+
+## 1. Summary
+| Field | Value |
+| --- | --- |
+| routing candidates | 15 |
+| sampling candidates | 15 |
+| routing ready | 2 |
+| sampling ready | 2 |
+| shared ready | 2 |
+| routing reason-record coverage | 100.0% |
+| sampling reason-record coverage | 100.0% |
+| final recommendation | readiness_population_materialized |
+| exact next action | preserve_evidence_backed_ready_and_non_ready_states |
+
+## 2. State counts
+| State | Routing | Sampling |
+| --- | --- | --- |
+| ready | 2 | 2 |
+| blocked | 1 | 1 |
+| deferred | 12 | 12 |
+| fail_closed | 0 | 0 |
+
+## 3. Candidate examples
+| Symbol | Preset | Routing | Sampling | Shared ready | Reason records | Primary reasons |
+| --- | --- | --- | --- | --- | --- | --- |
+| AAPL | trend_pullback_continuation_daily_v1 | ready (97) | ready (100) | yes | routing+sampling | evidence_ready_for_readonly_routing, sampling_ready_for_readonly_requirements |
+| NVDA | trend_pullback_continuation_daily_v1 | ready (97) | ready (100) | yes | routing+sampling | evidence_ready_for_readonly_routing, sampling_ready_for_readonly_requirements |
+| ASMI | relative_strength_vs_sector_daily_v1 | blocked (0) | blocked (0) | no | routing+sampling | source_identity_blocked |
+| AMD | relative_strength_vs_region_daily_v1 | deferred (90) | deferred (90) | no | routing+sampling | oos_evidence_missing |
+| ASML | trend_continuation_daily_v1 | deferred (90) | deferred (90) | no | routing+sampling | oos_evidence_missing |
+| MSFT | relative_strength_vs_region_daily_v1 | deferred (90) | deferred (90) | no | routing+sampling | oos_evidence_missing |
+| TSM | vol_compression_breakout_daily_v1 | deferred (32) | deferred (32) | no | routing+sampling | source_or_cache_coverage_missing |
+| ADYEN | relative_strength_vs_sector_daily_v1 | deferred (15) | deferred (15) | no | routing+sampling | source_or_cache_coverage_missing |
+| BABA | post_shock_stabilization_daily_v1 | deferred (15) | deferred (15) | no | routing+sampling | source_or_cache_coverage_missing |
+| BESI | trend_continuation_daily_v1 | deferred (15) | deferred (15) | no | routing+sampling | source_or_cache_coverage_missing |
+| QQQ | index_regime_filter_daily_v1 | deferred (15) | deferred (15) | no | routing+sampling | source_or_cache_coverage_missing |
+| SMH | vol_compression_breakout_4h_v1 | deferred (15) | deferred (15) | no | routing+sampling | source_or_cache_coverage_missing |
+| SONY | vol_compression_breakout_daily_v1 | deferred (15) | deferred (15) | no | routing+sampling | source_or_cache_coverage_missing |
+| SPY | vol_compression_breakout_4h_v1 | deferred (15) | deferred (15) | no | routing+sampling | source_or_cache_coverage_missing |
+| TM | post_shock_stabilization_daily_v1 | deferred (15) | deferred (15) | no | routing+sampling | source_or_cache_coverage_missing |
+
+## 4. Doctrine
+- Routing and sampling readiness are evidence-derived, read-only surfaces.
+- Missing reason-record support, missing basket evidence, or missing real readiness inputs fail closed.
+- This report does not activate routing, sampling, paper, shadow, live, broker, risk, or execution behavior.

--- a/reporting/qre_routing_sampling_readiness.py
+++ b/reporting/qre_routing_sampling_readiness.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+
+REPORT_KIND: Final[str] = "qre_routing_sampling_readiness"
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "ade-qre-017d-2026-06-25"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_routing_sampling_readiness")
+LATEST_NAME: Final[str] = "latest.json"
+DOC_PATH: Final[Path] = Path("docs/governance/qre_routing_sampling_readiness.md")
+WRITE_PREFIX: Final[str] = "logs/qre_routing_sampling_readiness/"
+
+_MAX_EXAMPLES: Final[int] = 16
+_STATE_ORDER: Final[tuple[str, ...]] = ("ready", "blocked", "deferred", "fail_closed")
+
+
+def _research_module(name: str) -> Any:
+    return importlib.import_module(name)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _bounded_list(
+    value: Any,
+    *,
+    limit: int = _MAX_EXAMPLES,
+    width: int = 200,
+) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        return []
+    out: list[str] = []
+    for item in value:
+        text = _text(item)
+        if text and text not in out:
+            out.append(text[:width])
+    return out[:limit]
+
+
+def _validate_write_target(path: Path) -> None:
+    normalized = path.as_posix()
+    if WRITE_PREFIX not in normalized:
+        raise ValueError(
+            "qre_routing_sampling_readiness: refusing write outside allowlist: "
+            f"{path!r}"
+        )
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _reason_record_index(records: Sequence[Mapping[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+    out: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in records:
+        family = _text(row.get("record_family"))
+        subject_id = _text(row.get("subject_id"))
+        if family and subject_id:
+            out[(family, subject_id)] = dict(row)
+    return out
+
+
+def _state_counts(rows: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts = Counter(_text(row.get(key)) or "unknown" for row in rows)
+    ordered = {state: int(counts.get(state, 0)) for state in _STATE_ORDER}
+    if counts.get("unknown"):
+        ordered["unknown"] = int(counts["unknown"])
+    return ordered
+
+
+def _coverage_pct(total: int, present: int) -> float:
+    if total <= 0:
+        return 0.0
+    return round((present / total) * 100.0, 2)
+
+
+def _candidate_rows(
+    *,
+    routing_rows: Sequence[Mapping[str, Any]],
+    sampling_rows: Sequence[Mapping[str, Any]],
+    reason_record_index: Mapping[tuple[str, str], Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    sampling_by_id = {
+        _text(row.get("candidate_id")): row
+        for row in sampling_rows
+        if _text(row.get("candidate_id"))
+    }
+    merged_rows: list[dict[str, Any]] = []
+    for routing_row in routing_rows:
+        candidate_id = _text(routing_row.get("candidate_id"))
+        if not candidate_id:
+            continue
+        sampling_row = sampling_by_id.get(candidate_id, {})
+        routing_reason = reason_record_index.get(("routing_readiness", candidate_id))
+        sampling_reason = reason_record_index.get(("sampling_readiness", candidate_id))
+        primary_reasons = [
+            reason
+            for reason in (
+                _text(routing_row.get("primary_reason_code")),
+                _text(sampling_row.get("primary_reason_code")),
+            )
+            if reason
+        ]
+        merged_rows.append(
+            {
+                "candidate_id": candidate_id,
+                "symbol": _text(routing_row.get("symbol") or sampling_row.get("symbol")),
+                "preset_id": _text(
+                    routing_row.get("preset_id") or sampling_row.get("preset_id")
+                ),
+                "behavior_family": _text(
+                    routing_row.get("behavior_family")
+                    or sampling_row.get("behavior_family")
+                ),
+                "timeframes": _bounded_list(
+                    routing_row.get("timeframes") or sampling_row.get("timeframes")
+                ),
+                "routing_state": _text(routing_row.get("routing_readiness_state")),
+                "routing_score_pct": int(routing_row.get("routing_readiness_score_pct") or 0),
+                "sampling_state": _text(sampling_row.get("sampling_readiness_state")),
+                "sampling_score_pct": int(
+                    sampling_row.get("sampling_readiness_score_pct") or 0
+                ),
+                "shared_ready": bool(routing_row.get("routing_ready"))
+                and bool(sampling_row.get("sampling_ready")),
+                "routing_reason_record_present": routing_reason is not None,
+                "sampling_reason_record_present": sampling_reason is not None,
+                "routing_reason_record_id": _text(
+                    (routing_reason or {}).get("record_id")
+                )[:64],
+                "sampling_reason_record_id": _text(
+                    (sampling_reason or {}).get("record_id")
+                )[:64],
+                "primary_reasons": primary_reasons[:4],
+                "follow_up": _text(
+                    sampling_row.get("follow_up") or routing_row.get("follow_up")
+                ),
+            }
+        )
+    merged_rows.sort(
+        key=lambda row: (
+            0 if row["shared_ready"] else 1,
+            _STATE_ORDER.index(row["routing_state"])
+            if row["routing_state"] in _STATE_ORDER
+            else len(_STATE_ORDER),
+            _STATE_ORDER.index(row["sampling_state"])
+            if row["sampling_state"] in _STATE_ORDER
+            else len(_STATE_ORDER),
+            -int(row["routing_score_pct"]),
+            -int(row["sampling_score_pct"]),
+            row["symbol"],
+            row["preset_id"],
+        )
+    )
+    return merged_rows
+
+
+def _final_recommendation(
+    *,
+    routing_total: int,
+    sampling_total: int,
+    routing_missing_reason_records: int,
+    sampling_missing_reason_records: int,
+    shared_ready_count: int,
+) -> tuple[str, str]:
+    if routing_total == 0 or sampling_total == 0:
+        return (
+            "readiness_population_missing_real_evidence",
+            "materialize_real_basket_readiness_inputs",
+        )
+    if routing_missing_reason_records > 0 or sampling_missing_reason_records > 0:
+        return (
+            "readiness_population_reason_record_gap",
+            "repair_reason_record_coverage_before_authority_upgrade",
+        )
+    if shared_ready_count == 0:
+        return (
+            "readiness_population_materialized_zero_shared_ready",
+            "preserve_blockers_and_collect_more_real_evidence",
+        )
+    return (
+        "readiness_population_materialized",
+        "preserve_evidence_backed_ready_and_non_ready_states",
+    )
+
+
+def collect_snapshot(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+    materialize_supporting_outputs: bool = False,
+) -> dict[str, Any]:
+    routing = _research_module("research.qre_routing_readiness_from_basket")
+    sampling = _research_module("research.qre_sampling_readiness_from_basket")
+    reason_records = _research_module("research.qre_reason_records_v1")
+
+    routing_snapshot = routing.build_routing_readiness_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    sampling_snapshot = sampling.build_sampling_readiness_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    reason_snapshot = reason_records.build_reason_records_snapshot(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+
+    materialized_outputs: dict[str, str] = {}
+    if materialize_supporting_outputs:
+        for prefix, payload in (
+            ("routing_", routing.write_outputs(routing_snapshot, repo_root=repo_root)),
+            ("sampling_", sampling.write_outputs(sampling_snapshot, repo_root=repo_root)),
+        ):
+            for key, value in payload.items():
+                materialized_outputs[prefix + key] = _text(value)
+
+    routing_rows = [
+        row for row in (routing_snapshot.get("rows") or []) if isinstance(row, Mapping)
+    ]
+    sampling_rows = [
+        row for row in (sampling_snapshot.get("rows") or []) if isinstance(row, Mapping)
+    ]
+    reason_rows = [
+        row for row in (reason_snapshot.get("records") or []) if isinstance(row, Mapping)
+    ]
+    reason_index = _reason_record_index(reason_rows)
+    candidate_rows = _candidate_rows(
+        routing_rows=routing_rows,
+        sampling_rows=sampling_rows,
+        reason_record_index=reason_index,
+    )
+
+    routing_reason_record_present = sum(
+        1
+        for row in candidate_rows
+        if bool(row.get("routing_reason_record_present"))
+    )
+    sampling_reason_record_present = sum(
+        1
+        for row in candidate_rows
+        if bool(row.get("sampling_reason_record_present"))
+    )
+    shared_ready_count = sum(1 for row in candidate_rows if bool(row.get("shared_ready")))
+    ready_candidate_ids = [
+        _text(row.get("candidate_id"))
+        for row in candidate_rows
+        if bool(row.get("shared_ready"))
+    ][: _MAX_EXAMPLES]
+
+    routing_reason_counter = Counter(
+        _text(row.get("primary_reason_code"))
+        for row in routing_rows
+        if _text(row.get("primary_reason_code"))
+    )
+    sampling_reason_counter = Counter(
+        _text(row.get("primary_reason_code"))
+        for row in sampling_rows
+        if _text(row.get("primary_reason_code"))
+    )
+
+    routing_total = len(routing_rows)
+    sampling_total = len(sampling_rows)
+    routing_missing_reason_records = routing_total - routing_reason_record_present
+    sampling_missing_reason_records = sampling_total - sampling_reason_record_present
+    final_recommendation, exact_next_action = _final_recommendation(
+        routing_total=routing_total,
+        sampling_total=sampling_total,
+        routing_missing_reason_records=routing_missing_reason_records,
+        sampling_missing_reason_records=sampling_missing_reason_records,
+        shared_ready_count=shared_ready_count,
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "max_candidates": max_candidates,
+        "summary": {
+            "routing_candidate_count": routing_total,
+            "sampling_candidate_count": sampling_total,
+            "routing_ready_count": int(
+                ((_mapping := routing_snapshot.get("summary")) or {}).get("routing_ready_count")
+                or 0
+            ),
+            "sampling_ready_count": int(
+                ((_mapping := sampling_snapshot.get("summary")) or {}).get("sampling_ready_count")
+                or 0
+            ),
+            "routing_state_counts": _state_counts(
+                routing_rows,
+                "routing_readiness_state",
+            ),
+            "sampling_state_counts": _state_counts(
+                sampling_rows,
+                "sampling_readiness_state",
+            ),
+            "shared_ready_count": shared_ready_count,
+            "routing_reason_record_coverage_pct": _coverage_pct(
+                routing_total,
+                routing_reason_record_present,
+            ),
+            "sampling_reason_record_coverage_pct": _coverage_pct(
+                sampling_total,
+                sampling_reason_record_present,
+            ),
+            "routing_missing_reason_record_count": routing_missing_reason_records,
+            "sampling_missing_reason_record_count": sampling_missing_reason_records,
+            "final_recommendation": final_recommendation,
+            "exact_next_action": exact_next_action,
+        },
+        "ready_candidate_ids_top": ready_candidate_ids,
+        "routing_primary_reason_counts": dict(sorted(routing_reason_counter.items())),
+        "sampling_primary_reason_counts": dict(sorted(sampling_reason_counter.items())),
+        "candidate_examples_top": candidate_rows[:_MAX_EXAMPLES],
+        "supporting_sources": {
+            "routing_report_kind": _text(routing_snapshot.get("report_kind")),
+            "sampling_report_kind": _text(sampling_snapshot.get("report_kind")),
+            "reason_record_kind": _text(reason_snapshot.get("record_kind")),
+            "routing_summary": dict(
+                sorted(
+                    (
+                        (routing_snapshot.get("summary") or {})
+                        if isinstance(routing_snapshot.get("summary"), Mapping)
+                        else {}
+                    ).items()
+                )
+            ),
+            "sampling_summary": dict(
+                sorted(
+                    (
+                        (sampling_snapshot.get("summary") or {})
+                        if isinstance(sampling_snapshot.get("summary"), Mapping)
+                        else {}
+                    ).items()
+                )
+            ),
+            "reason_record_meta": dict(
+                sorted(
+                    (
+                        (reason_snapshot.get("meta") or {})
+                        if isinstance(reason_snapshot.get("meta"), Mapping)
+                        else {}
+                    ).items()
+                )
+            ),
+        },
+        "materialized_supporting_outputs": materialized_outputs,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "routing_runtime_activation": False,
+            "sampling_runtime_activation": False,
+        },
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    routing_counts = (
+        summary.get("routing_state_counts")
+        if isinstance(summary.get("routing_state_counts"), Mapping)
+        else {}
+    )
+    sampling_counts = (
+        summary.get("sampling_state_counts")
+        if isinstance(summary.get("sampling_state_counts"), Mapping)
+        else {}
+    )
+    rows = report.get("candidate_examples_top") if isinstance(report.get("candidate_examples_top"), list) else []
+    summary_table = _table(
+        ["Field", "Value"],
+        [
+            ["routing candidates", str(summary.get("routing_candidate_count") or 0)],
+            ["sampling candidates", str(summary.get("sampling_candidate_count") or 0)],
+            ["routing ready", str(summary.get("routing_ready_count") or 0)],
+            ["sampling ready", str(summary.get("sampling_ready_count") or 0)],
+            ["shared ready", str(summary.get("shared_ready_count") or 0)],
+            [
+                "routing reason-record coverage",
+                f"{summary.get('routing_reason_record_coverage_pct') or 0.0}%",
+            ],
+            [
+                "sampling reason-record coverage",
+                f"{summary.get('sampling_reason_record_coverage_pct') or 0.0}%",
+            ],
+            ["final recommendation", _text(summary.get("final_recommendation"))],
+            ["exact next action", _text(summary.get("exact_next_action"))],
+        ],
+    )
+    state_table = _table(
+        ["State", "Routing", "Sampling"],
+        [
+            [
+                state,
+                str(routing_counts.get(state) or 0),
+                str(sampling_counts.get(state) or 0),
+            ]
+            for state in _STATE_ORDER
+        ],
+    )
+    candidate_table = _table(
+        [
+            "Symbol",
+            "Preset",
+            "Routing",
+            "Sampling",
+            "Shared ready",
+            "Reason records",
+            "Primary reasons",
+        ],
+        [
+            [
+                _text(row.get("symbol")),
+                _text(row.get("preset_id")),
+                f"{_text(row.get('routing_state'))} ({row.get('routing_score_pct') or 0})",
+                f"{_text(row.get('sampling_state'))} ({row.get('sampling_score_pct') or 0})",
+                "yes" if bool(row.get("shared_ready")) else "no",
+                (
+                    "routing+sampling"
+                    if bool(row.get("routing_reason_record_present"))
+                    and bool(row.get("sampling_reason_record_present"))
+                    else "routing-only"
+                    if bool(row.get("routing_reason_record_present"))
+                    else "sampling-only"
+                    if bool(row.get("sampling_reason_record_present"))
+                    else "missing"
+                ),
+                ", ".join(_bounded_list(row.get("primary_reasons"), limit=3)),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Routing and Sampling Readiness",
+            "",
+            "## 1. Summary",
+            summary_table,
+            "",
+            "## 2. State counts",
+            state_table,
+            "",
+            "## 3. Candidate examples",
+            candidate_table,
+            "",
+            "## 4. Doctrine",
+            "- Routing and sampling readiness are evidence-derived, read-only surfaces.",
+            "- Missing reason-record support, missing basket evidence, or missing real readiness inputs fail closed.",
+            "- This report does not activate routing, sampling, paper, shadow, live, broker, risk, or execution behavior.",
+        ]
+    )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    _validate_write_target(latest)
+    payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(payload, encoding="utf-8")
+    os.replace(tmp_json, latest)
+
+    doc_path = repo_root / DOC_PATH
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_text(render_markdown(report) + "\n", encoding="utf-8")
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "doc": DOC_PATH.as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m reporting.qre_routing_sampling_readiness",
+        description=(
+            "Materialize a read-only routing/sampling readiness summary from "
+            "real basket evidence and reason-record coverage."
+        ),
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = collect_snapshot(
+        repo_root=Path("."),
+        max_candidates=args.max_candidates,
+        materialize_supporting_outputs=args.write,
+    )
+    if args.write:
+        write_outputs(report, repo_root=Path("."))
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reporting/roadmap_task_units.py
+++ b/reporting/roadmap_task_units.py
@@ -626,7 +626,7 @@ _UNIT_SEED: Final[tuple[dict[str, Any], ...]] = (
         "risk_class": "LOW",
         "authority_hint": "AUTO_ALLOWED_CANDIDATE",
         "operator_gate": "none",
-        "status": "not_started",
+        "status": "merged",
     },
     {
         "id": "u_ade_qre_017e_kpi_snapshot_reporter_001",

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -342,10 +342,12 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert item_17c.dependencies == ("ADE-QRE-017B",)
     assert _dependencies_done(item_17c, items) is True
     item_17d = items["ADE-QRE-017D"]
-    assert item_17d.status == "ready"
+    assert item_17d.status == "done"
+    item_17e = items["ADE-QRE-017E"]
+    assert item_17e.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17d
+    assert _next_eligible_ready_item(items) == item_17e
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,16 +83,17 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017d_as_next_eligible_ready_item_after_017c() -> None:
+def test_ade_qre_017_chain_selects_017e_as_next_eligible_ready_item_after_017d() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017D"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017E"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
     assert rows["ADE-QRE-017C"]["status"] == "done"
-    assert rows["ADE-QRE-017D"]["status"] == "ready"
+    assert rows["ADE-QRE-017D"]["status"] == "done"
+    assert rows["ADE-QRE-017E"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017d_after_017c_completion() -> None:
+def test_current_queue_selects_017e_after_017d_completion() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017D"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017E"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -169,7 +169,8 @@ def test_current_queue_selects_017d_after_017c_completion() -> None:
     assert rows["ADE-QRE-017A"]["auto_selectable"] is False
     assert rows["ADE-QRE-017B"]["status"] == "done"
     assert rows["ADE-QRE-017C"]["status"] == "done"
-    assert rows["ADE-QRE-017D"]["status"] == "ready"
+    assert rows["ADE-QRE-017D"]["status"] == "done"
+    assert rows["ADE-QRE-017E"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False

--- a/tests/unit/test_qre_routing_sampling_readiness.py
+++ b/tests/unit/test_qre_routing_sampling_readiness.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from reporting import qre_routing_sampling_readiness as readiness
+
+
+def _routing_row(
+    *,
+    candidate_id: str,
+    symbol: str,
+    state: str,
+    score: int,
+    reason: str,
+    ready: bool,
+) -> dict[str, object]:
+    return {
+        "candidate_id": candidate_id,
+        "symbol": symbol,
+        "preset_id": "preset-a",
+        "behavior_family": "trend_pullback",
+        "timeframes": ["1d"],
+        "routing_readiness_state": state,
+        "routing_readiness_score_pct": score,
+        "primary_reason_code": reason,
+        "routing_ready": ready,
+    }
+
+
+def _sampling_row(
+    *,
+    candidate_id: str,
+    symbol: str,
+    state: str,
+    score: int,
+    reason: str,
+    ready: bool,
+) -> dict[str, object]:
+    return {
+        "candidate_id": candidate_id,
+        "symbol": symbol,
+        "preset_id": "preset-a",
+        "behavior_family": "trend_pullback",
+        "timeframes": ["1d"],
+        "sampling_readiness_state": state,
+        "sampling_readiness_score_pct": score,
+        "primary_reason_code": reason,
+        "sampling_ready": ready,
+    }
+
+
+def _reason_record(record_family: str, subject_id: str) -> dict[str, object]:
+    return {
+        "record_id": f"rr-{record_family}-{subject_id}",
+        "record_family": record_family,
+        "subject_id": subject_id,
+        "reason_codes": ["ok"],
+        "evidence_refs": ["research/production_discovery_catalog.py"],
+    }
+
+
+def test_collect_snapshot_fails_closed_when_real_readiness_rows_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        readiness,
+        "_research_module",
+        lambda name: {
+            "research.qre_routing_readiness_from_basket": SimpleNamespace(
+                build_routing_readiness_from_basket=lambda **_: {
+                    "summary": {"routing_ready_count": 0},
+                    "rows": [],
+                },
+            ),
+            "research.qre_sampling_readiness_from_basket": SimpleNamespace(
+                build_sampling_readiness_from_basket=lambda **_: {
+                    "summary": {"sampling_ready_count": 0},
+                    "rows": [],
+                },
+            ),
+            "research.qre_reason_records_v1": SimpleNamespace(
+                build_reason_records_snapshot=lambda **_: {
+                    "records": [],
+                    "meta": {"records_by_surface": {}},
+                    "record_kind": "qre_reason_record",
+                },
+            ),
+        }[name],
+    )
+
+    report = readiness.collect_snapshot(repo_root=tmp_path)
+
+    assert report["summary"]["routing_candidate_count"] == 0
+    assert report["summary"]["sampling_candidate_count"] == 0
+    assert (
+        report["summary"]["final_recommendation"]
+        == "readiness_population_missing_real_evidence"
+    )
+    assert (
+        report["summary"]["exact_next_action"]
+        == "materialize_real_basket_readiness_inputs"
+    )
+
+
+def test_collect_snapshot_surfaces_reason_record_gaps_and_materializes_outputs(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def _routing_write(report, *, repo_root=Path(".")):
+        base = repo_root / "logs" / "qre_routing_readiness_from_basket"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "latest.json").write_text("{}", encoding="utf-8")
+        return {"latest": "logs/qre_routing_readiness_from_basket/latest.json"}
+
+    def _sampling_write(report, *, repo_root=Path(".")):
+        base = repo_root / "logs" / "qre_sampling_readiness_from_basket"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "latest.json").write_text("{}", encoding="utf-8")
+        return {"latest": "logs/qre_sampling_readiness_from_basket/latest.json"}
+
+    monkeypatch.setattr(
+        readiness,
+        "_research_module",
+        lambda name: {
+            "research.qre_routing_readiness_from_basket": SimpleNamespace(
+                build_routing_readiness_from_basket=lambda **_: {
+                    "report_kind": "qre_routing_readiness_from_basket",
+                    "summary": {"routing_ready_count": 1},
+                    "rows": [
+                        _routing_row(
+                            candidate_id="cand-1",
+                            symbol="AAPL",
+                            state="ready",
+                            score=97,
+                            reason="evidence_ready_for_readonly_routing",
+                            ready=True,
+                        ),
+                        _routing_row(
+                            candidate_id="cand-2",
+                            symbol="MSFT",
+                            state="deferred",
+                            score=90,
+                            reason="oos_evidence_missing",
+                            ready=False,
+                        ),
+                    ],
+                },
+                write_outputs=_routing_write,
+            ),
+            "research.qre_sampling_readiness_from_basket": SimpleNamespace(
+                build_sampling_readiness_from_basket=lambda **_: {
+                    "report_kind": "qre_sampling_readiness_from_basket",
+                    "summary": {"sampling_ready_count": 1},
+                    "rows": [
+                        _sampling_row(
+                            candidate_id="cand-1",
+                            symbol="AAPL",
+                            state="ready",
+                            score=100,
+                            reason="sampling_ready_for_readonly_requirements",
+                            ready=True,
+                        ),
+                        _sampling_row(
+                            candidate_id="cand-2",
+                            symbol="MSFT",
+                            state="deferred",
+                            score=90,
+                            reason="oos_evidence_missing",
+                            ready=False,
+                        ),
+                    ],
+                },
+                write_outputs=_sampling_write,
+            ),
+            "research.qre_reason_records_v1": SimpleNamespace(
+                build_reason_records_snapshot=lambda **_: {
+                    "record_kind": "qre_reason_record",
+                    "meta": {"records_by_surface": {"routing_readiness": 1, "sampling_readiness": 2}},
+                    "records": [
+                        _reason_record("routing_readiness", "cand-1"),
+                        _reason_record("sampling_readiness", "cand-1"),
+                        _reason_record("sampling_readiness", "cand-2"),
+                    ],
+                },
+            ),
+        }[name],
+    )
+
+    report = readiness.collect_snapshot(
+        repo_root=tmp_path,
+        materialize_supporting_outputs=True,
+    )
+
+    assert report["summary"]["routing_candidate_count"] == 2
+    assert report["summary"]["sampling_candidate_count"] == 2
+    assert report["summary"]["shared_ready_count"] == 1
+    assert report["summary"]["routing_missing_reason_record_count"] == 1
+    assert report["summary"]["sampling_missing_reason_record_count"] == 0
+    assert (
+        report["summary"]["final_recommendation"]
+        == "readiness_population_reason_record_gap"
+    )
+    assert (
+        report["summary"]["exact_next_action"]
+        == "repair_reason_record_coverage_before_authority_upgrade"
+    )
+    assert report["materialized_supporting_outputs"] == {
+        "routing_latest": "logs/qre_routing_readiness_from_basket/latest.json",
+        "sampling_latest": "logs/qre_sampling_readiness_from_basket/latest.json",
+    }
+
+
+def test_write_outputs_materializes_json_and_doc(tmp_path: Path) -> None:
+    report = {
+        "summary": {
+            "routing_candidate_count": 2,
+            "sampling_candidate_count": 2,
+            "routing_ready_count": 1,
+            "sampling_ready_count": 1,
+            "shared_ready_count": 1,
+            "routing_reason_record_coverage_pct": 100.0,
+            "sampling_reason_record_coverage_pct": 100.0,
+            "final_recommendation": "readiness_population_materialized",
+            "exact_next_action": "preserve_evidence_backed_ready_and_non_ready_states",
+            "routing_state_counts": {"ready": 1, "blocked": 0, "deferred": 1, "fail_closed": 0},
+            "sampling_state_counts": {"ready": 1, "blocked": 0, "deferred": 1, "fail_closed": 0},
+        },
+        "candidate_examples_top": [
+            {
+                "symbol": "AAPL",
+                "preset_id": "preset-a",
+                "routing_state": "ready",
+                "routing_score_pct": 97,
+                "sampling_state": "ready",
+                "sampling_score_pct": 100,
+                "shared_ready": True,
+                "routing_reason_record_present": True,
+                "sampling_reason_record_present": True,
+                "primary_reasons": ["routing_ready"],
+            }
+        ],
+    }
+
+    paths = readiness.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_routing_sampling_readiness/latest.json"
+    assert paths["doc"] == "docs/governance/qre_routing_sampling_readiness.md"
+    assert "QRE Routing and Sampling Readiness" in (
+        tmp_path / paths["doc"]
+    ).read_text(encoding="utf-8")
+
+
+def test_module_avoids_static_research_imports() -> None:
+    src = Path(readiness.__file__).read_text(encoding="utf-8")
+    assert "from research import" not in src
+    assert "import research" not in src

--- a/tests/unit/test_roadmap_next_unit.py
+++ b/tests/unit/test_roadmap_next_unit.py
@@ -646,8 +646,8 @@ def test_materialized_current_a20_stack_selects_ade_qre_017c_after_017b_merge(
     auth_path.write_text(json.dumps(auth_payload, sort_keys=True), encoding="utf-8")
 
     snap = _snap(tmp_path)
-    assert snap["selection"]["selected_unit_id"] == "u_ade_qre_017d_readiness_population_reporter_001"
-    assert snap["selection"]["selected_phase"] == "ade_qre_017d"
+    assert snap["selection"]["selected_unit_id"] == "u_ade_qre_017e_kpi_snapshot_reporter_001"
+    assert snap["selection"]["selected_phase"] == "ade_qre_017e"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_roadmap_task_units.py
+++ b/tests/unit/test_roadmap_task_units.py
@@ -1010,6 +1010,8 @@ _MERGED_UNIT_IDS: frozenset[str] = frozenset(
         "u_ade_qre_017b_evidence_density_inventory_001",
         # ADE-QRE-017C reason-record maturity reporter merged via the current queue item PR.
         "u_ade_qre_017c_reason_record_maturity_reporter_001",
+        # ADE-QRE-017D routing/sampling readiness reporter merged via the current queue item PR.
+        "u_ade_qre_017d_readiness_population_reporter_001",
         # PR #250 (merge SHA fcb1abb) + PR #251 queue-status update.
         "u_v3_15_16_diagnostic_routing_signals_schema_001",
         # PR #252 (merge SHA 6f588a8) + this queue-status update PR.
@@ -1077,18 +1079,15 @@ def test_ade_qre_017_wave_prerequisites_form_linear_chain(snap: dict) -> None:
     ]
 
 
-def test_ade_qre_017a_through_017c_units_are_merged_and_future_wave_units_not_started(
+def test_ade_qre_017a_through_017d_units_are_merged_and_future_wave_units_not_started(
     snap: dict,
 ) -> None:
     by_id = {u["id"]: u for u in snap["implementation_units"]}
     assert by_id["u_ade_qre_017a_maturity_matrix_reporter_001"]["status"] == "merged"
     assert by_id["u_ade_qre_017b_evidence_density_inventory_001"]["status"] == "merged"
     assert by_id["u_ade_qre_017c_reason_record_maturity_reporter_001"]["status"] == "merged"
-    for unit_id in (
-        "u_ade_qre_017d_readiness_population_reporter_001",
-        "u_ade_qre_017e_kpi_snapshot_reporter_001",
-    ):
-        assert by_id[unit_id]["status"] == "not_started", unit_id
+    assert by_id["u_ade_qre_017d_readiness_population_reporter_001"]["status"] == "merged"
+    assert by_id["u_ade_qre_017e_kpi_snapshot_reporter_001"]["status"] == "not_started"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a canonical read-only routing/sampling readiness reporter for ADE-QRE-017D
- materialize and document current repository-backed readiness population from real basket evidence plus reason-record coverage
- advance the canonical queue and A20 selector state so ADE-QRE-017E becomes the next eligible unit after merge

## Scope
- reporting/qre_routing_sampling_readiness.py
- docs/governance/qre_routing_sampling_readiness.md
- queue/A20 lifecycle updates for ADE-QRE-017D -> done and ADE-QRE-017E -> ready
- targeted unit coverage for the new reporter and selector progression

## Dependencies
- follows merged ADE-QRE-017C implementation PR #624
- follows merged ADE-QRE-017C completion-evidence PR #625

## Forbidden scope
- no live, paper, shadow, broker, risk, execution, trading, or capital-allocation changes
- no frozen contract changes to research/research_latest.json or research/strategy_matrix.csv
- no .claude/** changes
- no readiness inferred from scaffold presence alone

## Validation
- python -m pytest tests/unit/test_qre_routing_sampling_readiness.py tests/unit/test_roadmap_task_units.py tests/unit/test_roadmap_next_unit.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- python scripts/governance_lint.py
- python -m reporting.architecture_import_scan --format summary
- python -m reporting.qre_routing_sampling_readiness
- python -m reporting.ade_queue_status_self_audit --no-write
- python -m reporting.roadmap_task_units
- python -m reporting.roadmap_unit_authority
- python -m reporting.roadmap_next_unit --status
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv