### PR TITLE
docs: record ADE-QRE-017O completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3211,7 +3211,21 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017O`
 - title: Opportunity Research Value.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #649, merge SHA `7d317b64cd8df6a7fcb3af97054c1b42bd6a61c1`;
+  implementation added `research/qre_opportunity_research_value.py`,
+  `packages/qre_research/opportunity_value.py`, canonical doc
+  `docs/governance/qre_opportunity_research_value.md`, and focused tests in
+  `tests/unit/test_qre_opportunity_research_value.py`; canonical artifact:
+  `logs/qre_opportunity_research_value/latest.json`; validation:
+  `python -m pytest tests/unit/test_qre_opportunity_research_value.py tests/unit/test_qre_behavior_thesis_registry.py tests/unit/test_qre_behavior_thesis_evidence.py tests/unit/test_qre_prior_failure_retrieval.py tests/unit/test_hypothesis_discovery_minimal.py -q`,
+  `python -m research.qre_opportunity_research_value --write`,
+  `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`,
+  `python -m reporting.architecture_import_scan --format summary`,
+  `git diff --check`; checks green; post-merge validation passed on `main`;
+  frozen contracts unchanged; protected/execution paths untouched; opportunity
+  scoring remained expected research value only and did not become alpha,
+  registration, or campaign authority.
 - purpose: implement a deterministic research-value score for prioritization
   that is explicitly not alpha probability.
 - source document:
@@ -3235,7 +3249,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017P`
 - title: Routing Baseline Comparison.
-- status: `blocked until ADE-QRE-017O done`
+- status: `ready`
 - purpose: compare current routing against deterministic baselines and measure
   actual decision usefulness.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -374,10 +374,11 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17m)
     assert item_17n.status == "done"
     assert _done_evidence_is_complete(item_17n)
-    assert item_17o.status == "ready"
+    assert item_17o.status == "done"
+    assert _done_evidence_is_complete(item_17o)
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == item_17o
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017P"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017o_after_017n_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017p_after_017o_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017O"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017P"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -113,7 +113,9 @@ def test_ade_qre_017_chain_selects_017o_after_017n_completion_evidence() -> None
     assert rows["ADE-QRE-017M"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017N"]["status"] == "done"
     assert rows["ADE-QRE-017N"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017O"]["status"] == "ready"
+    assert rows["ADE-QRE-017O"]["status"] == "done"
+    assert rows["ADE-QRE-017O"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017P"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017o_after_017n_completion_evidence() -> None:
+def test_current_queue_selects_017p_after_017o_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017O"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017P"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -190,7 +190,9 @@ def test_current_queue_selects_017o_after_017n_completion_evidence() -> None:
     assert rows["ADE-QRE-017M"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017N"]["status"] == "done"
     assert rows["ADE-QRE-017N"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017O"]["status"] == "ready"
+    assert rows["ADE-QRE-017O"]["status"] == "done"
+    assert rows["ADE-QRE-017O"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017P"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017O completion evidence in the canonical queue
- mark ADE-QRE-017P ready after ADE-QRE-017O merge
- update queue lifecycle and self-audit tests to select ADE-QRE-017P next

## Dependencies
- requires merged PR #649 / merge SHA 7d317b64cd8df6a7fcb3af97054c1b42bd6a61c1

## Scope
- canonical queue document
- queue lifecycle and self-audit tests

## Forbidden scope
- no implementation changes beyond queue evidence maintenance
- no .claude/** changes
- no frozen contract changes (esearch/research_latest.json, esearch/strategy_matrix.csv)
- no runtime, paper/shadow/live, broker/risk/execution changes

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check
