### PR TITLE
docs: record ADE-QRE-017J completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3029,7 +3029,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017J`
 - title: Source Quality, PIT, and Identity Readiness.
-- status: `ready`
+- status: `done`
 - purpose: implement freshness, missing-data, duplicate, monotonicity,
   outlier, coverage, agreement, PIT, revision, identity, and allowed-use
   readiness.
@@ -3049,13 +3049,19 @@ live, broker, risk, or execution work.
   - frozen contracts and runtime paths listed under `ADE-QRE-017`.
 - validation required:
   - quality failures and identity ambiguity block rather than downgrade.
+- completion evidence:
+  - PR #638, merge SHA `5a1ae50a2c7a015d1e3a171f09ab80a54d83d17d`; checks green before squash-merge; implementation report:
+    `research/qre_source_quality_pit_identity_readiness.py`; governance note:
+    `docs/governance/qre_source_quality_pit_identity_readiness.md`; tracked artifact:
+    `artifacts/data_readiness/source_quality_pit_identity_readiness_latest.v1.json`; focused validation:
+    `python -m pytest tests/unit/test_qre_data_source_quality_readiness.py tests/unit/test_qre_data_source_lifecycle.py tests/unit/test_qre_data_symbology_resolver.py tests/unit/test_point_in_time_policy.py tests/unit/test_report_lag_policy.py tests/unit/test_qre_historical_accounting_foundation.py tests/unit/test_qre_symbology_resolver_foundation.py tests/unit/test_qre_source_lifecycle_quality_gate.py tests/unit/test_qre_source_quality_pit_identity_readiness.py -q`; post-merge governance and architecture validation passed on `main`; frozen contracts unchanged; protected/execution paths untouched.
 - next dependency: `ADE-QRE-017K`.
 
 ### ADE-QRE-017K - Source Usefulness Ledger
 
 - queue id: `ADE-QRE-017K`
 - title: Source Usefulness Ledger.
-- status: `blocked until ADE-QRE-017J done`
+- status: `ready`
 - purpose: track actual source outcomes, usefulness, disagreements, savings,
   and operator value without treating source quality as alpha.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -355,14 +355,17 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     item_17h = items["ADE-QRE-017H"]
     item_17i = items["ADE-QRE-017I"]
     item_17j = items["ADE-QRE-017J"]
+    item_17k = items["ADE-QRE-017K"]
     assert item_17h.status == "done"
     assert _done_evidence_is_complete(item_17h)
     assert item_17i.status == "done"
     assert _done_evidence_is_complete(item_17i)
-    assert item_17j.status == "ready"
+    assert item_17j.status == "done"
+    assert _done_evidence_is_complete(item_17j)
+    assert item_17k.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17j
+    assert _next_eligible_ready_item(items) == item_17k
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017j_after_017i_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017k_after_017j_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017J"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017K"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -103,7 +103,9 @@ def test_ade_qre_017_chain_selects_017j_after_017i_completion_evidence() -> None
     assert rows["ADE-QRE-017H"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017I"]["status"] == "done"
     assert rows["ADE-QRE-017I"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017J"]["status"] == "ready"
+    assert rows["ADE-QRE-017J"]["status"] == "done"
+    assert rows["ADE-QRE-017J"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017K"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017j_after_017i_completion_evidence() -> None:
+def test_current_queue_selects_017k_after_017j_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017J"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017K"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -180,7 +180,9 @@ def test_current_queue_selects_017j_after_017i_completion_evidence() -> None:
     assert rows["ADE-QRE-017H"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017I"]["status"] == "done"
     assert rows["ADE-QRE-017I"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017J"]["status"] == "ready"
+    assert rows["ADE-QRE-017J"]["status"] == "done"
+    assert rows["ADE-QRE-017J"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017K"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017J completion evidence in the canonical queue document
- mark ADE-QRE-017K ready as the next eligible item
- keep queue-selection tests aligned with the completed J item

## Dependencies
- PR #638 merged
- ADE-QRE-017J completed

## Scope
- `docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md`
- `tests/unit/test_ade_qre_014_queue_lifecycle.py`
- `tests/unit/test_ade_qre_017_queue_admission.py`
- `tests/unit/test_ade_queue_status_self_audit.py`

## Forbidden scope
- `.claude/**`
- `research/research_latest.json`
- `research/strategy_matrix.csv`
- live, paper, shadow, broker, risk, execution, trading, capital-allocation paths
- queue items beyond `ADE-QRE-017J` / `ADE-QRE-017K` status maintenance

## Validation
- `python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q`
- `python -m reporting.ade_queue_status_self_audit --no-write`
- `python scripts/governance_lint.py`
- `git diff --check`

## Handoff
- This PR only records canonical queue completion evidence. `ADE-QRE-017K` becomes the next eligible queue item after merge.