### PR TITLE
docs: record ADE-QRE-017F completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2899,7 +2899,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017F`
 - title: Funnel Census and Threshold-Distance Audit.
-- status: `ready`
+- status: `done`
 - purpose: materialize full funnel counts, threshold distances, and exactly-one
   recommendation per criterion without changing thresholds.
 - source document:
@@ -2918,13 +2918,21 @@ live, broker, risk, or execution work.
 - validation required:
   - stage counts, actual values, thresholds, and distances are explicit.
   - each criterion has exactly one recommendation.
+- completion evidence: PR #630, merge SHA
+  `41a0dd2b7c111360facc9dfc866d17dc6b611e9e`; read-only funnel census and
+  threshold-distance audit reporter added in
+  `reporting/qre_funnel_threshold_audit.py`, with governance note
+  `docs/governance/qre_funnel_threshold_audit.md`; required CI checks green
+  before squash-merge; post-merge queue/governance validation pending in the
+  follow-up queue-state PR; frozen contracts unchanged; protected/execution
+  paths untouched.
 - next dependency: `ADE-QRE-017G`.
 
 ### ADE-QRE-017G - Actionable Failure Taxonomy and Next Actions
 
 - queue id: `ADE-QRE-017G`
 - title: Actionable Failure Taxonomy and Next Actions.
-- status: `blocked until ADE-QRE-017F done`
+- status: `ready`
 - purpose: expand evidence-backed failure attribution and bind each supported
   failure class to exactly one bounded advisory next action.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -347,10 +347,13 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert item_17e.status == "done"
     assert _done_evidence_is_complete(item_17e) is True
     item_17f = items["ADE-QRE-017F"]
-    assert item_17f.status == "ready"
+    assert item_17f.status == "done"
+    assert _done_evidence_is_complete(item_17f) is True
+    item_17g = items["ADE-QRE-017G"]
+    assert item_17g.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17f
+    assert _next_eligible_ready_item(items) == item_17g
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017f_after_017e_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017g_after_017f_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017F"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017G"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -95,7 +95,9 @@ def test_ade_qre_017_chain_selects_017f_after_017e_completion_evidence() -> None
     assert rows["ADE-QRE-017D"]["status"] == "done"
     assert rows["ADE-QRE-017E"]["status"] == "done"
     assert rows["ADE-QRE-017E"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017F"]["status"] == "ready"
+    assert rows["ADE-QRE-017F"]["status"] == "done"
+    assert rows["ADE-QRE-017F"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017G"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017f_after_017e_completion_evidence() -> None:
+def test_current_queue_selects_017g_after_017f_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017F"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017G"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -172,7 +172,9 @@ def test_current_queue_selects_017f_after_017e_completion_evidence() -> None:
     assert rows["ADE-QRE-017D"]["status"] == "done"
     assert rows["ADE-QRE-017E"]["status"] == "done"
     assert rows["ADE-QRE-017E"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017F"]["status"] == "ready"
+    assert rows["ADE-QRE-017F"]["status"] == "done"
+    assert rows["ADE-QRE-017F"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017G"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017F completion evidence in the canonical ADE queue source
- flip ADE-QRE-017F to `done` and ADE-QRE-017G to `ready`
- preserve frozen contracts and keep execution-protected surfaces untouched

## Queue Item
- ADE-QRE-017F

## Dependencies
- PR #630 merged at `41a0dd2b7c111360facc9dfc866d17dc6b611e9e`

## Scope
- docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md only

## Forbidden Scope
- .claude/**
- research/research_latest.json
- research/strategy_matrix.csv
- live/paper/shadow/broker/risk/execution/capital-allocation paths

## Validation
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- python -m reporting.development_work_queue --no-write
- git diff --check

## Handoff
- After merge, refresh `main`, rerun queue/governance validations, and begin ADE-QRE-017G.