### PR TITLE
docs: record ADE-QRE-017M completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3135,7 +3135,22 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017M`
 - title: Supporting and Contradicting Evidence.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #645, merge SHA
+  `c3ca9d04b76e5bbd9d0bb5ef2217267bab164136`; implementation added
+  `research/qre_behavior_thesis_evidence.py`, canonical doc
+  `docs/governance/qre_behavior_thesis_evidence.md`, and focused tests in
+  `tests/unit/test_qre_behavior_thesis_evidence.py`; canonical artifact:
+  `logs/qre_behavior_thesis_evidence/latest.json`; validation:
+  `python -m pytest tests/unit/test_qre_behavior_thesis_evidence.py tests/unit/test_qre_behavior_thesis_registry.py tests/unit/test_qre_research_memory.py tests/unit/test_qre_research_memory_retrieval.py tests/unit/test_hypothesis_discovery_minimal.py -q`,
+  `python -m research.qre_behavior_thesis_evidence --write`,
+  `python scripts/governance_lint.py`,
+  `python -m pytest tests/architecture -q`,
+  `python -m reporting.architecture_import_scan --format summary`,
+  `git diff --check`; checks green; post-merge validation passed on `main`;
+  frozen contracts unchanged; protected/execution paths untouched;
+  contradictions, supporting evidence, and unresolved evidence remain explicit
+  and context-only.
 - purpose: attach supporting, contradicting, and unresolved evidence to each
   thesis with provenance.
 - source document:
@@ -3159,7 +3174,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017N`
 - title: Prior-Failure Retrieval.
-- status: `blocked until ADE-QRE-017M done`
+- status: `ready`
 - purpose: use existing retrieval and research memory to return related prior
   failures, dead zones, and actions as context only.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -358,6 +358,7 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     item_17k = items["ADE-QRE-017K"]
     item_17l = items["ADE-QRE-017L"]
     item_17m = items["ADE-QRE-017M"]
+    item_17n = items["ADE-QRE-017N"]
     assert item_17h.status == "done"
     assert _done_evidence_is_complete(item_17h)
     assert item_17i.status == "done"
@@ -368,10 +369,12 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17k)
     assert item_17l.status == "done"
     assert _done_evidence_is_complete(item_17l)
-    assert item_17m.status == "ready"
+    assert item_17m.status == "done"
+    assert _done_evidence_is_complete(item_17m)
+    assert item_17n.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17m
+    assert _next_eligible_ready_item(items) == item_17n
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017m_after_017l_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017n_after_017m_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017M"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017N"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -109,7 +109,9 @@ def test_ade_qre_017_chain_selects_017m_after_017l_completion_evidence() -> None
     assert rows["ADE-QRE-017K"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017L"]["status"] == "done"
     assert rows["ADE-QRE-017L"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017M"]["status"] == "ready"
+    assert rows["ADE-QRE-017M"]["status"] == "done"
+    assert rows["ADE-QRE-017M"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017N"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017m_after_017l_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017M"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017N"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -186,7 +186,9 @@ def test_current_queue_selects_017m_after_017l_completion_evidence() -> None:
     assert rows["ADE-QRE-017K"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017L"]["status"] == "done"
     assert rows["ADE-QRE-017L"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017M"]["status"] == "ready"
+    assert rows["ADE-QRE-017M"]["status"] == "done"
+    assert rows["ADE-QRE-017M"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017N"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-017M done in the canonical ADE queue
- record PR #645 merge evidence and post-merge validation
- advance the next eligible queue item to ADE-QRE-017N

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check
