### PR TITLE
feat: add ADE-QRE-017I OHLCV cache foundation

### DIFF
--- a/artifacts/cache/cache_foundation_latest.v1.json
+++ b/artifacts/cache/cache_foundation_latest.v1.json
@@ -1,0 +1,766 @@
+{
+  "future_external_source_blockers": [
+    {
+      "activation_requirements": [
+        "field_coverage_manifest_defined",
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "report_lag_policy_defined",
+        "restatement_policy_defined"
+      ],
+      "authentication_required": true,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "FACTOR_FIELD_COVERAGE_UNKNOWN",
+        "LICENSE_REVIEW_REQUIRED",
+        "POINT_IN_TIME_UNKNOWN",
+        "REPORT_LAG_POLICY_UNKNOWN",
+        "RESTATEMENT_POLICY_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "alpha_vantage_candidate",
+      "requires_operator_or_credentials": true,
+      "source_id": "alpha_vantage_candidate_manifest",
+      "source_status": "candidate",
+      "source_type": "fundamental_statement_data"
+    },
+    {
+      "activation_requirements": [
+        "operator_manual_review"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "companies_house_metadata",
+      "requires_operator_or_credentials": false,
+      "source_id": "companies_house_metadata_manifest",
+      "source_status": "manual_research_only",
+      "source_type": "issuer_metadata"
+    },
+    {
+      "activation_requirements": [
+        "operator_license_approval",
+        "point_in_time_policy_defined",
+        "source_manifest_quality_pass"
+      ],
+      "authentication_required": true,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "FACTOR_FIELD_COVERAGE_UNKNOWN",
+        "LICENSE_REVIEW_REQUIRED",
+        "POINT_IN_TIME_UNKNOWN",
+        "REPORT_LAG_POLICY_UNKNOWN",
+        "RESTATEMENT_POLICY_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "eodhd_candidate",
+      "requires_operator_or_credentials": true,
+      "source_id": "eodhd_candidate_manifest",
+      "source_status": "candidate",
+      "source_type": "fundamental_statement_data"
+    },
+    {
+      "activation_requirements": [
+        "identity_mapping_quality_gate",
+        "source_manifest_quality_pass"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "euronext_issuer_metadata",
+      "requires_operator_or_credentials": false,
+      "source_id": "euronext_issuer_metadata_manifest",
+      "source_status": "candidate",
+      "source_type": "issuer_metadata"
+    },
+    {
+      "activation_requirements": [
+        "downstream_provider_manifest_defined",
+        "operator_license_approval"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "UNKNOWN",
+      "manifest_block_reasons": [
+        "ACCESS_METHOD_UNKNOWN",
+        "MISSING_LICENSE_TERMS",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "manifest_status": "FAIL",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "MISSING_LICENSE_TERMS"
+      ],
+      "provider_id": "financial_datasets_mcp",
+      "requires_operator_or_credentials": true,
+      "source_id": "financial_datasets_mcp_manifest",
+      "source_status": "staging",
+      "source_type": "connector_staging"
+    },
+    {
+      "activation_requirements": [
+        "operator_license_approval",
+        "point_in_time_policy_defined",
+        "source_manifest_quality_pass"
+      ],
+      "authentication_required": true,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "FACTOR_FIELD_COVERAGE_UNKNOWN",
+        "LICENSE_REVIEW_REQUIRED",
+        "POINT_IN_TIME_UNKNOWN",
+        "REPORT_LAG_POLICY_UNKNOWN",
+        "RESTATEMENT_POLICY_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "financial_modeling_prep_candidate",
+      "requires_operator_or_credentials": true,
+      "source_id": "financial_modeling_prep_candidate_manifest",
+      "source_status": "candidate",
+      "source_type": "fundamental_statement_data"
+    },
+    {
+      "activation_requirements": [
+        "identity_mapping_quality_gate",
+        "source_manifest_quality_pass"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "nasdaq_listings_metadata",
+      "requires_operator_or_credentials": false,
+      "source_id": "nasdaq_listings_metadata_manifest",
+      "source_status": "candidate",
+      "source_type": "listing_metadata"
+    },
+    {
+      "activation_requirements": [
+        "identity_mapping_quality_gate",
+        "source_manifest_quality_pass"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "nyse_listings_metadata",
+      "requires_operator_or_credentials": false,
+      "source_id": "nyse_listings_metadata_manifest",
+      "source_status": "candidate",
+      "source_type": "listing_metadata"
+    },
+    {
+      "activation_requirements": [
+        "downstream_provider_manifest_defined",
+        "operator_license_approval"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "UNKNOWN",
+      "manifest_block_reasons": [
+        "MISSING_LICENSE_TERMS",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "manifest_status": "FAIL",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "MISSING_LICENSE_TERMS"
+      ],
+      "provider_id": "openbb_connector",
+      "requires_operator_or_credentials": true,
+      "source_id": "openbb_connector_manifest",
+      "source_status": "staging",
+      "source_type": "connector_staging"
+    },
+    {
+      "activation_requirements": [
+        "alias_resolution_reviewed",
+        "identity_mapping_quality_gate",
+        "operator_api_usage_approval",
+        "source_manifest_quality_pass"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "openfigi_symbology",
+      "requires_operator_or_credentials": false,
+      "source_id": "openfigi_symbology_manifest",
+      "source_status": "candidate",
+      "source_type": "identity_symbology"
+    },
+    {
+      "activation_requirements": [
+        "field_coverage_manifest_defined",
+        "issuer_to_symbol_mapping_reviewed",
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_quality_pass"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "REPORT_LAG_POLICY_UNKNOWN",
+        "RESTATEMENT_POLICY_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "sec_companyfacts",
+      "requires_operator_or_credentials": false,
+      "source_id": "sec_companyfacts_manifest",
+      "source_status": "candidate",
+      "source_type": "fundamental_statement_data"
+    },
+    {
+      "activation_requirements": [
+        "operator_manual_review"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [
+        "LICENSE_REVIEW_REQUIRED"
+      ],
+      "provider_id": "stooq_price_context",
+      "requires_operator_or_credentials": false,
+      "source_id": "stooq_price_context_manifest",
+      "source_status": "manual_research_only",
+      "source_type": "market_price_context"
+    },
+    {
+      "activation_requirements": [
+        "operator_manual_review"
+      ],
+      "authentication_required": false,
+      "license_policy_status": "WARN",
+      "manifest_block_reasons": [
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "manifest_status": "WARN",
+      "operator_explanation": "License policy remains fail-closed until terms review and downstream policy gates are explicit.",
+      "policy_block_reasons": [],
+      "provider_id": "yahoo_finance_yfinance",
+      "requires_operator_or_credentials": false,
+      "source_id": "yahoo_finance_yfinance_manifest",
+      "source_status": "manual_research_only",
+      "source_type": "manual_research_context"
+    }
+  ],
+  "local_cache_foundation": {
+    "cache_manifest_path": "logs/qre_data_cache_manifest/latest.json",
+    "cache_roots": [
+      {
+        "cache_kind": "macro",
+        "path": "data/cache/macro",
+        "status": "present"
+      },
+      {
+        "cache_kind": "market",
+        "path": "data/cache/market",
+        "status": "present"
+      }
+    ],
+    "source_quality_path": "logs/qre_data_source_quality_readiness/latest.json",
+    "sources": [
+      {
+        "content_hash": "sha256:84dd8c5359c1d4eafacbf647edbe6ffeffc920742e622a1ad8458ac1444775bd",
+        "file_count": 476,
+        "instrument": "AAPL",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-08T00:00:00Z",
+        "ready": true,
+        "row_count": 2380,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:48a62e5b03a30cc0610e6336d461a827355922a426f7efa98b37ac0d46320e1b",
+        "file_count": 4,
+        "instrument": "ADA-USD",
+        "max_timestamp_utc": "2026-04-21T23:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 66576,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:f98b970ceea8c7630b5fd85f7b63e7976e663c1d5ab9d08dd411cd817a87a690",
+        "file_count": 4,
+        "instrument": "ADA-USD",
+        "max_timestamp_utc": "2026-04-21T20:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 16656,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:2d2f872e270601ba6ae91653d8f68d4c6c79dcc8e30f12ce95a413885330d491",
+        "file_count": 454,
+        "instrument": "AMD",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-08T00:00:00Z",
+        "ready": true,
+        "row_count": 2270,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:4b7263a814fa8ac1be866ac194646ca6996fda1230a9a2140e3ee8607d3fab1d",
+        "file_count": 1,
+        "instrument": "AMD",
+        "max_timestamp_utc": "2026-04-24T17:30:00Z",
+        "min_timestamp_utc": "2024-05-28T13:30:00Z",
+        "ready": true,
+        "row_count": 952,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:439810abd387fe8a725eb985cf90e5b2c9505940bac0a905e52242d3f63de59f",
+        "file_count": 1,
+        "instrument": "AMZN",
+        "max_timestamp_utc": "2026-04-24T17:30:00Z",
+        "min_timestamp_utc": "2024-05-28T13:30:00Z",
+        "ready": true,
+        "row_count": 952,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:d77557956a7b53ced169eaf32062357a6aa1dcc8eb58e70c709dc087921302ad",
+        "file_count": 463,
+        "instrument": "ASML",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-08T00:00:00Z",
+        "ready": true,
+        "row_count": 2315,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:bfcf62c1f46529440bd32fa0475abf67ece219f930bed02f483af7cbfc079676",
+        "file_count": 1,
+        "instrument": "ASML",
+        "max_timestamp_utc": "2026-04-24T17:30:00Z",
+        "min_timestamp_utc": "2024-05-28T13:30:00Z",
+        "ready": true,
+        "row_count": 952,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:a9b91d4a0c30867911cc0c1a94c189e4ecbf31eb9ae0114e58bfc2f072e93d37",
+        "file_count": 431,
+        "instrument": "BNB-EUR",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-08T00:00:00Z",
+        "ready": true,
+        "row_count": 2973,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:c16123cf96c509b03749d57e212f102dbf526df7f9749219f24c19ab8b8daa18",
+        "file_count": 4,
+        "instrument": "BNB-USD",
+        "max_timestamp_utc": "2026-04-21T23:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 66576,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:31bb45537ef44c59d8827db3f10e71e720b0a72d7b6bf1a6b670ba7182669683",
+        "file_count": 4,
+        "instrument": "BNB-USD",
+        "max_timestamp_utc": "2026-04-21T20:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 16656,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:5305a1b3e90648282c383467cf577941cb2ae87af524fd3c4d1e7a07a44ad25f",
+        "file_count": 452,
+        "instrument": "BTC-EUR",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-08T00:00:00Z",
+        "ready": true,
+        "row_count": 3118,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:f71fafc15a9c8f16c1e91639310a504be2aa828245e649c06f0c182f0fafb84b",
+        "file_count": 2,
+        "instrument": "BTC-EUR",
+        "max_timestamp_utc": "2026-04-24T23:00:00Z",
+        "min_timestamp_utc": "2024-05-15T00:00:00Z",
+        "ready": true,
+        "row_count": 33290,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:3bbfc2b7188b6a983ce66a00721bcb8602b2fb631e0079c818418f38cd222f20",
+        "file_count": 6,
+        "instrument": "BTC-USD",
+        "max_timestamp_utc": "2026-04-21T23:00:00Z",
+        "min_timestamp_utc": "2024-05-08T00:00:00Z",
+        "ready": true,
+        "row_count": 99864,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:afd5476aeb7e7d5a6c6a0e812a36e4106bf3248888ef6c6909c8658e16a78301",
+        "file_count": 6,
+        "instrument": "BTC-USD",
+        "max_timestamp_utc": "2026-04-21T20:00:00Z",
+        "min_timestamp_utc": "2024-05-08T00:00:00Z",
+        "ready": true,
+        "row_count": 24984,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:ab8c8d02c5bc76ea99e733e9f062a89415e0b2fd94c628be09c041f62f1f6689",
+        "file_count": 4,
+        "instrument": "DOT-USD",
+        "max_timestamp_utc": "2026-04-21T23:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 66576,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:13996de1ef236f92b7baf40a68b7d9330f25a042192fba524ed2adf8a354c3f6",
+        "file_count": 4,
+        "instrument": "DOT-USD",
+        "max_timestamp_utc": "2026-04-21T20:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 16656,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:8266d7aa2341062ef424b6122abcc5766cfdb5285a66d94f34aaf5d505352b7d",
+        "file_count": 447,
+        "instrument": "ETH-EUR",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-04T00:00:00Z",
+        "ready": true,
+        "row_count": 3085,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:7429f66338f2ab09576e5fc1debf9f718eee5406a894a4621cf377a3f24f56b5",
+        "file_count": 1,
+        "instrument": "ETH-EUR",
+        "max_timestamp_utc": "2026-04-24T23:00:00Z",
+        "min_timestamp_utc": "2024-05-25T00:00:00Z",
+        "ready": true,
+        "row_count": 16645,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:ebf1204497ca1d4a2d06d74fc0ac4f422d9aad95b9f7ccb2865839e145fa339d",
+        "file_count": 6,
+        "instrument": "ETH-USD",
+        "max_timestamp_utc": "2026-04-21T23:00:00Z",
+        "min_timestamp_utc": "2024-05-08T00:00:00Z",
+        "ready": true,
+        "row_count": 99864,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:926b500f57a711cef56b98540c19d44c49183f13cc90a72853c813553556e2fd",
+        "file_count": 6,
+        "instrument": "ETH-USD",
+        "max_timestamp_utc": "2026-04-21T20:00:00Z",
+        "min_timestamp_utc": "2024-05-08T00:00:00Z",
+        "ready": true,
+        "row_count": 24984,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:77baaa09f463a1af96093ea2d97744f02a6302ef36394f0e0f47d1d75c785ff6",
+        "file_count": 4,
+        "instrument": "LINK-USD",
+        "max_timestamp_utc": "2026-04-21T23:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 66576,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:460d5baf21f13fe8dd42beeb3881ceabb4cf635bf97e61f147d66423b384f3aa",
+        "file_count": 4,
+        "instrument": "LINK-USD",
+        "max_timestamp_utc": "2026-04-21T20:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 16656,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:8041001d3ce01cfc503f0ab5a59bc152bdec3738a26d8e73fc997c313bba1d8a",
+        "file_count": 1,
+        "instrument": "META",
+        "max_timestamp_utc": "2026-04-24T17:30:00Z",
+        "min_timestamp_utc": "2024-05-28T13:30:00Z",
+        "ready": true,
+        "row_count": 952,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:d0c2bd6a4abe3926328a38dfc33f37854d016f041adcd33e6fe6267f7bcacd7c",
+        "file_count": 465,
+        "instrument": "MSFT",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-08T00:00:00Z",
+        "ready": true,
+        "row_count": 2325,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:127207bc47bf93e04d8cfcb1545a889a72de9df39c9836a6105d920f632c66ae",
+        "file_count": 1,
+        "instrument": "MSFT",
+        "max_timestamp_utc": "2026-04-24T17:30:00Z",
+        "min_timestamp_utc": "2024-05-28T13:30:00Z",
+        "ready": true,
+        "row_count": 952,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:c1fde4f3c570e9504208d5082f29dc2d735f565f48c7da67b655366441cf6e7d",
+        "file_count": 485,
+        "instrument": "NVDA",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-06T00:00:00Z",
+        "ready": true,
+        "row_count": 2425,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:92c37ba17473ce118acde948b1f03123367668526938cf1587c2c4cfe975cd3d",
+        "file_count": 2,
+        "instrument": "NVDA",
+        "max_timestamp_utc": "2026-04-24T17:30:00Z",
+        "min_timestamp_utc": "2024-05-15T13:30:00Z",
+        "ready": true,
+        "row_count": 1904,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:ef9455ce9a7e419455fd62e40ba724ec3dde3fa5890680cba6e89ec293caf221",
+        "file_count": 439,
+        "instrument": "SOL-EUR",
+        "max_timestamp_utc": "2026-05-22T00:00:00Z",
+        "min_timestamp_utc": "2026-04-08T00:00:00Z",
+        "ready": true,
+        "row_count": 3029,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:496e237e7efdfcede2e2e75d52930699ff1f47440bb5a3b7b3d693ab02c1145a",
+        "file_count": 1,
+        "instrument": "SOL-EUR",
+        "max_timestamp_utc": "2026-04-24T23:00:00Z",
+        "min_timestamp_utc": "2024-05-25T00:00:00Z",
+        "ready": true,
+        "row_count": 16645,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:d989c0e5567860523ba00ffe41d2204e804bdb02faac37288449443599b3c5d6",
+        "file_count": 4,
+        "instrument": "SOL-USD",
+        "max_timestamp_utc": "2026-04-21T23:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 66576,
+        "source": "yfinance",
+        "timeframe": "1h"
+      },
+      {
+        "content_hash": "sha256:f2dede344be53faa1f078ef4df76e0e5112b3bb793cb6fdd90eff997dbd3a41b",
+        "file_count": 4,
+        "instrument": "SOL-USD",
+        "max_timestamp_utc": "2026-04-21T20:00:00Z",
+        "min_timestamp_utc": "2024-05-13T00:00:00Z",
+        "ready": true,
+        "row_count": 16656,
+        "source": "yfinance",
+        "timeframe": "4h"
+      },
+      {
+        "content_hash": "sha256:c7d06d5e229d9196ca22354057c6e587624568c7148c540260f765737b8296c1",
+        "file_count": 1,
+        "instrument": "TEST",
+        "max_timestamp_utc": "2026-04-21T00:00:00Z",
+        "min_timestamp_utc": "2026-04-15T00:00:00Z",
+        "ready": true,
+        "row_count": 5,
+        "source": "yfinance",
+        "timeframe": "1d"
+      },
+      {
+        "content_hash": "sha256:37f9903d2e0671e54b1803e32e1bdac3fbc8bf1b735cd1fe058e97c795d80d3a",
+        "file_count": 1,
+        "instrument": "TSM",
+        "max_timestamp_utc": "2026-04-24T17:30:00Z",
+        "min_timestamp_utc": "2024-05-28T13:30:00Z",
+        "ready": true,
+        "row_count": 952,
+        "source": "yfinance",
+        "timeframe": "4h"
+      }
+    ]
+  },
+  "report_kind": "qre_ohlcv_cache_foundation",
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "external_source_activation_not_required": true,
+    "fetches_external_data": false,
+    "mutates_cache": false,
+    "mutates_frozen_contracts": false,
+    "mutates_research_outputs": false,
+    "paper_shadow_live_forbidden": true,
+    "read_only": true,
+    "source_activation_remains_separate": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "cache_file_count": 4189,
+    "cache_manifest_status": "ready",
+    "cache_root_status_counts": {
+      "present": 2
+    },
+    "coverage_row_count": 34,
+    "external_blocker_count": 13,
+    "external_blockers_requiring_operator_or_credentials": 5,
+    "instrument_count": 20,
+    "local_source_status_counts": {
+      "ready": 34
+    },
+    "manifest_content_hash": "sha256:7017b28ce6c1886dd3d4c7778d57181ee825883bb744c56fed61893030ca910a",
+    "operator_summary": "Local OHLCV/cache foundation is ready from repository-local datasets. Cache manifest, source-quality readiness, source/cache materialization, and throughput policy are aligned, while external source activation remains separately blocked until explicit manifest, license, and policy gates pass.",
+    "ready_coverage_row_count": 34,
+    "research_ready": true,
+    "source_cache_linked": true,
+    "source_count": 1,
+    "source_quality_status": "ready",
+    "status": "ready",
+    "throughput_status": "ready",
+    "timeframe_count": 3
+  },
+  "supporting_reports": {
+    "cache_manifest_status": {
+      "fails_closed": false,
+      "path": "logs/qre_data_cache_manifest/latest.json",
+      "research_ready": true,
+      "schema_version": "1.0",
+      "status": "ready"
+    },
+    "cache_throughput": {
+      "blocked_reason_counts": {},
+      "cache_manifest_ready": true,
+      "duckdb_catalog_manifest_ready": true,
+      "polars_use_policy_ready": true,
+      "research_ready": true,
+      "snapshot_contract_ready": true,
+      "status": "ready"
+    },
+    "source_cache_materialization": {
+      "cache_manifest_sidecar_status": "present_ready",
+      "missing_sidecars": [],
+      "present_not_ready_sidecars": [],
+      "source_cache_readiness_linked": true,
+      "source_quality_sidecar_status": "present_ready"
+    },
+    "source_quality_status": {
+      "fails_closed": false,
+      "path": "logs/qre_data_source_quality_readiness/latest.json",
+      "research_ready": true,
+      "schema_version": "1.0",
+      "status": "ready"
+    }
+  }
+}

--- a/docs/governance/qre_ohlcv_cache_foundation.md
+++ b/docs/governance/qre_ohlcv_cache_foundation.md
@@ -1,0 +1,54 @@
+# QRE OHLCV/Cache Foundation
+
+## Purpose
+
+`research.qre_ohlcv_cache_foundation` materializes one deterministic read-only
+foundation report over the existing local OHLCV/cache evidence surfaces.
+
+It composes:
+
+- `packages.qre_data.cache_manifest`
+- `packages.qre_data.source_quality_readiness`
+- `research.qre_source_cache_readiness_materialization`
+- `research.qre_cache_throughput_manifest`
+- `research.external_intelligence.source_manifest_registry`
+
+## Scope
+
+- Uses repository-local cache sidecars and datasets first.
+- Reports whether the local cache foundation is reproducible, versioned, and
+  quality-gated.
+- Surfaces future external source blockers separately from the local foundation.
+- Writes only:
+  - `logs/qre_ohlcv_cache_foundation/latest.json`
+  - `logs/qre_ohlcv_cache_foundation/operator_summary.md`
+  - `artifacts/cache/cache_foundation_latest.v1.json`
+
+## Out Of Scope
+
+- No external fetches.
+- No cache backfill or mutation.
+- No activation of source providers.
+- No paper, shadow, live, broker, risk, execution, or capital-allocation paths.
+- No mutation of `research/research_latest.json` or `research/strategy_matrix.csv`.
+
+## Commands
+
+```powershell
+python -m research.qre_ohlcv_cache_foundation
+python -m research.qre_ohlcv_cache_foundation --write
+python -m research.qre_ohlcv_cache_foundation --duckdb-available true --polars-available true
+```
+
+## Readiness Semantics
+
+The foundation is `ready` only when all of the following are true:
+
+- the local cache manifest is research-ready;
+- the local source-quality report is research-ready;
+- the source/cache materialization links both sidecars;
+- the throughput manifest remains research-ready.
+
+External source providers may still remain blocked. Those blockers are reported
+explicitly and do not silently change the local cache foundation into authority
+for trading or source activation.

--- a/research/qre_ohlcv_cache_foundation.py
+++ b/research/qre_ohlcv_cache_foundation.py
@@ -1,0 +1,439 @@
+"""Read-only QRE OHLCV/cache foundation materialization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_data import cache_manifest, source_quality_readiness
+from research import qre_cache_throughput_manifest, qre_source_cache_readiness_materialization
+from research.external_intelligence import source_manifest_registry
+
+REPORT_KIND: Final[str] = "qre_ohlcv_cache_foundation"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_ohlcv_cache_foundation")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_ohlcv_cache_foundation/"
+ARTIFACT_DIR: Final[Path] = Path("artifacts/cache")
+ARTIFACT_NAME: Final[str] = "cache_foundation_latest.v1.json"
+ARTIFACT_WRITE_PREFIX: Final[str] = "artifacts/cache/"
+_CACHE_MANIFEST_PATH: Final[Path] = Path("logs/qre_data_cache_manifest/latest.json")
+_SOURCE_QUALITY_PATH: Final[Path] = Path("logs/qre_data_source_quality_readiness/latest.json")
+_THROUGHPUT_PATH: Final[Path] = Path("logs/qre_cache_throughput_manifest/latest.json")
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _counter_dict(values: Sequence[str]) -> dict[str, int]:
+    return dict(sorted(Counter(values).items()))
+
+
+def _throughput_report(
+    *,
+    repo_root: Path,
+    duckdb_available: bool | None,
+    polars_available: bool | None,
+) -> dict[str, Any]:
+    payload = _read_json(repo_root / _THROUGHPUT_PATH)
+    if isinstance(payload, dict) and isinstance(payload.get("summary"), Mapping):
+        return payload
+    return qre_cache_throughput_manifest.build_cache_throughput_manifest(
+        repo_root=repo_root,
+        cache_manifest_path=_CACHE_MANIFEST_PATH,
+        duckdb_available=duckdb_available,
+        polars_available=polars_available,
+    )
+
+
+def _local_cache_sources(coverage: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in coverage:
+        rows.append(
+            {
+                "source": str(row.get("source") or "unknown"),
+                "instrument": str(row.get("instrument") or "unknown"),
+                "timeframe": str(row.get("timeframe") or "unknown"),
+                "ready": bool(row.get("ready")),
+                "file_count": int(row.get("file_count") or 0),
+                "row_count": int(row.get("row_count") or 0),
+                "min_timestamp_utc": row.get("min_timestamp_utc"),
+                "max_timestamp_utc": row.get("max_timestamp_utc"),
+                "content_hash": row.get("content_hash"),
+            }
+        )
+    rows.sort(key=lambda item: (item["source"], item["instrument"], item["timeframe"]))
+    return rows
+
+
+def _future_external_source_blockers() -> list[dict[str, Any]]:
+    registry = source_manifest_registry.build_source_manifest_registry()
+    policy_by_source = registry["policy_by_source"]
+    blocked: list[dict[str, Any]] = []
+    for row in registry["rows"]:
+        source_id = str(row["source_id"])
+        provider_id = str(row["provider_id"])
+        policy = policy_by_source[source_id]
+        license_status = str(policy["license_policy_status"])
+        manifest_status = str(row["manifest_status"])
+        activation_requirements = [str(item) for item in row.get("activation_requirements", [])]
+        block_reasons = [str(item) for item in row.get("manifest_block_reasons", [])]
+        requires_operator_or_credentials = bool(row.get("authentication_required")) or (
+            "operator_license_approval" in activation_requirements
+        )
+        if license_status == "PASS" and manifest_status == "PASS" and not requires_operator_or_credentials:
+            continue
+        blocked.append(
+            {
+                "source_id": source_id,
+                "provider_id": provider_id,
+                "source_type": str(row["source_type"]),
+                "source_status": str(row["source_status"]),
+                "license_policy_status": license_status,
+                "manifest_status": manifest_status,
+                "authentication_required": bool(row.get("authentication_required")),
+                "requires_operator_or_credentials": requires_operator_or_credentials,
+                "activation_requirements": activation_requirements,
+                "manifest_block_reasons": block_reasons,
+                "policy_block_reasons": [str(item) for item in policy.get("block_reasons", [])],
+                "operator_explanation": str(policy["operator_explanation"]),
+            }
+        )
+    blocked.sort(key=lambda item: (item["provider_id"], item["source_id"]))
+    return blocked
+
+
+def build_ohlcv_cache_foundation(
+    *,
+    repo_root: Path = Path("."),
+    duckdb_available: bool | None = None,
+    polars_available: bool | None = None,
+) -> dict[str, Any]:
+    manifest_status = cache_manifest.read_manifest_status(repo_root=repo_root)
+    source_quality_status = source_quality_readiness.read_source_quality_status(repo_root=repo_root)
+    manifest_payload = _read_json(repo_root / _CACHE_MANIFEST_PATH) or {}
+    throughput = _throughput_report(
+        repo_root=repo_root,
+        duckdb_available=duckdb_available,
+        polars_available=polars_available,
+    )
+    materialization = qre_source_cache_readiness_materialization.build_source_cache_readiness_materialization(
+        repo_root=repo_root
+    )
+
+    manifest_summary = (
+        manifest_payload.get("summary") if isinstance(manifest_payload.get("summary"), Mapping) else {}
+    )
+    coverage = manifest_payload.get("coverage")
+    cache_roots = manifest_payload.get("cache_roots")
+    if not isinstance(coverage, list):
+        coverage = []
+    if not isinstance(cache_roots, list):
+        cache_roots = []
+
+    local_cache_sources = _local_cache_sources(
+        [row for row in coverage if isinstance(row, Mapping)]
+    )
+    local_ready_sources = [row for row in local_cache_sources if row["ready"]]
+    external_blockers = _future_external_source_blockers()
+
+    foundation_ready = all(
+        (
+            bool(manifest_status.get("research_ready")),
+            bool(source_quality_status.get("research_ready")),
+            bool(throughput["summary"]["research_ready"]),
+            bool(materialization["summary"]["source_cache_readiness_linked"]),
+        )
+    )
+    blocked_reasons: list[str] = []
+    if not bool(manifest_status.get("research_ready")):
+        blocked_reasons.append(str(manifest_status.get("status") or "cache_manifest_not_ready"))
+    if not bool(source_quality_status.get("research_ready")):
+        blocked_reasons.append(
+            str(source_quality_status.get("status") or "source_quality_not_ready")
+        )
+    if not bool(throughput["summary"]["research_ready"]):
+        blocked_reasons.extend(
+            str(item["reason"])
+            for item in throughput.get("throughput_blockers", [])
+            if isinstance(item, Mapping)
+        )
+    if not bool(materialization["summary"]["source_cache_readiness_linked"]):
+        blocked_reasons.extend(
+            str(reason)
+            for reason in materialization["summary"].get("missing_sidecars", [])
+        )
+        blocked_reasons.extend(
+            f"{reason}_not_ready"
+            for reason in materialization["summary"].get("present_not_ready_sidecars", [])
+        )
+
+    operator_summary = (
+        "Local OHLCV/cache foundation is ready from repository-local datasets. "
+        "Cache manifest, source-quality readiness, source/cache materialization, "
+        "and throughput policy are aligned, while external source activation remains "
+        "separately blocked until explicit manifest, license, and policy gates pass."
+        if foundation_ready
+        else "Local OHLCV/cache foundation remains fail-closed because "
+        + ", ".join(sorted(set(blocked_reasons)))
+        + "."
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "status": "ready" if foundation_ready else "not_ready",
+            "research_ready": foundation_ready,
+            "cache_manifest_status": str(manifest_status.get("status") or "missing"),
+            "source_quality_status": str(source_quality_status.get("status") or "missing"),
+            "throughput_status": str(throughput["summary"]["status"]),
+            "source_cache_linked": bool(materialization["summary"]["source_cache_readiness_linked"]),
+            "cache_file_count": int(manifest_summary.get("cache_file_count") or 0),
+            "coverage_row_count": int(manifest_summary.get("coverage_row_count") or 0),
+            "ready_coverage_row_count": len(local_ready_sources),
+            "source_count": len({row["source"] for row in local_cache_sources}),
+            "instrument_count": len({row["instrument"] for row in local_cache_sources}),
+            "timeframe_count": len({row["timeframe"] for row in local_cache_sources}),
+            "cache_root_status_counts": _counter_dict(
+                [str(row.get("status") or "unknown") for row in cache_roots if isinstance(row, Mapping)]
+            ),
+            "local_source_status_counts": _counter_dict(
+                ["ready" if row["ready"] else "blocked" for row in local_cache_sources]
+            ),
+            "external_blocker_count": len(external_blockers),
+            "external_blockers_requiring_operator_or_credentials": sum(
+                1 for row in external_blockers if row["requires_operator_or_credentials"]
+            ),
+            "manifest_content_hash": manifest_summary.get("manifest_content_hash"),
+            "operator_summary": operator_summary,
+        },
+        "local_cache_foundation": {
+            "cache_manifest_path": str(manifest_status.get("path") or _CACHE_MANIFEST_PATH.as_posix()),
+            "source_quality_path": str(
+                source_quality_status.get("path") or _SOURCE_QUALITY_PATH.as_posix()
+            ),
+            "cache_roots": [row for row in cache_roots if isinstance(row, Mapping)],
+            "sources": local_cache_sources,
+        },
+        "supporting_reports": {
+            "cache_manifest_status": manifest_status,
+            "source_quality_status": source_quality_status,
+            "source_cache_materialization": {
+                "cache_manifest_sidecar_status": materialization["summary"][
+                    "cache_manifest_sidecar_status"
+                ],
+                "source_quality_sidecar_status": materialization["summary"][
+                    "source_quality_sidecar_status"
+                ],
+                "source_cache_readiness_linked": materialization["summary"][
+                    "source_cache_readiness_linked"
+                ],
+                "missing_sidecars": materialization["summary"]["missing_sidecars"],
+                "present_not_ready_sidecars": materialization["summary"][
+                    "present_not_ready_sidecars"
+                ],
+            },
+            "cache_throughput": {
+                "status": throughput["summary"]["status"],
+                "research_ready": throughput["summary"]["research_ready"],
+                "cache_manifest_ready": throughput["summary"]["cache_manifest_ready"],
+                "snapshot_contract_ready": throughput["summary"]["snapshot_contract_ready"],
+                "duckdb_catalog_manifest_ready": throughput["summary"][
+                    "duckdb_catalog_manifest_ready"
+                ],
+                "polars_use_policy_ready": throughput["summary"]["polars_use_policy_ready"],
+                "blocked_reason_counts": throughput["summary"]["blocked_reason_counts"],
+            },
+        },
+        "future_external_source_blockers": external_blockers,
+        "safety_invariants": {
+            "read_only": True,
+            "fetches_external_data": False,
+            "mutates_cache": False,
+            "mutates_research_outputs": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "external_source_activation_not_required": True,
+            "source_activation_remains_separate": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    local = (
+        report.get("local_cache_foundation")
+        if isinstance(report.get("local_cache_foundation"), Mapping)
+        else {}
+    )
+    sources = local.get("sources") if isinstance(local.get("sources"), list) else []
+    blockers = (
+        report.get("future_external_source_blockers")
+        if isinstance(report.get("future_external_source_blockers"), list)
+        else []
+    )
+    summary_table = _table(
+        ["Field", "Value"],
+        [
+            ["status", str(summary.get("status") or "")],
+            ["research_ready", str(summary.get("research_ready") or False)],
+            ["cache_manifest_status", str(summary.get("cache_manifest_status") or "")],
+            ["source_quality_status", str(summary.get("source_quality_status") or "")],
+            ["throughput_status", str(summary.get("throughput_status") or "")],
+            ["source_cache_linked", str(summary.get("source_cache_linked") or False)],
+            ["cache_file_count", str(summary.get("cache_file_count") or 0)],
+            ["coverage_row_count", str(summary.get("coverage_row_count") or 0)],
+            ["source_count", str(summary.get("source_count") or 0)],
+            ["external_blocker_count", str(summary.get("external_blocker_count") or 0)],
+        ],
+    )
+    source_table = _table(
+        ["source", "instrument", "timeframe", "ready", "file_count", "row_count"],
+        [
+            [
+                str(row.get("source") or ""),
+                str(row.get("instrument") or ""),
+                str(row.get("timeframe") or ""),
+                str(row.get("ready") or False),
+                str(row.get("file_count") or 0),
+                str(row.get("row_count") or 0),
+            ]
+            for row in sources[:12]
+            if isinstance(row, Mapping)
+        ],
+    )
+    blocker_table = _table(
+        ["source_id", "provider_id", "license", "manifest", "operator_or_credentials"],
+        [
+            [
+                str(row.get("source_id") or ""),
+                str(row.get("provider_id") or ""),
+                str(row.get("license_policy_status") or ""),
+                str(row.get("manifest_status") or ""),
+                str(row.get("requires_operator_or_credentials") or False),
+            ]
+            for row in blockers[:12]
+            if isinstance(row, Mapping)
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE OHLCV Cache Foundation",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Summary",
+            summary_table,
+            "",
+            "## Local Cache Sources",
+            source_table,
+            "",
+            "## Future External Source Blockers",
+            blocker_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_ohlcv_cache_foundation: refusing write outside allowlist: {path!r}"
+        )
+
+
+def _validate_artifact_target(path: Path) -> None:
+    if ARTIFACT_WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_ohlcv_cache_foundation: refusing artifact write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    artifact_base = repo_root / ARTIFACT_DIR
+    artifact_base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    artifact = artifact_base / ARTIFACT_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+    _validate_artifact_target(artifact)
+
+    payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+
+    tmp_artifact = artifact.with_suffix(artifact.suffix + ".tmp")
+    tmp_artifact.write_text(payload, encoding="utf-8")
+    os.replace(tmp_artifact, artifact)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+        "cache_foundation_artifact": artifact.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_ohlcv_cache_foundation",
+        description="Materialize the read-only QRE OHLCV/cache foundation report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--duckdb-available",
+        choices=("auto", "true", "false"),
+        default="auto",
+    )
+    parser.add_argument(
+        "--polars-available",
+        choices=("auto", "true", "false"),
+        default="auto",
+    )
+    args = parser.parse_args(argv)
+    duckdb_available = None if args.duckdb_available == "auto" else args.duckdb_available == "true"
+    polars_available = None if args.polars_available == "auto" else args.polars_available == "true"
+    report = build_ohlcv_cache_foundation(
+        duckdb_available=duckdb_available,
+        polars_available=polars_available,
+    )
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_ohlcv_cache_foundation.py
+++ b/tests/unit/test_qre_ohlcv_cache_foundation.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from packages.qre_data import cache_manifest, source_quality_readiness
+from research import qre_cache_throughput_manifest
+from research import qre_ohlcv_cache_foundation as foundation
+
+
+def _write_parquet(path: Path, timestamps: list[datetime]) -> None:
+    table = pa.table(
+        {
+            "instrument_id": ["btc-usd"] * len(timestamps),
+            "interval": ["1h"] * len(timestamps),
+            "timestamp_utc": timestamps,
+            "close": [100.0 + i for i, _ in enumerate(timestamps)],
+        }
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, path)
+
+
+def _seed_cache_and_source_sidecars(tmp_path: Path) -> None:
+    cache = tmp_path / "data" / "cache" / "market"
+    _write_parquet(
+        cache / "yfinance__AAPL__1d__20260401__20260402__abc123.parquet",
+        [datetime(2026, 4, 1, 0, 0, tzinfo=UTC)],
+    )
+    manifest_payload = cache_manifest.build_cache_manifest(
+        cache_dirs={"market": Path("data/cache/market")},
+        repo_root=tmp_path,
+        generated_at_utc="2026-06-26T00:00:00Z",
+    )
+    cache_manifest.write_manifest_outputs(
+        manifest_payload,
+        output_dir=Path("logs/qre_data_cache_manifest"),
+        repo_root=tmp_path,
+    )
+    source_payload = source_quality_readiness.build_source_quality_report(
+        manifest_payload,
+        generated_at_utc="2026-06-26T00:00:00Z",
+    )
+    source_quality_readiness.write_source_quality_outputs(
+        source_payload,
+        output_dir=Path("logs/qre_data_source_quality_readiness"),
+        repo_root=tmp_path,
+    )
+
+
+def test_foundation_reports_local_cache_ready_and_external_blockers_separately(
+    tmp_path: Path,
+) -> None:
+    _seed_cache_and_source_sidecars(tmp_path)
+
+    report = foundation.build_ohlcv_cache_foundation(
+        repo_root=tmp_path,
+        duckdb_available=True,
+        polars_available=True,
+    )
+
+    assert report["report_kind"] == "qre_ohlcv_cache_foundation"
+    assert report["summary"]["research_ready"] is True
+    assert report["summary"]["cache_manifest_status"] == "ready"
+    assert report["summary"]["source_quality_status"] == "ready"
+    assert report["summary"]["throughput_status"] == "ready"
+    assert report["summary"]["source_cache_linked"] is True
+    assert report["summary"]["cache_file_count"] == 1
+    assert report["summary"]["coverage_row_count"] == 1
+    assert report["summary"]["local_source_status_counts"] == {"ready": 1}
+    assert report["local_cache_foundation"]["sources"] == [
+        {
+            "source": "yfinance",
+            "instrument": "AAPL",
+            "timeframe": "1d",
+            "ready": True,
+            "file_count": 1,
+            "row_count": 1,
+            "min_timestamp_utc": "2026-04-01T00:00:00Z",
+            "max_timestamp_utc": "2026-04-01T00:00:00Z",
+            "content_hash": report["local_cache_foundation"]["sources"][0]["content_hash"],
+        }
+    ]
+    assert report["future_external_source_blockers"]
+    assert any(
+        row["requires_operator_or_credentials"] for row in report["future_external_source_blockers"]
+    )
+    assert "Local OHLCV/cache foundation is ready" in report["summary"]["operator_summary"]
+
+
+def test_foundation_fails_closed_when_cache_sidecars_are_missing(tmp_path: Path) -> None:
+    report = foundation.build_ohlcv_cache_foundation(
+        repo_root=tmp_path,
+        duckdb_available=False,
+        polars_available=False,
+    )
+
+    assert report["summary"]["research_ready"] is False
+    assert report["summary"]["cache_manifest_status"] == "missing_manifest"
+    assert report["summary"]["source_quality_status"] == "missing_source_quality_report"
+    assert report["summary"]["throughput_status"] == "not_ready"
+    assert report["summary"]["source_cache_linked"] is False
+    assert report["summary"]["cache_file_count"] == 0
+    assert report["summary"]["coverage_row_count"] == 0
+    assert report["summary"]["local_source_status_counts"] == {}
+    assert report["future_external_source_blockers"]
+    assert "duckdb_module_unavailable" in report["summary"]["operator_summary"]
+
+
+def test_write_outputs_persists_log_and_artifact_files(tmp_path: Path) -> None:
+    _seed_cache_and_source_sidecars(tmp_path)
+    report = foundation.build_ohlcv_cache_foundation(
+        repo_root=tmp_path,
+        duckdb_available=True,
+        polars_available=True,
+    )
+
+    paths = foundation.write_outputs(report, repo_root=tmp_path)
+
+    assert paths == {
+        "latest": "logs/qre_ohlcv_cache_foundation/latest.json",
+        "operator_summary": "logs/qre_ohlcv_cache_foundation/operator_summary.md",
+        "cache_foundation_artifact": "artifacts/cache/cache_foundation_latest.v1.json",
+    }
+    latest_path = tmp_path / paths["latest"]
+    artifact_path = tmp_path / paths["cache_foundation_artifact"]
+    assert latest_path.is_file()
+    assert artifact_path.is_file()
+    payload = json.loads(latest_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["research_ready"] is True
+    assert json.loads(artifact_path.read_text(encoding="utf-8"))["report_kind"] == (
+        "qre_ohlcv_cache_foundation"
+    )
+
+
+def test_foundation_prefers_existing_throughput_sidecar_over_current_environment(
+    tmp_path: Path,
+) -> None:
+    _seed_cache_and_source_sidecars(tmp_path)
+    throughput = qre_cache_throughput_manifest.build_cache_throughput_manifest(
+        repo_root=tmp_path,
+        cache_manifest_path=Path("logs/qre_data_cache_manifest/latest.json"),
+        generated_at_utc="2026-06-26T00:00:00Z",
+        duckdb_available=True,
+        polars_available=True,
+    )
+    qre_cache_throughput_manifest.write_outputs(
+        throughput,
+        repo_root=tmp_path,
+        output_dir=Path("logs/qre_cache_throughput_manifest"),
+    )
+
+    report = foundation.build_ohlcv_cache_foundation(
+        repo_root=tmp_path,
+        duckdb_available=False,
+        polars_available=False,
+    )
+
+    assert report["summary"]["throughput_status"] == "ready"
+    assert report["summary"]["research_ready"] is True


### PR DESCRIPTION
## Summary
- implement ADE-QRE-017I with a deterministic read-only `research.qre_ohlcv_cache_foundation` report
- compose the existing cache manifest, source-quality readiness, source/cache materialization, and throughput sidecars into one local OHLCV/cache foundation surface
- add operator docs, a tracked cache foundation artifact, and targeted regression coverage including sidecar-preference behavior

## Dependencies
- depends on ADE-QRE-017H done
- unblocks ADE-QRE-017J after merge and completion-evidence follow-up

## Scope
- `research/qre_ohlcv_cache_foundation.py`
- `docs/governance/qre_ohlcv_cache_foundation.md`
- `tests/unit/test_qre_ohlcv_cache_foundation.py`
- `artifacts/cache/cache_foundation_latest.v1.json`

## Forbidden scope
- no `.claude/**`
- no `research/research_latest.json`
- no `research/strategy_matrix.csv`
- no paper/shadow/live activation
- no broker/risk/execution/capital-allocation changes
- no external fetches or cache backfills

## Validation
- `python -m pytest tests/unit/test_qre_ohlcv_cache_foundation.py tests/unit/test_qre_data_cache_manifest.py tests/unit/test_qre_data_source_quality_readiness.py tests/unit/test_qre_source_cache_readiness_materialization.py tests/unit/test_qre_cache_throughput_manifest.py -q`
- `python -m ruff check research/qre_ohlcv_cache_foundation.py tests/unit/test_qre_ohlcv_cache_foundation.py`
- `python scripts/governance_lint.py`
- `python -m reporting.architecture_import_scan --format summary`
- `python -m pytest tests/architecture -q`
- `python -m reporting.ade_queue_status_self_audit --no-write`
- `python -m reporting.development_work_queue --no-write`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Handoff
- after merge, record ADE-QRE-017I completion evidence in the canonical queue and flip ADE-QRE-017J to ready