### PR TITLE
docs: record ADE-QRE-017K completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3061,7 +3061,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017K`
 - title: Source Usefulness Ledger.
-- status: `ready`
+- status: `done`
 - purpose: track actual source outcomes, usefulness, disagreements, savings,
   and operator value without treating source quality as alpha.
 - source document:
@@ -3079,13 +3079,24 @@ live, broker, risk, or execution work.
   - frozen contracts and runtime paths listed under `ADE-QRE-017`.
 - validation required:
   - usefulness is tied to actual influenced outcomes.
+- completion evidence:
+  PR #640, merge SHA `4f66d632346d4bf9e4eb171f6e70bdc70ed3cb53`; checks green before
+  squash-merge; implementation note:
+  `docs/governance/qre_source_usefulness_ledger.md`; canonical artifact:
+  `logs/qre_source_usefulness_ledger/latest.json`; operator summary:
+  `logs/qre_source_usefulness_ledger/operator_summary.md`; validation:
+  `python -m pytest tests/unit/test_qre_source_usefulness_ledger.py tests/unit/test_qre_lineage_graph_v1.py -q`,
+  `python -m research.qre_source_usefulness_ledger --status`,
+  `python scripts/governance_lint.py`, `git diff --check`; post-merge governance
+  and architecture validation passed on `main`; frozen contracts unchanged;
+  protected/execution paths untouched.
 - next dependency: `ADE-QRE-017L`.
 
 ### ADE-QRE-017L - Behavior Thesis Registry
 
 - queue id: `ADE-QRE-017L`
 - title: Behavior Thesis Registry.
-- status: `blocked until ADE-QRE-017K done`
+- status: `ready`
 - purpose: create a deterministic behavior-thesis registry with mechanism,
   falsification, sampling, validation, OOS, and data requirements.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -356,16 +356,19 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     item_17i = items["ADE-QRE-017I"]
     item_17j = items["ADE-QRE-017J"]
     item_17k = items["ADE-QRE-017K"]
+    item_17l = items["ADE-QRE-017L"]
     assert item_17h.status == "done"
     assert _done_evidence_is_complete(item_17h)
     assert item_17i.status == "done"
     assert _done_evidence_is_complete(item_17i)
     assert item_17j.status == "done"
     assert _done_evidence_is_complete(item_17j)
-    assert item_17k.status == "ready"
+    assert item_17k.status == "done"
+    assert _done_evidence_is_complete(item_17k)
+    assert item_17l.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17k
+    assert _next_eligible_ready_item(items) == item_17l
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -87,7 +87,7 @@ def test_ade_qre_017_chain_selects_017k_after_017j_completion_evidence() -> None
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017K"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017L"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -105,7 +105,9 @@ def test_ade_qre_017_chain_selects_017k_after_017j_completion_evidence() -> None
     assert rows["ADE-QRE-017I"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017J"]["status"] == "done"
     assert rows["ADE-QRE-017J"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017K"]["status"] == "ready"
+    assert rows["ADE-QRE-017K"]["status"] == "done"
+    assert rows["ADE-QRE-017K"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017L"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017k_after_017j_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017K"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017L"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -182,7 +182,9 @@ def test_current_queue_selects_017k_after_017j_completion_evidence() -> None:
     assert rows["ADE-QRE-017I"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017J"]["status"] == "done"
     assert rows["ADE-QRE-017J"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017K"]["status"] == "ready"
+    assert rows["ADE-QRE-017K"]["status"] == "done"
+    assert rows["ADE-QRE-017K"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017L"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
Promotes ADE-QRE-017K to done and makes ADE-QRE-017L the next ready item.

Scope:
- update the canonical queue document with ADE-QRE-017K completion evidence
- update queue lifecycle and audit tests to the new next-eligible item

Validation:
- python -m pytest tests/unit/test_qre_source_usefulness_ledger.py tests/unit/test_qre_lineage_graph_v1.py -q
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python scripts/governance_lint.py
- git diff --check