### PR TITLE
docs: record ADE-QRE-017N completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3174,7 +3174,19 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017N`
 - title: Prior-Failure Retrieval.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #647, merge SHA `5a8b51092cfb2acf4a6757030785473a6835cde8`;
+  implementation added `research/qre_prior_failure_retrieval.py`, canonical
+  doc `docs/governance/qre_prior_failure_retrieval.md`, and focused tests in
+  `tests/unit/test_qre_prior_failure_retrieval.py`; canonical artifact:
+  `logs/qre_prior_failure_retrieval/latest.json`; validation:
+  `python -m pytest tests/unit/test_qre_prior_failure_retrieval.py tests/unit/test_qre_behavior_thesis_registry.py tests/unit/test_qre_behavior_thesis_evidence.py tests/unit/test_qre_research_memory.py tests/unit/test_qre_research_memory_retrieval.py tests/unit/test_qre_retrieval_maturity.py -q`,
+  `python -m research.qre_prior_failure_retrieval --write`,
+  `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`,
+  `python -m reporting.architecture_import_scan --format summary`,
+  `git diff --check`; checks green; post-merge validation passed on `main`;
+  frozen contracts unchanged; protected/execution paths untouched; retrieval
+  remained context only and did not become evidence authority.
 - purpose: use existing retrieval and research memory to return related prior
   failures, dead zones, and actions as context only.
 - source document:
@@ -3199,7 +3211,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017O`
 - title: Opportunity Research Value.
-- status: `blocked until ADE-QRE-017N done`
+- status: `ready`
 - purpose: implement a deterministic research-value score for prioritization
   that is explicitly not alpha probability.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -359,6 +359,7 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     item_17l = items["ADE-QRE-017L"]
     item_17m = items["ADE-QRE-017M"]
     item_17n = items["ADE-QRE-017N"]
+    item_17o = items["ADE-QRE-017O"]
     assert item_17h.status == "done"
     assert _done_evidence_is_complete(item_17h)
     assert item_17i.status == "done"
@@ -371,10 +372,12 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17l)
     assert item_17m.status == "done"
     assert _done_evidence_is_complete(item_17m)
-    assert item_17n.status == "ready"
+    assert item_17n.status == "done"
+    assert _done_evidence_is_complete(item_17n)
+    assert item_17o.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17n
+    assert _next_eligible_ready_item(items) == item_17o
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017n_after_017m_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017o_after_017n_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017N"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017O"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -111,7 +111,9 @@ def test_ade_qre_017_chain_selects_017n_after_017m_completion_evidence() -> None
     assert rows["ADE-QRE-017L"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017M"]["status"] == "done"
     assert rows["ADE-QRE-017M"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017N"]["status"] == "ready"
+    assert rows["ADE-QRE-017N"]["status"] == "done"
+    assert rows["ADE-QRE-017N"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017O"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017m_after_017l_completion_evidence() -> None:
+def test_current_queue_selects_017o_after_017n_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017N"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017O"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -188,7 +188,9 @@ def test_current_queue_selects_017m_after_017l_completion_evidence() -> None:
     assert rows["ADE-QRE-017L"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017M"]["status"] == "done"
     assert rows["ADE-QRE-017M"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017N"]["status"] == "ready"
+    assert rows["ADE-QRE-017N"]["status"] == "done"
+    assert rows["ADE-QRE-017N"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017O"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-017N done with PR and post-merge validation evidence
- advance ADE-QRE-017O to ready in the canonical queue
- update queue admission and audit tests to select ADE-QRE-017O next

## Scope
- canonical queue document
- queue parser and audit tests

## Forbidden Scope
- no implementation changes
- no queue mutation outside canonical source
- no frozen contract changes

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check

## Handoff
- next eligible ready item should be ADE-QRE-017O after merge