### PR TITLE
docs: record ADE-QRE-017L completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3096,7 +3096,22 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017L`
 - title: Behavior Thesis Registry.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #643, merge SHA
+  `029d6b2107175a5feb4cacda84ad46f3e1b15c97`; implementation added
+  `research/qre_behavior_thesis_registry.py`, canonical doc
+  `docs/governance/qre_behavior_thesis_registry.md`, and focused tests in
+  `tests/unit/test_qre_behavior_thesis_registry.py`; canonical artifact:
+  `logs/qre_behavior_thesis_registry/latest.json`; validation:
+  `python -m pytest tests/unit/test_qre_behavior_thesis_registry.py tests/unit/test_qre_research_memory.py tests/unit/test_qre_research_memory_retrieval.py tests/unit/test_qre_hypothesis_model.py -q`,
+  `python -m research.qre_behavior_thesis_registry --write`,
+  `python scripts/governance_lint.py`,
+  `python -m pytest tests/architecture -q`,
+  `python -m reporting.architecture_import_scan --format summary`,
+  `git diff --check`; checks green; post-merge validation passed on `main`;
+  frozen contracts unchanged; protected/execution paths untouched; no
+  executable strategy generation, strategy registration, or campaign
+  authority added.
 - purpose: create a deterministic behavior-thesis registry with mechanism,
   falsification, sampling, validation, OOS, and data requirements.
 - source document:
@@ -3120,7 +3135,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017M`
 - title: Supporting and Contradicting Evidence.
-- status: `blocked until ADE-QRE-017L done`
+- status: `ready`
 - purpose: attach supporting, contradicting, and unresolved evidence to each
   thesis with provenance.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -357,6 +357,7 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     item_17j = items["ADE-QRE-017J"]
     item_17k = items["ADE-QRE-017K"]
     item_17l = items["ADE-QRE-017L"]
+    item_17m = items["ADE-QRE-017M"]
     assert item_17h.status == "done"
     assert _done_evidence_is_complete(item_17h)
     assert item_17i.status == "done"
@@ -365,10 +366,12 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17j)
     assert item_17k.status == "done"
     assert _done_evidence_is_complete(item_17k)
-    assert item_17l.status == "ready"
+    assert item_17l.status == "done"
+    assert _done_evidence_is_complete(item_17l)
+    assert item_17m.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17l
+    assert _next_eligible_ready_item(items) == item_17m
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017k_after_017j_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017m_after_017l_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017L"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017M"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -107,7 +107,9 @@ def test_ade_qre_017_chain_selects_017k_after_017j_completion_evidence() -> None
     assert rows["ADE-QRE-017J"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017K"]["status"] == "done"
     assert rows["ADE-QRE-017K"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017L"]["status"] == "ready"
+    assert rows["ADE-QRE-017L"]["status"] == "done"
+    assert rows["ADE-QRE-017L"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017M"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017k_after_017j_completion_evidence() -> None:
+def test_current_queue_selects_017m_after_017l_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017L"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017M"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -184,7 +184,9 @@ def test_current_queue_selects_017k_after_017j_completion_evidence() -> None:
     assert rows["ADE-QRE-017J"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017K"]["status"] == "done"
     assert rows["ADE-QRE-017K"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017L"]["status"] == "ready"
+    assert rows["ADE-QRE-017L"]["status"] == "done"
+    assert rows["ADE-QRE-017L"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017M"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017L completion evidence in the canonical ADE queue
- move ADE-QRE-017L to done and ADE-QRE-017M to ready
- update queue lifecycle and queue audit tests to select ADE-QRE-017M next

## Dependencies
- follows merged ADE-QRE-017L implementation PR #643 / merge 