### PR TITLE
docs: record ADE-QRE-017H completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2964,7 +2964,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017H`
 - title: Action Usefulness Tracking.
-- status: `ready`
+- status: `done`
 - purpose: track whether recommended actions were executed and whether they
   improved useful outcomes or repeated failure.
 - source document:
@@ -2982,13 +2982,20 @@ live, broker, risk, or execution work.
 - validation required:
   - executed, blocked, repeated-failure, compute-saved, and false-positive
     outcomes are explicit.
+- completion evidence: PR #634, merge SHA
+  `4774c56bae5ff7c814b8db917321e27f6c50af7d`; read-only action usefulness
+  tracker added in `reporting/qre_action_usefulness_tracking.py`, with
+  governance summary `docs/governance/qre_action_usefulness_tracking.md`;
+  required CI checks green before squash-merge; post-merge queue/governance
+  validation pending in the follow-up queue-state PR; frozen contracts
+  unchanged; protected/execution paths untouched.
 - next dependency: `ADE-QRE-017I`.
 
 ### ADE-QRE-017I - Quality-Gated OHLCV/Cache Foundation
 
 - queue id: `ADE-QRE-017I`
 - title: Quality-Gated OHLCV/Cache Foundation.
-- status: `blocked until ADE-QRE-017H done`
+- status: `ready`
 - purpose: mature a reproducible, versioned, quality-gated OHLCV/cache
   foundation using existing packages and repository-local datasets first.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -353,10 +353,13 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert item_17g.status == "done"
     assert _done_evidence_is_complete(item_17g) is True
     item_17h = items["ADE-QRE-017H"]
-    assert item_17h.status == "ready"
+    item_17i = items["ADE-QRE-017I"]
+    assert item_17h.status == "done"
+    assert _done_evidence_is_complete(item_17h)
+    assert item_17i.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17h
+    assert _next_eligible_ready_item(items) == item_17i
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017h_after_017g_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017i_after_017h_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017H"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017I"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -99,7 +99,9 @@ def test_ade_qre_017_chain_selects_017h_after_017g_completion_evidence() -> None
     assert rows["ADE-QRE-017F"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017G"]["status"] == "done"
     assert rows["ADE-QRE-017G"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017H"]["status"] == "ready"
+    assert rows["ADE-QRE-017H"]["status"] == "done"
+    assert rows["ADE-QRE-017H"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017I"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017h_after_017g_completion_evidence() -> None:
+def test_current_queue_selects_017i_after_017h_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017H"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017I"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -176,7 +176,9 @@ def test_current_queue_selects_017h_after_017g_completion_evidence() -> None:
     assert rows["ADE-QRE-017F"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017G"]["status"] == "done"
     assert rows["ADE-QRE-017G"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017H"]["status"] == "ready"
+    assert rows["ADE-QRE-017H"]["status"] == "done"
+    assert rows["ADE-QRE-017H"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017I"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- mark `ADE-QRE-017H` done in the canonical queue source with merge evidence from PR #634
- promote `ADE-QRE-017I` from blocked to ready now that `017H` is complete
- update queue-state tests so the self-audit selects `ADE-QRE-017I` as the next eligible item

## Scope
- `docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md`
- `tests/unit/test_ade_qre_014_queue_lifecycle.py`
- `tests/unit/test_ade_qre_017_queue_admission.py`
- `tests/unit/test_ade_queue_status_self_audit.py`

## Validation
- `python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q`
- `python -m reporting.ade_queue_status_self_audit --no-write`
- `python scripts/governance_lint.py`
- `python -m reporting.development_work_queue --no-write`
- `git diff --check`

## Handoff
- after merge, `ADE-QRE-017I` should be the queue self-audit next eligible ready item
- next implementation branch should start `ADE-QRE-017I` from refreshed `main`