### PR TITLE
ADE-QRE-017E: record completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2884,19 +2884,22 @@ live, broker, risk, or execution work.
 - validation required:
   - unavailable KPIs are explicit.
   - snapshot generation is repeatable.
-- completion evidence: substantive implementation PR pending merge evidence; this
-  branch adds a read-only KPI completeness and historical snapshot reporter that
-  combines current trusted-loop operational KPI projection with research-quality
-  KPI readiness, records every KPI as numeric or explicitly unavailable, and
-  writes deterministic history only under
-  `logs/qre_kpi_snapshot_completeness/`.
+- completion evidence: PR #628, merge SHA
+  `ac35e6d347de9464c0eb075ed69d1ac3855ad506`; read-only KPI completeness and
+  historical snapshot reporter added in
+  `reporting/qre_kpi_snapshot_completeness.py`, with governance note
+  `docs/governance/qre_kpi_snapshot_completeness.md`; required CI checks green
+  before squash-merge; post-merge governance lint, `tests/architecture`,
+  architecture scanner summary, queue self-audit, next-unit status, and frozen
+  contract diff checks passed on `main`; frozen contracts unchanged;
+  protected/execution paths untouched.
 - next dependency: `ADE-QRE-017F`.
 
 ### ADE-QRE-017F - Funnel Census and Threshold-Distance Audit
 
 - queue id: `ADE-QRE-017F`
 - title: Funnel Census and Threshold-Distance Audit.
-- status: `blocked until ADE-QRE-017E done`
+- status: `ready`
 - purpose: materialize full funnel counts, threshold distances, and exactly-one
   recommendation per criterion without changing thresholds.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -345,10 +345,12 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert item_17d.status == "done"
     item_17e = items["ADE-QRE-017E"]
     assert item_17e.status == "done"
-    assert _done_evidence_is_complete(item_17e) is False
+    assert _done_evidence_is_complete(item_17e) is True
+    item_17f = items["ADE-QRE-017F"]
+    assert item_17f.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) is None
+    assert _next_eligible_ready_item(items) == item_17f
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,19 +83,19 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_blocks_017f_until_017e_done_evidence_is_complete() -> None:
+def test_ade_qre_017_chain_selects_017f_after_017e_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] is None
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017F"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
     assert rows["ADE-QRE-017C"]["status"] == "done"
     assert rows["ADE-QRE-017D"]["status"] == "done"
     assert rows["ADE-QRE-017E"]["status"] == "done"
-    assert rows["ADE-QRE-017E"]["done_evidence"]["complete"] is False
-    assert rows["ADE-QRE-017F"]["status"] == "blocked until ADE-QRE-017E done"
+    assert rows["ADE-QRE-017E"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017F"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_blocks_017f_until_017e_done_evidence_is_complete() -> None:
+def test_current_queue_selects_017f_after_017e_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] is None
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017F"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -171,8 +171,8 @@ def test_current_queue_blocks_017f_until_017e_done_evidence_is_complete() -> Non
     assert rows["ADE-QRE-017C"]["status"] == "done"
     assert rows["ADE-QRE-017D"]["status"] == "done"
     assert rows["ADE-QRE-017E"]["status"] == "done"
-    assert rows["ADE-QRE-017E"]["done_evidence"]["complete"] is False
-    assert rows["ADE-QRE-017F"]["status"] == "blocked until ADE-QRE-017E done"
+    assert rows["ADE-QRE-017E"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017F"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- record merged completion evidence for ADE-QRE-017E in the canonical queue
- advance ADE-QRE-017F to `ready`
- repin queue-state tests to the post-merge 017E state

## Queue Item
- ADE-QRE-017E completion evidence follow-up
- unlocks ADE-QRE-017F

## Scope
- queue-document evidence only
- queue-state tests only

## Forbidden Scope
- no `.claude/**`
- no `research/research_latest.json`
- no `research/strategy_matrix.csv`
- no runtime, strategy, paper, shadow, live, broker, risk, or execution changes

## Validation
- `python -m pytest tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q`
- `python -m reporting.ade_queue_status_self_audit --no-write`
- `python scripts/governance_lint.py`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Handoff
- after merge, ADE-QRE-017F becomes the canonical next eligible queue item
- continue directly into the ADE-QRE-017F implementation branch