### PR TITLE
ADE-QRE-017J: source quality PIT identity readiness

### DIFF
--- a/artifacts/data_readiness/source_quality_pit_identity_readiness_latest.v1.json
+++ b/artifacts/data_readiness/source_quality_pit_identity_readiness_latest.v1.json
@@ -1,0 +1,546 @@
+{
+  "manifest_rows": [
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_RESTATEMENT_POLICY",
+        "POINT_IN_TIME_UNKNOWN",
+        "REPORT_LAG_UNKNOWN",
+        "RESTATEMENT_POLICY_UNKNOWN",
+        "historical_lineage_reproducible",
+        "identity_alias_ambiguity_present",
+        "identity_mapping_not_explicit",
+        "no_lookahead_snapshot_contract",
+        "quality_gates_not_passed",
+        "report_lag_policy_supported",
+        "restatement_policy_supported"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "BLOCKED",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "BLOCKED",
+        "report_lag_policy": "BLOCKED",
+        "restatement_policy": "BLOCKED",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "alpha_vantage_candidate",
+      "source_id": "alpha_vantage_candidate_manifest",
+      "source_status": "candidate",
+      "source_type": "fundamental_statement_data"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "identity_alias_ambiguity_present",
+        "identity_mapping_not_explicit",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "companies_house_metadata",
+      "source_id": "companies_house_metadata_manifest",
+      "source_status": "manual_research_only",
+      "source_type": "issuer_metadata"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_RESTATEMENT_POLICY",
+        "POINT_IN_TIME_UNKNOWN",
+        "REPORT_LAG_UNKNOWN",
+        "RESTATEMENT_POLICY_UNKNOWN",
+        "historical_lineage_reproducible",
+        "identity_alias_ambiguity_present",
+        "identity_mapping_not_explicit",
+        "no_lookahead_snapshot_contract",
+        "quality_gates_not_passed",
+        "report_lag_policy_supported",
+        "restatement_policy_supported"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "BLOCKED",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "BLOCKED",
+        "report_lag_policy": "BLOCKED",
+        "restatement_policy": "BLOCKED",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "eodhd_candidate",
+      "source_id": "eodhd_candidate_manifest",
+      "source_status": "candidate",
+      "source_type": "fundamental_statement_data"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "identity_alias_ambiguity_present",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "euronext_issuer_metadata",
+      "source_id": "euronext_issuer_metadata_manifest",
+      "source_status": "candidate",
+      "source_type": "issuer_metadata"
+    },
+    {
+      "blocking_reasons": [
+        "MISSING_LICENSE_TERMS",
+        "identity_mapping_not_explicit",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "PARTIAL",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "NOT_APPLICABLE",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "UNKNOWN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "FAIL",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "financial_datasets_mcp",
+      "source_id": "financial_datasets_mcp_manifest",
+      "source_status": "staging",
+      "source_type": "connector_staging"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_RESTATEMENT_POLICY",
+        "POINT_IN_TIME_UNKNOWN",
+        "REPORT_LAG_UNKNOWN",
+        "RESTATEMENT_POLICY_UNKNOWN",
+        "historical_lineage_reproducible",
+        "identity_alias_ambiguity_present",
+        "identity_mapping_not_explicit",
+        "no_lookahead_snapshot_contract",
+        "quality_gates_not_passed",
+        "report_lag_policy_supported",
+        "restatement_policy_supported"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "BLOCKED",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "BLOCKED",
+        "report_lag_policy": "BLOCKED",
+        "restatement_policy": "BLOCKED",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "financial_modeling_prep_candidate",
+      "source_id": "financial_modeling_prep_candidate_manifest",
+      "source_status": "candidate",
+      "source_type": "fundamental_statement_data"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "identity_alias_ambiguity_present",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "nasdaq_listings_metadata",
+      "source_id": "nasdaq_listings_metadata_manifest",
+      "source_status": "candidate",
+      "source_type": "listing_metadata"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "identity_alias_ambiguity_present",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "nyse_listings_metadata",
+      "source_id": "nyse_listings_metadata_manifest",
+      "source_status": "candidate",
+      "source_type": "listing_metadata"
+    },
+    {
+      "blocking_reasons": [
+        "MISSING_LICENSE_TERMS",
+        "identity_mapping_not_explicit",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "PARTIAL",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "NOT_APPLICABLE",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "UNKNOWN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "FAIL",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "openbb_connector",
+      "source_id": "openbb_connector_manifest",
+      "source_status": "staging",
+      "source_type": "connector_staging"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "identity_alias_ambiguity_present",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "openfigi_symbology",
+      "source_id": "openfigi_symbology_manifest",
+      "source_status": "candidate",
+      "source_type": "identity_symbology"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_RESTATEMENT_POLICY",
+        "REPORT_LAG_UNKNOWN",
+        "RESTATEMENT_POLICY_UNKNOWN",
+        "historical_lineage_reproducible",
+        "identity_alias_ambiguity_present",
+        "no_lookahead_snapshot_contract",
+        "quality_gates_not_passed",
+        "report_lag_policy_supported",
+        "restatement_policy_supported"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "PARTIAL",
+        "historical_lineage": "BLOCKED",
+        "identity_readiness": "PARTIAL",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "BLOCKED",
+        "report_lag_policy": "BLOCKED",
+        "restatement_policy": "BLOCKED",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "sec_companyfacts",
+      "source_id": "sec_companyfacts_manifest",
+      "source_status": "candidate",
+      "source_type": "fundamental_statement_data"
+    },
+    {
+      "blocking_reasons": [
+        "LICENSE_REVIEW_REQUIRED",
+        "identity_mapping_not_explicit",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "NOT_APPLICABLE",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "stooq_price_context",
+      "source_id": "stooq_price_context_manifest",
+      "source_status": "manual_research_only",
+      "source_type": "market_price_context"
+    },
+    {
+      "blocking_reasons": [
+        "identity_mapping_not_explicit",
+        "quality_gates_not_passed"
+      ],
+      "dimension_statuses": {
+        "allowed_use_and_license": "BLOCKED",
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "BLOCKED",
+        "historical_lineage": "NOT_APPLICABLE",
+        "identity_readiness": "NOT_APPLICABLE",
+        "missing_data_checks": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "point_in_time_policy": "NOT_APPLICABLE",
+        "report_lag_policy": "NOT_APPLICABLE",
+        "restatement_policy": "NOT_APPLICABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "license_policy_status": "WARN",
+      "lifecycle_status": "blocked",
+      "manifest_status": "WARN",
+      "operator_explanation": "Source readiness remains fail-closed until license, PIT, report-lag, restatement, identity, and declared quality-gate evidence are explicit.",
+      "provider_id": "yahoo_finance_yfinance",
+      "source_id": "yahoo_finance_yfinance_manifest",
+      "source_status": "manual_research_only",
+      "source_type": "manual_research_context"
+    }
+  ],
+  "observed_source_rows": [
+    {
+      "blocking_reasons": [],
+      "coverage_row_count": 34,
+      "dimension_statuses": {
+        "coverage": "PARTIAL",
+        "duplicate_detection": "UNAVAILABLE",
+        "freshness": "PARTIAL",
+        "missing_data_checks": "PARTIAL",
+        "outlier_handling": "UNAVAILABLE",
+        "source_agreement": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE"
+      },
+      "observed_source": "yfinance",
+      "operator_explanation": "Observed cache evidence is present for this source, but monotonicity, duplicate-bar, outlier, and cross-source agreement checks are not yet explicit.",
+      "quality_ready_row_count": 4189,
+      "ready_coverage_row_count": 34,
+      "timestamp_complete_row_count": 34
+    }
+  ],
+  "readiness_status_vocabulary": [
+    "READY",
+    "PARTIAL",
+    "BLOCKED",
+    "UNAVAILABLE",
+    "NOT_APPLICABLE"
+  ],
+  "report_kind": "qre_source_quality_pit_identity_readiness",
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "diagnostics_do_not_trade": true,
+    "fetches_external_data": false,
+    "mutates_frozen_contracts": false,
+    "mutates_research_outputs": false,
+    "mutates_runtime_state": false,
+    "paper_shadow_live_forbidden": true,
+    "provider_activation_forbidden": true,
+    "read_only": true,
+    "retrieval_not_authority": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "cache_manifest_research_ready": true,
+    "identity_ambiguity_blocked_count": 3,
+    "manifest_blocking_reason_counts": {
+      "LICENSE_REVIEW_REQUIRED": 10,
+      "MISSING_LICENSE_TERMS": 2,
+      "MISSING_POINT_IN_TIME_POLICY": 4,
+      "MISSING_REPORT_LAG_POLICY": 4,
+      "MISSING_RESTATEMENT_POLICY": 4,
+      "POINT_IN_TIME_UNKNOWN": 3,
+      "REPORT_LAG_UNKNOWN": 4,
+      "RESTATEMENT_POLICY_UNKNOWN": 4,
+      "historical_lineage_reproducible": 4,
+      "identity_alias_ambiguity_present": 9,
+      "identity_mapping_not_explicit": 8,
+      "no_lookahead_snapshot_contract": 4,
+      "quality_gates_not_passed": 13,
+      "report_lag_policy_supported": 4,
+      "restatement_policy_supported": 4
+    },
+    "manifest_dimension_status_counts": {
+      "BLOCKED": 39,
+      "NOT_APPLICABLE": 40,
+      "PARTIAL": 25,
+      "UNAVAILABLE": 65
+    },
+    "observed_blocking_reason_counts": {},
+    "observed_dimension_status_counts": {
+      "PARTIAL": 3,
+      "UNAVAILABLE": 4
+    },
+    "observed_source_count": 1,
+    "operator_summary": "Local cache evidence is present for observed sources, but source governance, PIT, report-lag, restatement, and identity readiness remain fail-closed at the manifest level.",
+    "pit_required_blocked_count": 4,
+    "source_manifest_count": 13,
+    "source_quality_report_ready": true,
+    "source_quality_report_status": "ready"
+  },
+  "supporting_reports": {
+    "cache_manifest": {
+      "manifest_content_hash": "sha256:7017b28ce6c1886dd3d4c7778d57181ee825883bb744c56fed61893030ca910a",
+      "report_kind": "qre_data_cache_manifest",
+      "research_ready": true
+    },
+    "historical_accounting_foundation": {
+      "report_kind": "qre_historical_accounting_foundation",
+      "required_blocked_count": 4
+    },
+    "source_cache_readiness_materialization": {
+      "report_kind": "qre_source_cache_readiness_materialization",
+      "source_cache_readiness_linked": true
+    },
+    "source_lifecycle_quality_gate": {
+      "report_kind": "qre_source_lifecycle_quality_gate",
+      "source_quality_report_ready": true
+    },
+    "source_quality_status": {
+      "fails_closed": false,
+      "path": "logs/qre_data_source_quality_readiness/latest.json",
+      "research_ready": true,
+      "schema_version": "1.0",
+      "status": "ready"
+    },
+    "symbology_resolver_foundation": {
+      "ambiguity_blocked_count": 3,
+      "report_kind": "qre_symbology_resolver_foundation",
+      "verified_count": 38
+    }
+  }
+}

--- a/docs/governance/qre_source_quality_pit_identity_readiness.md
+++ b/docs/governance/qre_source_quality_pit_identity_readiness.md
@@ -1,0 +1,37 @@
+# QRE Source Quality, PIT, and Identity Readiness
+
+`ADE-QRE-017J` materializes one read-only readiness surface across the
+existing cache, source-quality, lifecycle, PIT, historical-accounting,
+and symbology foundations.
+
+## Scope
+
+- local observed-source evidence remains distinct from source-manifest
+  governance;
+- license and allowed-use state fail closed before PIT or identity can
+  be treated as readiness;
+- identity ambiguity remains visible and blocking;
+- PIT, report-lag, and restatement stay explicit per source manifest;
+- diagnostics remain research context only.
+
+## Current interpretation
+
+- Repository-local cache evidence exists for observed sources such as
+  `yfinance`, but that does not override manifest-level license or
+  readiness blockers.
+- Candidate source manifests remain blocked on license review, PIT
+  policy, report-lag policy, restatement policy, or identity-gate
+  completeness.
+- Symbology is infrastructure only. Verified mappings are surfaced, but
+  ambiguous aliases keep identity readiness partial or blocked.
+
+## Canonical artifact
+
+- `artifacts/data_readiness/source_quality_pit_identity_readiness_latest.v1.json`
+
+## Protected boundaries
+
+- no provider activation;
+- no external fetches;
+- no mutation of cache or frozen research contracts;
+- no paper, shadow, live, broker, risk, or execution behavior.

--- a/research/qre_source_quality_pit_identity_readiness.py
+++ b/research/qre_source_quality_pit_identity_readiness.py
@@ -1,0 +1,595 @@
+"""Read-only QRE source quality, PIT, and identity readiness materialization."""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_data import cache_manifest, source_quality_readiness
+from research import (
+    qre_historical_accounting_foundation,
+    qre_source_cache_readiness_materialization,
+    qre_source_lifecycle_quality_gate,
+    qre_symbology_resolver_foundation,
+)
+from research.data_readiness import point_in_time_policy, report_lag_policy, restatement_policy
+from research.external_intelligence import source_manifest_registry
+
+REPORT_KIND: Final[str] = "qre_source_quality_pit_identity_readiness"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_source_quality_pit_identity_readiness")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_source_quality_pit_identity_readiness/"
+ARTIFACT_DIR: Final[Path] = Path("artifacts/data_readiness")
+ARTIFACT_NAME: Final[str] = "source_quality_pit_identity_readiness_latest.v1.json"
+ARTIFACT_WRITE_PREFIX: Final[str] = "artifacts/data_readiness/"
+READINESS_STATUS_VOCABULARY: Final[tuple[str, ...]] = (
+    "READY",
+    "PARTIAL",
+    "BLOCKED",
+    "UNAVAILABLE",
+    "NOT_APPLICABLE",
+)
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _normalize(text: Any) -> str:
+    return str(text or "").strip().lower()
+
+
+def _quality_row_by_source(
+    source_quality_report: Mapping[str, Any],
+) -> dict[str, Mapping[str, Any]]:
+    rows = source_quality_report.get("sources")
+    if not isinstance(rows, list):
+        return {}
+    result: dict[str, Mapping[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        result[_normalize(row.get("source"))] = row
+    return result
+
+
+def _coverage_rows_by_source(cache_report: Mapping[str, Any]) -> dict[str, list[Mapping[str, Any]]]:
+    rows = cache_report.get("coverage")
+    if not isinstance(rows, list):
+        return {}
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        grouped.setdefault(_normalize(row.get("source")), []).append(row)
+    return grouped
+
+
+@functools.lru_cache(maxsize=8)
+def _load_cache_report(repo_root_text: str) -> dict[str, Any]:
+    repo_root = Path(repo_root_text)
+    status = cache_manifest.read_manifest_status(repo_root=repo_root)
+    path_text = str(status.get("path") or "")
+    if status.get("status") in {"ready", "not_ready"} and path_text:
+        path = repo_root / path_text
+        if path.is_file():
+            return json.loads(path.read_text(encoding="utf-8"))
+    return cache_manifest.build_cache_manifest(repo_root=repo_root)
+
+
+@functools.lru_cache(maxsize=8)
+def _load_source_quality_status_and_report(
+    repo_root_text: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    repo_root = Path(repo_root_text)
+    status = source_quality_readiness.read_source_quality_status(repo_root=repo_root)
+    path_text = str(status.get("path") or "")
+    if status.get("status") in {"ready", "not_ready"} and path_text:
+        path = repo_root / path_text
+        if path.is_file():
+            return status, json.loads(path.read_text(encoding="utf-8"))
+    manifest = _load_cache_report(repo_root_text)
+    report = source_quality_readiness.build_source_quality_report(manifest)
+    return status, report
+
+
+def _observed_source_row(
+    *,
+    source_name: str,
+    quality_row: Mapping[str, Any] | None,
+    coverage_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    quality_status_counts = (
+        quality_row.get("quality_status_counts") if isinstance(quality_row, Mapping) else {}
+    )
+    if not isinstance(quality_status_counts, Mapping):
+        quality_status_counts = {}
+
+    ready_quality = int(quality_status_counts.get("ready") or 0)
+    coverage_ready_rows = sum(bool(row.get("ready")) for row in coverage_rows)
+    coverage_row_count = len(coverage_rows)
+    timestamp_complete_rows = sum(
+        bool(row.get("min_timestamp_utc")) and bool(row.get("max_timestamp_utc"))
+        for row in coverage_rows
+    )
+    statuses = {
+        "freshness": "PARTIAL" if timestamp_complete_rows else "BLOCKED",
+        "missing_data_checks": "PARTIAL" if ready_quality else "BLOCKED",
+        "timestamp_monotonicity": "UNAVAILABLE",
+        "duplicate_detection": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "coverage": "PARTIAL" if coverage_ready_rows else "BLOCKED",
+        "source_agreement": "UNAVAILABLE",
+    }
+    blockers: list[str] = []
+    if not timestamp_complete_rows:
+        blockers.append("timestamp_range_missing")
+    if not ready_quality:
+        blockers.append("source_quality_rows_not_ready")
+    if coverage_row_count == 0:
+        blockers.append("coverage_rows_missing")
+    return {
+        "observed_source": source_name,
+        "coverage_row_count": coverage_row_count,
+        "ready_coverage_row_count": coverage_ready_rows,
+        "timestamp_complete_row_count": timestamp_complete_rows,
+        "quality_ready_row_count": ready_quality,
+        "dimension_statuses": statuses,
+        "blocking_reasons": blockers,
+        "operator_explanation": (
+            "Observed cache evidence is present for this source, but monotonicity, duplicate-bar, "
+            "outlier, and cross-source agreement checks are not yet explicit."
+            if coverage_row_count
+            else "No observed cache evidence is present for this source."
+        ),
+    }
+
+
+def _historical_row_by_source(report: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    rows = report.get("rows")
+    if not isinstance(rows, list):
+        return {}
+    return {
+        str(row["source_id"]): row
+        for row in rows
+        if isinstance(row, Mapping) and "source_id" in row
+    }
+
+
+def _policy_row_by_source(report: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    rows = report.get("rows")
+    if not isinstance(rows, list):
+        return {}
+    return {
+        str(row["source_id"]): row
+        for row in rows
+        if isinstance(row, Mapping) and "source_id" in row
+    }
+
+
+def _identity_summary_status(symbology_report: Mapping[str, Any]) -> tuple[str, list[str]]:
+    summary = symbology_report.get("summary")
+    if not isinstance(summary, Mapping):
+        return "UNAVAILABLE", ["symbology_summary_missing"]
+    blocked = int(summary.get("ambiguity_blocked_count") or 0)
+    verified = int(summary.get("verified_count") or 0)
+    if verified <= 0:
+        return "BLOCKED", ["no_verified_provider_symbols"]
+    if blocked > 0:
+        return "PARTIAL", ["identity_alias_ambiguity_present"]
+    return "READY", []
+
+
+def _manifest_readiness_row(
+    manifest: Mapping[str, Any],
+    *,
+    policy_by_source: Mapping[str, Mapping[str, Any]],
+    pit_by_source: Mapping[str, Mapping[str, Any]],
+    report_lag_by_source: Mapping[str, Mapping[str, Any]],
+    restatement_by_source: Mapping[str, Mapping[str, Any]],
+    historical_by_source: Mapping[str, Mapping[str, Any]],
+    lifecycle_by_source: Mapping[str, Mapping[str, Any]],
+    symbology_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    source_id = str(manifest["source_id"])
+    source_type = str(manifest["source_type"])
+    policy_row = policy_by_source[source_id]
+    pit_row = pit_by_source[source_id]
+    report_lag_row = report_lag_by_source[source_id]
+    restatement_row = restatement_by_source[source_id]
+    historical_row = historical_by_source[source_id]
+    lifecycle_row = lifecycle_by_source[source_id]
+
+    identity_status, identity_blockers = _identity_summary_status(symbology_report)
+    if source_type not in {"identity_symbology", "listing_metadata", "issuer_metadata", "fundamental_statement_data"}:
+        identity_status = "NOT_APPLICABLE"
+        identity_blockers = []
+
+    dimension_statuses = {
+        "allowed_use_and_license": (
+            "READY" if bool(policy_row.get("allowed_for_quality_gate")) else "BLOCKED"
+        ),
+        "point_in_time_policy": (
+            "READY"
+            if str(pit_row.get("policy_status")) == "SUPPORTED"
+            else "PARTIAL"
+            if str(pit_row.get("policy_status")) == "PARTIALLY_SUPPORTED"
+            else "BLOCKED"
+            if str(pit_row.get("requirement_status")) == "REQUIRED"
+            else "NOT_APPLICABLE"
+        ),
+        "report_lag_policy": (
+            "READY"
+            if str(report_lag_row.get("policy_status")) == "SUPPORTED"
+            else "PARTIAL"
+            if str(report_lag_row.get("policy_status")) == "PARTIALLY_SUPPORTED"
+            else "BLOCKED"
+            if str(report_lag_row.get("requirement_status")) == "REQUIRED"
+            else "NOT_APPLICABLE"
+        ),
+        "restatement_policy": (
+            "READY"
+            if str(restatement_row.get("policy_status")) == "SUPPORTED"
+            else "PARTIAL"
+            if str(restatement_row.get("policy_status")) == "PARTIALLY_SUPPORTED"
+            else "BLOCKED"
+            if str(restatement_row.get("requirement_status")) == "REQUIRED"
+            else "NOT_APPLICABLE"
+        ),
+        "historical_lineage": (
+            "READY"
+            if bool(historical_row.get("gate_statuses", {}).get("historical_lineage_reproducible"))
+            else "BLOCKED"
+            if bool(historical_row.get("requires_historical_accounting"))
+            else "NOT_APPLICABLE"
+        ),
+        "identity_readiness": identity_status,
+        "freshness": (
+            "BLOCKED"
+            if _normalize(manifest.get("expected_freshness")).endswith("unknown")
+            or _normalize(manifest.get("expected_freshness")) == "unknown"
+            else "NOT_APPLICABLE"
+            if _normalize(manifest.get("source_type")) in {"identity_symbology", "listing_metadata", "issuer_metadata"}
+            else "PARTIAL"
+        ),
+        "missing_data_checks": "UNAVAILABLE",
+        "timestamp_monotonicity": "UNAVAILABLE",
+        "duplicate_detection": "UNAVAILABLE",
+        "outlier_handling": "UNAVAILABLE",
+        "coverage": (
+            "PARTIAL"
+            if bool(manifest.get("factor_field_coverage_claims"))
+            else "BLOCKED"
+        ),
+        "source_agreement": "UNAVAILABLE",
+    }
+
+    blocking_reasons: list[str] = []
+    blocking_reasons.extend(str(reason) for reason in policy_row.get("block_reasons") or [])
+    blocking_reasons.extend(str(reason) for reason in pit_row.get("block_reasons") or [])
+    blocking_reasons.extend(str(reason) for reason in report_lag_row.get("block_reasons") or [])
+    blocking_reasons.extend(str(reason) for reason in restatement_row.get("block_reasons") or [])
+    blocking_reasons.extend(str(reason) for reason in historical_row.get("blocking_reasons") or [])
+    blocking_reasons.extend(identity_blockers)
+    if not bool(lifecycle_row.get("source_quality_ready")):
+        blocking_reasons.append("source_quality_sidecar_not_ready")
+    if not bool(lifecycle_row.get("gate_statuses", {}).get("identity_mapping_present")):
+        blocking_reasons.append("identity_mapping_not_explicit")
+    if not bool(lifecycle_row.get("gate_statuses", {}).get("quality_gates_passed")):
+        blocking_reasons.append("quality_gates_not_passed")
+
+    return {
+        "source_id": source_id,
+        "provider_id": str(manifest["provider_id"]),
+        "source_type": source_type,
+        "source_status": str(manifest["source_status"]),
+        "manifest_status": str(manifest["manifest_status"]),
+        "license_policy_status": str(policy_row.get("license_policy_status") or "UNKNOWN"),
+        "lifecycle_status": str(lifecycle_row.get("lifecycle_status") or "blocked"),
+        "dimension_statuses": dimension_statuses,
+        "blocking_reasons": sorted(set(blocking_reasons)),
+        "operator_explanation": (
+            "Source readiness remains fail-closed until license, PIT, report-lag, restatement, "
+            "identity, and declared quality-gate evidence are explicit."
+        ),
+    }
+
+
+def build_source_quality_pit_identity_readiness(
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    repo_root_text = str(repo_root.resolve())
+    manifest_registry = source_manifest_registry.build_source_manifest_registry()
+    lifecycle_report = qre_source_lifecycle_quality_gate.build_source_lifecycle_quality_gate(
+        repo_root=repo_root
+    )
+    historical_report = (
+        qre_historical_accounting_foundation.build_historical_accounting_foundation()
+    )
+    pit_report = point_in_time_policy.build_point_in_time_policy()
+    report_lag_report = report_lag_policy.build_report_lag_policy()
+    restatement_report = restatement_policy.build_restatement_policy()
+    symbology_report = qre_symbology_resolver_foundation.build_symbology_resolver_foundation()
+    cache_report = _load_cache_report(repo_root_text)
+    source_quality_status, source_quality_report = _load_source_quality_status_and_report(
+        repo_root_text
+    )
+    source_cache_report = (
+        qre_source_cache_readiness_materialization.build_source_cache_readiness_materialization(
+            repo_root=repo_root
+        )
+    )
+
+    lifecycle_by_source = _historical_row_by_source(lifecycle_report)
+    historical_by_source = _historical_row_by_source(historical_report)
+    policy_by_source = {
+        str(row["source_id"]): row
+        for row in manifest_registry["license_policy_rows"]
+        if isinstance(row, Mapping)
+    }
+    pit_by_source = _policy_row_by_source(pit_report)
+    report_lag_by_source = _policy_row_by_source(report_lag_report)
+    restatement_by_source = _policy_row_by_source(restatement_report)
+
+    manifest_rows = [
+        _manifest_readiness_row(
+            row,
+            policy_by_source=policy_by_source,
+            pit_by_source=pit_by_source,
+            report_lag_by_source=report_lag_by_source,
+            restatement_by_source=restatement_by_source,
+            historical_by_source=historical_by_source,
+            lifecycle_by_source=lifecycle_by_source,
+            symbology_report=symbology_report,
+        )
+        for row in manifest_registry["rows"]
+        if isinstance(row, Mapping)
+    ]
+    manifest_rows.sort(key=lambda row: row["source_id"])
+
+    quality_by_source = _quality_row_by_source(source_quality_report)
+    coverage_by_source = _coverage_rows_by_source(cache_report)
+    observed_rows = [
+        _observed_source_row(
+            source_name=source_name,
+            quality_row=quality_by_source.get(source_name),
+            coverage_rows=rows,
+        )
+        for source_name, rows in sorted(coverage_by_source.items())
+    ]
+
+    manifest_dimension_counts = Counter(
+        status
+        for row in manifest_rows
+        for status in row["dimension_statuses"].values()
+    )
+    observed_dimension_counts = Counter(
+        status
+        for row in observed_rows
+        for status in row["dimension_statuses"].values()
+    )
+    manifest_blockers = Counter(
+        blocker for row in manifest_rows for blocker in row["blocking_reasons"]
+    )
+    observed_blockers = Counter(
+        blocker for row in observed_rows for blocker in row["blocking_reasons"]
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "readiness_status_vocabulary": list(READINESS_STATUS_VOCABULARY),
+        "summary": {
+            "source_manifest_count": len(manifest_rows),
+            "observed_source_count": len(observed_rows),
+            "cache_manifest_research_ready": bool(cache_report["summary"]["research_ready"]),
+            "source_quality_report_status": str(source_quality_status.get("status") or "missing"),
+            "source_quality_report_ready": bool(source_quality_status.get("research_ready")),
+            "manifest_dimension_status_counts": dict(sorted(manifest_dimension_counts.items())),
+            "observed_dimension_status_counts": dict(sorted(observed_dimension_counts.items())),
+            "manifest_blocking_reason_counts": dict(sorted(manifest_blockers.items())),
+            "observed_blocking_reason_counts": dict(sorted(observed_blockers.items())),
+            "identity_ambiguity_blocked_count": int(
+                symbology_report["summary"]["ambiguity_blocked_count"]
+            ),
+            "pit_required_blocked_count": int(
+                historical_report["summary"]["required_blocked_count"]
+            ),
+            "operator_summary": (
+                "Local cache evidence is present for observed sources, but source governance, PIT, "
+                "report-lag, restatement, and identity readiness remain fail-closed at the manifest level."
+            ),
+        },
+        "manifest_rows": manifest_rows,
+        "observed_source_rows": observed_rows,
+        "supporting_reports": {
+            "cache_manifest": {
+                "report_kind": cache_report["report_kind"],
+                "research_ready": cache_report["summary"]["research_ready"],
+                "manifest_content_hash": cache_report["summary"]["manifest_content_hash"],
+            },
+            "source_quality_status": source_quality_status,
+            "source_cache_readiness_materialization": {
+                "report_kind": source_cache_report["report_kind"],
+                "source_cache_readiness_linked": source_cache_report["summary"][
+                    "source_cache_readiness_linked"
+                ],
+            },
+            "source_lifecycle_quality_gate": {
+                "report_kind": lifecycle_report["report_kind"],
+                "source_quality_report_ready": lifecycle_report["summary"][
+                    "source_quality_report_ready"
+                ],
+            },
+            "historical_accounting_foundation": {
+                "report_kind": historical_report["report_kind"],
+                "required_blocked_count": historical_report["summary"]["required_blocked_count"],
+            },
+            "symbology_resolver_foundation": {
+                "report_kind": symbology_report["report_kind"],
+                "ambiguity_blocked_count": symbology_report["summary"]["ambiguity_blocked_count"],
+                "verified_count": symbology_report["summary"]["verified_count"],
+            },
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "fetches_external_data": False,
+            "mutates_runtime_state": False,
+            "mutates_research_outputs": False,
+            "mutates_frozen_contracts": False,
+            "provider_activation_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "retrieval_not_authority": True,
+            "diagnostics_do_not_trade": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    manifest_rows = (
+        report.get("manifest_rows") if isinstance(report.get("manifest_rows"), list) else []
+    )
+    observed_rows = (
+        report.get("observed_source_rows")
+        if isinstance(report.get("observed_source_rows"), list)
+        else []
+    )
+    summary_table = _table(
+        ["Field", "Value"],
+        [
+            ["source_manifest_count", str(summary.get("source_manifest_count") or 0)],
+            ["observed_source_count", str(summary.get("observed_source_count") or 0)],
+            ["source_quality_report_status", str(summary.get("source_quality_report_status") or "")],
+            ["source_quality_report_ready", str(summary.get("source_quality_report_ready") or False)],
+            ["identity_ambiguity_blocked_count", str(summary.get("identity_ambiguity_blocked_count") or 0)],
+            ["pit_required_blocked_count", str(summary.get("pit_required_blocked_count") or 0)],
+        ],
+    )
+    manifest_table = _table(
+        ["source_id", "license", "pit", "report_lag", "restatement", "identity"],
+        [
+            [
+                str(row.get("source_id") or ""),
+                str((row.get("dimension_statuses") or {}).get("allowed_use_and_license") or ""),
+                str((row.get("dimension_statuses") or {}).get("point_in_time_policy") or ""),
+                str((row.get("dimension_statuses") or {}).get("report_lag_policy") or ""),
+                str((row.get("dimension_statuses") or {}).get("restatement_policy") or ""),
+                str((row.get("dimension_statuses") or {}).get("identity_readiness") or ""),
+            ]
+            for row in manifest_rows
+            if isinstance(row, Mapping)
+        ],
+    )
+    observed_table = _table(
+        ["observed_source", "freshness", "missing_data", "coverage", "blockers"],
+        [
+            [
+                str(row.get("observed_source") or ""),
+                str((row.get("dimension_statuses") or {}).get("freshness") or ""),
+                str((row.get("dimension_statuses") or {}).get("missing_data_checks") or ""),
+                str((row.get("dimension_statuses") or {}).get("coverage") or ""),
+                ",".join(str(value) for value in row.get("blocking_reasons") or []) or "none",
+            ]
+            for row in observed_rows
+            if isinstance(row, Mapping)
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Source Quality, PIT, and Identity Readiness",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Status",
+            summary_table,
+            "",
+            "## Manifest Rows",
+            manifest_table,
+            "",
+            "## Observed Source Rows",
+            observed_table,
+        ]
+    )
+
+
+def _validate_log_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_source_quality_pit_identity_readiness: refusing write outside allowlist: {path!r}"
+        )
+
+
+def _validate_artifact_target(path: Path) -> None:
+    if ARTIFACT_WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_source_quality_pit_identity_readiness: refusing artifact write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    log_base = repo_root / DEFAULT_OUTPUT_DIR
+    log_base.mkdir(parents=True, exist_ok=True)
+    artifact_base = repo_root / ARTIFACT_DIR
+    artifact_base.mkdir(parents=True, exist_ok=True)
+
+    latest = log_base / LATEST_NAME
+    summary = log_base / SUMMARY_NAME
+    artifact = artifact_base / ARTIFACT_NAME
+    for path in (latest, summary):
+        _validate_log_target(path)
+    _validate_artifact_target(artifact)
+
+    latest_payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(latest_payload, encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+
+    tmp_artifact = artifact.with_suffix(artifact.suffix + ".tmp")
+    tmp_artifact.write_text(latest_payload, encoding="utf-8")
+    os.replace(tmp_artifact, artifact)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+        "artifact": artifact.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_source_quality_pit_identity_readiness",
+        description="Materialize the read-only QRE source quality, PIT, and identity readiness report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_source_quality_pit_identity_readiness()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_source_quality_pit_identity_readiness.py
+++ b/tests/unit/test_qre_source_quality_pit_identity_readiness.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_source_quality_pit_identity_readiness as report_module
+
+
+def test_report_is_deterministic_and_fail_closed() -> None:
+    left = report_module.build_source_quality_pit_identity_readiness()
+    right = report_module.build_source_quality_pit_identity_readiness()
+
+    assert left == right
+    assert left["summary"]["source_manifest_count"] >= 1
+    assert left["summary"]["pit_required_blocked_count"] >= 1
+    assert left["summary"]["identity_ambiguity_blocked_count"] >= 1
+
+
+def test_local_observed_cache_evidence_is_separate_from_manifest_governance() -> None:
+    report = report_module.build_source_quality_pit_identity_readiness()
+    observed = {
+        row["observed_source"]: row
+        for row in report["observed_source_rows"]
+    }
+    manifest = {
+        row["source_id"]: row
+        for row in report["manifest_rows"]
+    }
+
+    yfinance = observed["yfinance"]
+    assert yfinance["dimension_statuses"]["freshness"] == "PARTIAL"
+    assert yfinance["dimension_statuses"]["coverage"] == "PARTIAL"
+    assert yfinance["dimension_statuses"]["timestamp_monotonicity"] == "UNAVAILABLE"
+    assert yfinance["dimension_statuses"]["duplicate_detection"] == "UNAVAILABLE"
+
+    manifest_row = manifest["yahoo_finance_yfinance_manifest"]
+    assert manifest_row["dimension_statuses"]["allowed_use_and_license"] == "BLOCKED"
+    assert manifest_row["dimension_statuses"]["identity_readiness"] == "NOT_APPLICABLE"
+
+
+def test_sec_and_openfigi_remain_blocked_or_partial_without_fake_pit_or_identity_passes() -> None:
+    rows = {
+        row["source_id"]: row
+        for row in report_module.build_source_quality_pit_identity_readiness()["manifest_rows"]
+    }
+
+    sec = rows["sec_companyfacts_manifest"]
+    assert sec["dimension_statuses"]["point_in_time_policy"] == "BLOCKED"
+    assert sec["dimension_statuses"]["report_lag_policy"] == "BLOCKED"
+    assert sec["dimension_statuses"]["restatement_policy"] == "BLOCKED"
+    assert "MISSING_POINT_IN_TIME_POLICY" in sec["blocking_reasons"]
+
+    openfigi = rows["openfigi_symbology_manifest"]
+    assert openfigi["dimension_statuses"]["point_in_time_policy"] == "NOT_APPLICABLE"
+    assert openfigi["dimension_statuses"]["identity_readiness"] in {"PARTIAL", "BLOCKED"}
+    assert "identity_alias_ambiguity_present" in openfigi["blocking_reasons"]
+
+
+def test_write_outputs_persists_log_and_artifact(tmp_path: Path) -> None:
+    report = report_module.build_source_quality_pit_identity_readiness()
+    paths = report_module.write_outputs(report, repo_root=tmp_path)
+
+    payload = json.loads((tmp_path / paths["latest"]).read_text(encoding="utf-8"))
+    artifact = json.loads((tmp_path / paths["artifact"]).read_text(encoding="utf-8"))
+    summary = (tmp_path / paths["operator_summary"]).read_text(encoding="utf-8")
+
+    assert payload["report_kind"] == "qre_source_quality_pit_identity_readiness"
+    assert artifact["schema_version"] == "1.0"
+    assert "# QRE Source Quality, PIT, and Identity Readiness" in summary
+
+
+def test_safety_invariants_keep_report_read_only() -> None:
+    report = report_module.build_source_quality_pit_identity_readiness()
+
+    assert report["safety_invariants"] == {
+        "read_only": True,
+        "fetches_external_data": False,
+        "mutates_runtime_state": False,
+        "mutates_research_outputs": False,
+        "mutates_frozen_contracts": False,
+        "provider_activation_forbidden": True,
+        "paper_shadow_live_forbidden": True,
+        "broker_risk_execution_forbidden": True,
+        "retrieval_not_authority": True,
+        "diagnostics_do_not_trade": True,
+    }
+    assert tuple(report["readiness_status_vocabulary"]) == report_module.READINESS_STATUS_VOCABULARY


### PR DESCRIPTION
## Summary
- implement ADE-QRE-017J with a read-only source quality, PIT, and identity readiness materialization
- add a tracked readiness artifact and governance note for the new report
- add focused unit coverage proving local observed cache evidence stays separate from manifest-level governance blockers

## Dependencies
- ADE-QRE-017I done

## Scope
- `research/qre_source_quality_pit_identity_readiness.py`
- `artifacts/data_readiness/source_quality_pit_identity_readiness_latest.v1.json`
- `docs/governance/qre_source_quality_pit_identity_readiness.md`
- `tests/unit/test_qre_source_quality_pit_identity_readiness.py`

## Forbidden scope
- `.claude/**`
- `research/research_latest.json`
- `research/strategy_matrix.csv`
- live, paper, shadow, broker, risk, execution, trading, capital-allocation paths
- queue-state mutations

## Validation
- `python -m ruff check research/qre_source_quality_pit_identity_readiness.py tests/unit/test_qre_source_quality_pit_identity_readiness.py`
- `python -m pytest tests/unit/test_qre_data_source_quality_readiness.py tests/unit/test_qre_data_source_lifecycle.py tests/unit/test_qre_data_symbology_resolver.py tests/unit/test_point_in_time_policy.py tests/unit/test_report_lag_policy.py tests/unit/test_qre_historical_accounting_foundation.py tests/unit/test_qre_symbology_resolver_foundation.py tests/unit/test_qre_source_lifecycle_quality_gate.py tests/unit/test_qre_source_quality_pit_identity_readiness.py -q`
- `python scripts/governance_lint.py`
- `python -m reporting.architecture_import_scan --format summary`
- `python -m pytest tests/architecture -q`
- `python -m reporting.ade_queue_status_self_audit --no-write`
- `python -m reporting.development_work_queue --no-write`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Handoff
- This PR implements ADE-QRE-017J only. Queue status remains unchanged here; completion evidence and promotion of ADE-QRE-017K follow after merge.