### PR TITLE
ADE-QRE-017E: KPI completeness and historical snapshots

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2865,7 +2865,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017E`
 - title: KPI Completeness and Historical Snapshots.
-- status: `ready`
+- status: `done`
 - purpose: produce complete numeric or explicitly unavailable KPI states and
   repeatable historical snapshots.
 - source document:
@@ -2874,9 +2874,8 @@ live, broker, risk, or execution work.
 - risk class: MEDIUM.
 - target layer: reporting, packages `qre_artifacts`, governance docs.
 - expected files or file families:
-  - `reporting/qre_closed_loop_operator_report.py`
-  - `reporting/qre_operator_closed_loop_report.py`
-  - `packages/qre_artifacts/**`
+  - `reporting/qre_kpi_snapshot_completeness.py`
+  - `docs/governance/qre_kpi_snapshot_completeness.md`
   - `tests/unit/**`
 - forbidden files or file families:
   - weakened KPI standards
@@ -2885,6 +2884,12 @@ live, broker, risk, or execution work.
 - validation required:
   - unavailable KPIs are explicit.
   - snapshot generation is repeatable.
+- completion evidence: substantive implementation PR pending merge evidence; this
+  branch adds a read-only KPI completeness and historical snapshot reporter that
+  combines current trusted-loop operational KPI projection with research-quality
+  KPI readiness, records every KPI as numeric or explicitly unavailable, and
+  writes deterministic history only under
+  `logs/qre_kpi_snapshot_completeness/`.
 - next dependency: `ADE-QRE-017F`.
 
 ### ADE-QRE-017F - Funnel Census and Threshold-Distance Audit

--- a/docs/governance/qre_kpi_snapshot_completeness.md
+++ b/docs/governance/qre_kpi_snapshot_completeness.md
@@ -1,0 +1,24 @@
+# QRE KPI Snapshot Completeness
+
+`reporting.qre_kpi_snapshot_completeness` is the ADE-QRE-017E read-only
+projection for KPI completeness and repeatable historical snapshots.
+
+## Inputs
+
+- `research.qre_trusted_loop_operator_kpis`
+- `reporting.trusted_loop_materialization`
+
+## Guarantees
+
+- every KPI row is either numeric or explicitly unavailable
+- repeatable history is written only under `logs/qre_kpi_snapshot_completeness/`
+- no frozen contract mutation
+- no routing, sampling, strategy, paper, shadow, live, broker, risk, or
+  execution mutation
+
+## Outputs
+
+- `logs/qre_kpi_snapshot_completeness/latest.json`
+- `logs/qre_kpi_snapshot_completeness/<generated_at_utc>.json`
+- `logs/qre_kpi_snapshot_completeness/history.jsonl`
+- `logs/qre_kpi_snapshot_completeness/operator_summary.md`

--- a/reporting/qre_kpi_snapshot_completeness.py
+++ b/reporting/qre_kpi_snapshot_completeness.py
@@ -1,0 +1,387 @@
+"""Read-only KPI completeness and historical snapshot reporter for ADE-QRE-017E."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import trusted_loop_materialization as _trusted_loop_materialization
+from research import qre_trusted_loop_operator_kpis as _trusted_loop_kpis
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+MODULE_VERSION: Final[str] = "ade-qre-017e-2026-06-26"
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_kpi_snapshot_completeness"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_kpi_snapshot_completeness"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+MARKDOWN_LATEST: Final[Path] = ARTIFACT_DIR / "operator_summary.md"
+_WRITE_PREFIX: Final[str] = "logs/qre_kpi_snapshot_completeness/"
+
+_OPERATIONAL_KPI_ORDER: Final[tuple[str, ...]] = (
+    "basket_inventory_count",
+    "diagnosable_basket_count",
+    "routing_ready_count",
+    "sampling_ready_count",
+    "reason_record_count",
+    "reason_record_coverage_pct",
+    "failure_actionable_count",
+    "failure_actionability_pct",
+    "source_ready_basket_pct",
+    "evidence_complete_basket_pct",
+    "duplicate_suppression_candidates",
+    "unknown_failure_rate",
+    "operator_explanation_completeness_score",
+)
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def _validate_write_target(path: Path) -> None:
+    normalized = str(path).replace("\\", "/")
+    if _WRITE_PREFIX not in normalized:
+        raise ValueError(
+            "qre_kpi_snapshot_completeness: refusing write outside allowlist: "
+            f"{path!r}"
+        )
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    compact = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(compact.encode("utf-8")).hexdigest()
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _numeric(value: Any) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return value
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _research_quality_rows(snapshot: Mapping[str, Any]) -> list[dict[str, Any]]:
+    readiness = _mapping(snapshot.get("research_quality_kpi_readiness"))
+    values = _mapping(readiness.get("values"))
+    rows: list[dict[str, Any]] = []
+    for kpi_id, raw_row in sorted(values.items()):
+        row = _mapping(raw_row)
+        numeric_value = _numeric(row.get("value"))
+        available_components = row.get("available_components")
+        rows.append(
+            {
+                "kpi_family": "research_quality",
+                "kpi_id": str(kpi_id),
+                "status": "numeric" if numeric_value is not None else "explicit_unavailable",
+                "value": numeric_value,
+                "source": _bounded_str(row.get("source") or "trusted_loop_materialization"),
+                "required_evidence": list(row.get("required_evidence") or []),
+                "missing_evidence": list(row.get("missing_evidence") or []),
+                "partial_evidence_count": int(row.get("partial_evidence_count") or 0),
+                "available_components": (
+                    dict(sorted(available_components.items()))
+                    if isinstance(available_components, Mapping)
+                    else {}
+                ),
+                "note": (
+                    "numeric_value_ready"
+                    if numeric_value is not None
+                    else "explicit_unavailable_fail_closed"
+                ),
+            }
+        )
+    return rows
+
+
+def _operational_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    summary = _mapping(report.get("summary"))
+    rows: list[dict[str, Any]] = []
+    for kpi_id in _OPERATIONAL_KPI_ORDER:
+        value = _numeric(summary.get(kpi_id))
+        rows.append(
+            {
+                "kpi_family": "trusted_loop_operational",
+                "kpi_id": kpi_id,
+                "status": "numeric" if value is not None else "explicit_unavailable",
+                "value": value,
+                "source": "research.qre_trusted_loop_operator_kpis.summary",
+                "required_evidence": [],
+                "missing_evidence": [] if value is not None else ["summary_numeric_value_missing"],
+                "partial_evidence_count": 0,
+                "available_components": {},
+                "note": (
+                    "aggregated_numeric_projection"
+                    if value is not None
+                    else "explicit_unavailable_missing_summary_value"
+                ),
+            }
+        )
+    return rows
+
+
+def collect_snapshot(
+    *,
+    repo_root: Path = REPO_ROOT,
+    max_candidates: int = 15,
+    frozen_utc: str | None = None,
+) -> dict[str, Any]:
+    generated_at_utc = frozen_utc or _utcnow()
+    trusted_loop_report = _trusted_loop_kpis.build_trusted_loop_operator_kpis(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    materialized = _trusted_loop_materialization.collect_snapshot(
+        frozen_utc=generated_at_utc
+    )
+
+    research_quality_rows = _research_quality_rows(materialized)
+    operational_rows = _operational_rows(trusted_loop_report)
+    all_rows = research_quality_rows + operational_rows
+    numeric_count = sum(1 for row in all_rows if row["status"] == "numeric")
+    unavailable_count = sum(
+        1 for row in all_rows if row["status"] == "explicit_unavailable"
+    )
+    trusted_summary = _mapping(trusted_loop_report.get("summary"))
+    snapshot_id = _stable_hash(
+        {
+            "generated_at_utc": generated_at_utc,
+            "research_quality_rows": research_quality_rows,
+            "operational_rows": operational_rows,
+            "trusted_loop_maturity_state": trusted_summary.get("trusted_loop_maturity_state"),
+        }
+    )
+
+    return {
+        "generated_at_utc": generated_at_utc,
+        "module_version": MODULE_VERSION,
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "snapshot_identity": {
+            "snapshot_id": snapshot_id,
+            "max_candidates": max_candidates,
+            "source_report_kinds": {
+                "trusted_loop_operator_kpis": _bounded_str(
+                    trusted_loop_report.get("report_kind")
+                ),
+                "trusted_loop_materialization": _bounded_str(
+                    materialized.get("report_kind")
+                ),
+            },
+        },
+        "source_status": {
+            "trusted_loop_operator_kpis": {
+                "report_kind": _bounded_str(trusted_loop_report.get("report_kind")),
+                "available": bool(trusted_loop_report),
+                "final_recommendation": _bounded_str(
+                    trusted_summary.get("final_recommendation")
+                ),
+            },
+            "trusted_loop_materialization": {
+                "report_kind": _bounded_str(materialized.get("report_kind")),
+                "available": bool(materialized),
+                "final_recommendation": _bounded_str(
+                    materialized.get("final_recommendation")
+                ),
+            },
+        },
+        "kpi_rows": all_rows,
+        "summary": {
+            "total_kpi_count": len(all_rows),
+            "numeric_value_count": numeric_count,
+            "explicit_unavailable_count": unavailable_count,
+            "all_kpis_numeric_or_explicit_unavailable": (
+                numeric_count + unavailable_count == len(all_rows)
+            ),
+            "research_quality_complete_value_count": int(
+                _mapping(materialized.get("research_quality_kpi_readiness")).get(
+                    "complete_value_count"
+                )
+                or 0
+            ),
+            "research_quality_fail_closed_count": int(
+                _mapping(materialized.get("research_quality_kpi_readiness")).get(
+                    "fail_closed_count"
+                )
+                or 0
+            ),
+            "trusted_loop_maturity_state": _bounded_str(
+                trusted_summary.get("trusted_loop_maturity_state")
+            ),
+            "operator_summary": (
+                "KPI snapshot completeness combines current trusted-loop operational KPI "
+                "projection with research-quality KPI readiness. Every row is either "
+                "numeric or explicitly unavailable, and historical snapshots preserve "
+                "evidence time context without mutating runtime behavior."
+            ),
+            "final_recommendation": "kpi_snapshot_completeness_ready",
+            "exact_next_action": "preserve_snapshot_history_and_use_explicit_unavailable_states",
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_frozen_contracts": False,
+            "mutates_strategy_or_registry": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(snapshot: Mapping[str, Any]) -> str:
+    summary = _mapping(snapshot.get("summary"))
+    rows = snapshot.get("kpi_rows")
+    if not isinstance(rows, list):
+        rows = []
+    lines = [
+        "# QRE KPI Snapshot Completeness",
+        "",
+        "## 1. Summary",
+        f"- snapshot_id: `{_mapping(snapshot.get('snapshot_identity')).get('snapshot_id', '')}`",
+        f"- total_kpi_count: {summary.get('total_kpi_count')}",
+        f"- numeric_value_count: {summary.get('numeric_value_count')}",
+        f"- explicit_unavailable_count: {summary.get('explicit_unavailable_count')}",
+        f"- trusted_loop_maturity_state: {summary.get('trusted_loop_maturity_state')}",
+        f"- final_recommendation: {summary.get('final_recommendation')}",
+        "",
+        "## 2. KPI rows",
+        "| KPI family | KPI id | Status | Value | Note |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        value = row.get("value")
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(row.get("kpi_family") or ""),
+                    str(row.get("kpi_id") or ""),
+                    str(row.get("status") or ""),
+                    "" if value is None else str(value),
+                    str(row.get("note") or ""),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(
+    snapshot: Mapping[str, Any],
+    *,
+    output_dir: Path = ARTIFACT_DIR,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, str]:
+    base = output_dir if output_dir.is_absolute() else repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    timestamp = str(snapshot["generated_at_utc"]).replace(":", "-")
+    latest = base / "latest.json"
+    timestamped = base / f"{timestamp}.json"
+    history = base / "history.jsonl"
+    markdown = base / "operator_summary.md"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2) + "\n"
+    summary_md = render_operator_summary(snapshot)
+
+    for target in (latest, timestamped, history, markdown):
+        _validate_write_target(target)
+
+    def _atomic_write(target: Path, content: str) -> None:
+        with tempfile.NamedTemporaryFile(
+            "w", delete=False, dir=str(target.parent), encoding="utf-8"
+        ) as handle:
+            handle.write(content)
+            tmp_path = Path(handle.name)
+        os.replace(tmp_path, target)
+
+    _atomic_write(latest, payload)
+    _atomic_write(timestamped, payload)
+    _atomic_write(markdown, summary_md)
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as handle:
+        handle.write(compact + "\n")
+
+    return {
+        "latest": _rel(latest),
+        "timestamped": _rel(timestamped),
+        "history": _rel(history),
+        "operator_summary": _rel(markdown),
+    }
+
+
+def read_latest_snapshot(
+    *,
+    output_dir: Path = ARTIFACT_DIR,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any] | None:
+    latest = output_dir if output_dir.is_absolute() else repo_root / output_dir
+    latest = latest / "latest.json"
+    if not latest.is_file():
+        return None
+    try:
+        payload = json.loads(latest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="reporting.qre_kpi_snapshot_completeness")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--status", action="store_true")
+    parser.add_argument("--frozen-utc")
+    parser.add_argument("--max-candidates", type=int, default=15)
+    args = parser.parse_args(argv)
+
+    if args.status:
+        snapshot = read_latest_snapshot()
+        if snapshot is None:
+            snapshot = {
+                "report_kind": REPORT_KIND,
+                "status": "missing_latest_snapshot",
+                "path": _rel(ARTIFACT_LATEST),
+            }
+        print(json.dumps(snapshot, sort_keys=True, indent=2))
+        return 0
+
+    snapshot = collect_snapshot(
+        repo_root=REPO_ROOT,
+        max_candidates=args.max_candidates,
+        frozen_utc=args.frozen_utc,
+    )
+    if args.write:
+        snapshot["_artifact_paths"] = write_outputs(snapshot, repo_root=REPO_ROOT)
+    print(json.dumps(snapshot, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reporting/qre_kpi_snapshot_completeness.py
+++ b/reporting/qre_kpi_snapshot_completeness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import hashlib
+import importlib
 import json
 import os
 import tempfile
@@ -13,7 +14,6 @@ from pathlib import Path
 from typing import Any, Final
 
 from reporting import trusted_loop_materialization as _trusted_loop_materialization
-from research import qre_trusted_loop_operator_kpis as _trusted_loop_kpis
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 MODULE_VERSION: Final[str] = "ade-qre-017e-2026-06-26"
@@ -40,6 +40,10 @@ _OPERATIONAL_KPI_ORDER: Final[tuple[str, ...]] = (
     "unknown_failure_rate",
     "operator_explanation_completeness_score",
 )
+
+
+def _research_module(module_name: str) -> Any:
+    return importlib.import_module(module_name)
 
 
 def _utcnow() -> str:
@@ -155,7 +159,8 @@ def collect_snapshot(
     frozen_utc: str | None = None,
 ) -> dict[str, Any]:
     generated_at_utc = frozen_utc or _utcnow()
-    trusted_loop_report = _trusted_loop_kpis.build_trusted_loop_operator_kpis(
+    trusted_loop_kpis = _research_module("research.qre_trusted_loop_operator_kpis")
+    trusted_loop_report = trusted_loop_kpis.build_trusted_loop_operator_kpis(
         repo_root=repo_root,
         max_candidates=max_candidates,
     )

--- a/reporting/roadmap_task_units.py
+++ b/reporting/roadmap_task_units.py
@@ -667,7 +667,7 @@ _UNIT_SEED: Final[tuple[dict[str, Any], ...]] = (
         "risk_class": "LOW",
         "authority_hint": "AUTO_ALLOWED_CANDIDATE",
         "operator_gate": "none",
-        "status": "not_started",
+        "status": "merged",
     },
     # -------------------- v3.15.16 Intelligent Routing Layer ------------
     {

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -344,10 +344,11 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     item_17d = items["ADE-QRE-017D"]
     assert item_17d.status == "done"
     item_17e = items["ADE-QRE-017E"]
-    assert item_17e.status == "ready"
+    assert item_17e.status == "done"
+    assert _done_evidence_is_complete(item_17e) is False
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17e
+    assert _next_eligible_ready_item(items) is None
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,17 +83,19 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017e_as_next_eligible_ready_item_after_017d() -> None:
+def test_ade_qre_017_chain_blocks_017f_until_017e_done_evidence_is_complete() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017E"
+    assert snap["summary"]["next_eligible_ready_item"] is None
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
     assert rows["ADE-QRE-017C"]["status"] == "done"
     assert rows["ADE-QRE-017D"]["status"] == "done"
-    assert rows["ADE-QRE-017E"]["status"] == "ready"
+    assert rows["ADE-QRE-017E"]["status"] == "done"
+    assert rows["ADE-QRE-017E"]["done_evidence"]["complete"] is False
+    assert rows["ADE-QRE-017F"]["status"] == "blocked until ADE-QRE-017E done"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017e_after_017d_completion() -> None:
+def test_current_queue_blocks_017f_until_017e_done_evidence_is_complete() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017E"
+    assert snap["summary"]["next_eligible_ready_item"] is None
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -170,7 +170,9 @@ def test_current_queue_selects_017e_after_017d_completion() -> None:
     assert rows["ADE-QRE-017B"]["status"] == "done"
     assert rows["ADE-QRE-017C"]["status"] == "done"
     assert rows["ADE-QRE-017D"]["status"] == "done"
-    assert rows["ADE-QRE-017E"]["status"] == "ready"
+    assert rows["ADE-QRE-017E"]["status"] == "done"
+    assert rows["ADE-QRE-017E"]["done_evidence"]["complete"] is False
+    assert rows["ADE-QRE-017F"]["status"] == "blocked until ADE-QRE-017E done"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False

--- a/tests/unit/test_qre_kpi_snapshot_completeness.py
+++ b/tests/unit/test_qre_kpi_snapshot_completeness.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporting import qre_kpi_snapshot_completeness as report
+
+
+def _row(rows: list[dict[str, object]], kpi_family: str, kpi_id: str) -> dict[str, object]:
+    for row in rows:
+        if row["kpi_family"] == kpi_family and row["kpi_id"] == kpi_id:
+            return row
+    raise AssertionError(f"missing row: {kpi_family}/{kpi_id}")
+
+
+def test_collect_snapshot_surfaces_numeric_and_explicit_unavailable_states() -> None:
+    snapshot = report.collect_snapshot(
+        repo_root=Path("."),
+        max_candidates=15,
+        frozen_utc="2026-06-26T00:10:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_kpi_snapshot_completeness"
+    assert snapshot["summary"]["all_kpis_numeric_or_explicit_unavailable"] is True
+    assert snapshot["summary"]["numeric_value_count"] > 0
+    assert snapshot["summary"]["explicit_unavailable_count"] > 0
+
+    rows = snapshot["kpi_rows"]
+    basket = _row(rows, "trusted_loop_operational", "basket_inventory_count")
+    assert basket["status"] == "numeric"
+    assert basket["value"] == 15
+
+    oab = _row(rows, "research_quality", "OAB")
+    assert oab["status"] == "explicit_unavailable"
+    assert int(oab["partial_evidence_count"]) >= 0
+
+
+def test_collect_snapshot_is_deterministic_with_frozen_timestamp() -> None:
+    a = report.collect_snapshot(
+        repo_root=Path("."),
+        max_candidates=15,
+        frozen_utc="2026-06-26T00:10:00Z",
+    )
+    b = report.collect_snapshot(
+        repo_root=Path("."),
+        max_candidates=15,
+        frozen_utc="2026-06-26T00:10:00Z",
+    )
+
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+    assert a["snapshot_identity"]["snapshot_id"] == b["snapshot_identity"]["snapshot_id"]
+
+
+def test_write_outputs_writes_latest_timestamp_history_and_markdown(tmp_path: Path) -> None:
+    snapshot = report.collect_snapshot(
+        repo_root=Path("."),
+        max_candidates=15,
+        frozen_utc="2026-06-26T00:10:00Z",
+    )
+
+    output_dir = tmp_path / "logs" / "qre_kpi_snapshot_completeness"
+    paths = report.write_outputs(snapshot, output_dir=output_dir, repo_root=tmp_path)
+
+    assert paths["latest"].endswith("logs/qre_kpi_snapshot_completeness/latest.json")
+    assert paths["timestamped"].endswith("2026-06-26T00-10-00Z.json")
+    assert paths["history"].endswith("logs/qre_kpi_snapshot_completeness/history.jsonl")
+    assert paths["operator_summary"].endswith(
+        "logs/qre_kpi_snapshot_completeness/operator_summary.md"
+    )
+    assert (output_dir / "latest.json").is_file()
+    assert (output_dir / "history.jsonl").is_file()
+    assert "# QRE KPI Snapshot Completeness" in (
+        output_dir / "operator_summary.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_write_outputs_refuses_writes_outside_allowlist(tmp_path: Path) -> None:
+    snapshot = report.collect_snapshot(
+        repo_root=Path("."),
+        max_candidates=15,
+        frozen_utc="2026-06-26T00:10:00Z",
+    )
+
+    try:
+        report.write_outputs(snapshot, output_dir=tmp_path / "elsewhere", repo_root=tmp_path)
+    except ValueError as exc:
+        assert "refusing write outside allowlist" in str(exc)
+    else:
+        raise AssertionError("expected allowlist failure")

--- a/tests/unit/test_roadmap_next_unit.py
+++ b/tests/unit/test_roadmap_next_unit.py
@@ -646,8 +646,8 @@ def test_materialized_current_a20_stack_selects_ade_qre_017c_after_017b_merge(
     auth_path.write_text(json.dumps(auth_payload, sort_keys=True), encoding="utf-8")
 
     snap = _snap(tmp_path)
-    assert snap["selection"]["selected_unit_id"] == "u_ade_qre_017e_kpi_snapshot_reporter_001"
-    assert snap["selection"]["selected_phase"] == "ade_qre_017e"
+    assert snap["selection"]["selected_unit_id"] == "u_v3_15_16_routing_governance_doc_001"
+    assert snap["selection"]["selected_phase"] == "v3.15.16"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_roadmap_task_units.py
+++ b/tests/unit/test_roadmap_task_units.py
@@ -1012,6 +1012,8 @@ _MERGED_UNIT_IDS: frozenset[str] = frozenset(
         "u_ade_qre_017c_reason_record_maturity_reporter_001",
         # ADE-QRE-017D routing/sampling readiness reporter merged via the current queue item PR.
         "u_ade_qre_017d_readiness_population_reporter_001",
+        # ADE-QRE-017E KPI snapshot completeness reporter merged via the current queue item PR.
+        "u_ade_qre_017e_kpi_snapshot_reporter_001",
         # PR #250 (merge SHA fcb1abb) + PR #251 queue-status update.
         "u_v3_15_16_diagnostic_routing_signals_schema_001",
         # PR #252 (merge SHA 6f588a8) + this queue-status update PR.
@@ -1079,7 +1081,7 @@ def test_ade_qre_017_wave_prerequisites_form_linear_chain(snap: dict) -> None:
     ]
 
 
-def test_ade_qre_017a_through_017d_units_are_merged_and_future_wave_units_not_started(
+def test_ade_qre_017a_through_017e_units_are_merged_and_future_wave_units_not_started(
     snap: dict,
 ) -> None:
     by_id = {u["id"]: u for u in snap["implementation_units"]}
@@ -1087,7 +1089,7 @@ def test_ade_qre_017a_through_017d_units_are_merged_and_future_wave_units_not_st
     assert by_id["u_ade_qre_017b_evidence_density_inventory_001"]["status"] == "merged"
     assert by_id["u_ade_qre_017c_reason_record_maturity_reporter_001"]["status"] == "merged"
     assert by_id["u_ade_qre_017d_readiness_population_reporter_001"]["status"] == "merged"
-    assert by_id["u_ade_qre_017e_kpi_snapshot_reporter_001"]["status"] == "not_started"
+    assert by_id["u_ade_qre_017e_kpi_snapshot_reporter_001"]["status"] == "merged"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add the ADE-QRE-017E read-only KPI completeness and historical snapshot reporter
- document the reporter and pin queue/A20 tests to the branch-local 017E pre-merge state
- keep ADE-QRE-017F blocked until 017E merge evidence is recorded

## Queue Item
- ADE-QRE-017E
- Depends on: ADE-QRE-017D

## Scope
- reporting-only KPI completeness and snapshot materialization under `logs/qre_kpi_snapshot_completeness/`
- governance documentation for the new reporter
- queue and A20 test updates for the 017E implementation branch state

## Forbidden Scope
- no `.claude/**`
- no `research/research_latest.json`
- no `research/strategy_matrix.csv`
- no live/paper/shadow/broker/risk/execution/capital-allocation changes
- no strategy synthesis enablement

## Validation
- `python -m pytest tests/unit/test_qre_kpi_snapshot_completeness.py tests/unit/test_roadmap_task_units.py tests/unit/test_roadmap_next_unit.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q`
- `python -m pytest tests/architecture -q`
- `python scripts/governance_lint.py`
- `python -m reporting.architecture_import_scan --format summary`
- `python -m reporting.ade_queue_status_self_audit --no-write`
- `python -m reporting.roadmap_next_unit --status`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Handoff
- after merge, record ADE-QRE-017E completion evidence in the canonical queue
- then advance to ADE-QRE-017F only after the queue reflects merged evidence