### PR TITLE
docs: record ADE-QRE-017I completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2995,7 +2995,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017I`
 - title: Quality-Gated OHLCV/Cache Foundation.
-- status: `ready`
+- status: `done`
 - purpose: mature a reproducible, versioned, quality-gated OHLCV/cache
   foundation using existing packages and repository-local datasets first.
 - source document:
@@ -3015,13 +3015,21 @@ live, broker, risk, or execution work.
 - validation required:
   - locally possible components complete before any external-source block is
     recorded.
+- completion evidence: PR #636, merge SHA
+  `23b9fdbbdbd5016640bf8cbe1bebc2442209643b`; read-only local cache
+  foundation report added in `research/qre_ohlcv_cache_foundation.py`, with
+  governance summary `docs/governance/qre_ohlcv_cache_foundation.md` and
+  tracked artifact `artifacts/cache/cache_foundation_latest.v1.json`; required
+  CI checks green before squash-merge; post-merge governance and architecture
+  validation passed on `main`; frozen contracts unchanged; protected/execution
+  paths untouched.
 - next dependency: `ADE-QRE-017J`.
 
 ### ADE-QRE-017J - Source Quality, PIT, and Identity Readiness
 
 - queue id: `ADE-QRE-017J`
 - title: Source Quality, PIT, and Identity Readiness.
-- status: `blocked until ADE-QRE-017I done`
+- status: `ready`
 - purpose: implement freshness, missing-data, duplicate, monotonicity,
   outlier, coverage, agreement, PIT, revision, identity, and allowed-use
   readiness.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -354,12 +354,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17g) is True
     item_17h = items["ADE-QRE-017H"]
     item_17i = items["ADE-QRE-017I"]
+    item_17j = items["ADE-QRE-017J"]
     assert item_17h.status == "done"
     assert _done_evidence_is_complete(item_17h)
-    assert item_17i.status == "ready"
+    assert item_17i.status == "done"
+    assert _done_evidence_is_complete(item_17i)
+    assert item_17j.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17i
+    assert _next_eligible_ready_item(items) == item_17j
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017i_after_017h_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017j_after_017i_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017I"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017J"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -101,7 +101,9 @@ def test_ade_qre_017_chain_selects_017i_after_017h_completion_evidence() -> None
     assert rows["ADE-QRE-017G"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017H"]["status"] == "done"
     assert rows["ADE-QRE-017H"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017I"]["status"] == "ready"
+    assert rows["ADE-QRE-017I"]["status"] == "done"
+    assert rows["ADE-QRE-017I"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017J"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017i_after_017h_completion_evidence() -> None:
+def test_current_queue_selects_017j_after_017i_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017I"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017J"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -178,7 +178,9 @@ def test_current_queue_selects_017i_after_017h_completion_evidence() -> None:
     assert rows["ADE-QRE-017G"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017H"]["status"] == "done"
     assert rows["ADE-QRE-017H"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017I"]["status"] == "ready"
+    assert rows["ADE-QRE-017I"]["status"] == "done"
+    assert rows["ADE-QRE-017I"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017J"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-017I done in the canonical ADE queue
- record PR #636 merge evidence and protected-scope validation details
- flip ADE-QRE-017J to ready and update queue-audit expectations

## Scope
- `docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md`
- `tests/unit/test_ade_qre_014_queue_lifecycle.py`
- `tests/unit/test_ade_qre_017_queue_admission.py`
- `tests/unit/test_ade_queue_status_self_audit.py`

## Forbidden scope
- no implementation changes
- no `.claude/**`
- no `research/research_latest.json`
- no `research/strategy_matrix.csv`
- no paper/shadow/live/broker/risk/execution changes

## Validation
- `python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q`
- `python -m reporting.ade_queue_status_self_audit --no-write`
- `python scripts/governance_lint.py`
- `python -m reporting.development_work_queue --no-write`
- `git diff --check`

## Handoff
- after merge, ADE-QRE-017J is the next eligible queue item