### PR TITLE
ADE-QRE-017P: add routing baseline comparison

### DIFF
--- a/docs/governance/qre_routing_baseline_comparison.md
+++ b/docs/governance/qre_routing_baseline_comparison.md
@@ -1,0 +1,16 @@
+# QRE Routing Baseline Comparison
+
+This surface compares the current context-only router ordering against simple deterministic baselines.
+
+| baseline_id | usefulness | top3_opportunity_capture | top3_high_priority_count |
+| --- | --- | --- | --- |
+| blocked_reason_count | 2.022 | 0.734 | 1 |
+| current_routing_score | 2.022 | 0.734 | 1 |
+| fifo_artifact_order | 2.022 | 0.734 | 1 |
+| lexical_direction_id | 2.022 | 0.734 | 1 |
+| lexical_behavior_id | 1.373 | 0.313 | 0 |
+
+- source router status: `ready`
+- source opportunity status: `ready`
+
+Current routing remains context only and does not authorize campaign execution.

--- a/packages/qre_research/README.md
+++ b/packages/qre_research/README.md
@@ -30,6 +30,10 @@ evidence density, prior-failure context, and proposal-only discovery signals
 into a deterministic expected-research-value score for prioritization only.
 The pure weighting helper for that surface lives in
 `packages.qre_research.opportunity_value`.
+The ADE-QRE-017P routing-baseline-comparison surface lives in
+`research.qre_routing_baseline_comparison` and compares the current
+context-only router ordering against trivial deterministic baselines without
+granting campaign authority.
 
 ## Source of Truth / Authority Boundary
 

--- a/research/qre_routing_baseline_comparison.py
+++ b/research/qre_routing_baseline_comparison.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any, Final
+
+
+REPORT_KIND: Final[str] = "qre_routing_baseline_comparison"
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "ade-qre-017p-2026-06-26"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_routing_baseline_comparison")
+LATEST_NAME: Final[str] = "latest.json"
+DOC_PATH: Final[Path] = Path("docs/governance/qre_routing_baseline_comparison.md")
+WRITE_PREFIXES: Final[tuple[str, ...]] = (
+    "logs/qre_routing_baseline_comparison/",
+    "docs/governance/qre_routing_baseline_comparison.md",
+)
+DEFAULT_ROUTER_PATH: Final[Path] = Path("logs/qre_research_cycle_router/latest.json")
+DEFAULT_OPPORTUNITY_PATH: Final[Path] = Path("logs/qre_opportunity_research_value/latest.json")
+
+BASELINE_IDS: Final[tuple[str, ...]] = (
+    "current_routing_score",
+    "fifo_artifact_order",
+    "lexical_direction_id",
+    "lexical_behavior_id",
+    "blocked_reason_count",
+)
+PRIORITY_BAND_VALUES: Final[frozenset[str]] = frozenset({"blocked", "low", "medium", "high", "missing"})
+NEXT_ACTION_VALUES: Final[frozenset[str]] = frozenset(
+    {
+        "advance_to_routing_comparison",
+        "increase_evidence_density",
+        "resolve_data_readiness",
+        "operator_review_context_only",
+        "keep_fail_closed",
+        "missing",
+    }
+)
+FINAL_RECOMMENDATION: Final[str] = "routing_baseline_comparison_ready"
+DIRECTION_REQUIRED_FIELDS: Final[tuple[str, ...]] = (
+    "direction_id",
+    "behavior_id",
+    "route_status",
+    "artifact_index",
+    "blocked_reason_count",
+    "routing_score",
+    "opportunity_score",
+    "opportunity_priority_band",
+    "opportunity_next_action",
+    "decision_usefulness_proxy",
+    "information_gain_proxy_score",
+    "provenance_refs",
+)
+BASELINE_REQUIRED_FIELDS: Final[tuple[str, ...]] = (
+    "baseline_id",
+    "ranking",
+    "decision_usefulness_score",
+    "top3_opportunity_capture",
+    "top3_mean_information_gain_proxy",
+    "top3_high_priority_count",
+    "top3_data_ready_count",
+    "top3_unique_behavior_count",
+    "comparison_scope",
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _read_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get(field)
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, dict)]
+
+
+def _validate_write_target(path: Path) -> None:
+    normalized = path.as_posix()
+    if not any(prefix in normalized for prefix in WRITE_PREFIXES):
+        raise ValueError(
+            f"qre_routing_baseline_comparison: refusing write outside allowlist: {path!r}"
+        )
+
+
+def _opportunity_index(payload: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    rows = _read_rows(payload, "rows")
+    by_behavior: dict[str, dict[str, Any]] = {}
+    for index, row in enumerate(rows):
+        behavior = _text(row.get("behavior_family"))
+        if behavior and behavior not in by_behavior:
+            by_behavior[behavior] = {**dict(row), "_row_index": index}
+    return by_behavior
+
+
+def _direction_behavior_id(row: dict[str, Any]) -> str:
+    return _text((row.get("target_hypothesis") or {}).get("behavior_id")) or _text(
+        (row.get("proposed_scope") or {}).get("behavior_id")
+    )
+
+
+def _direction_record(
+    row: dict[str, Any],
+    *,
+    index: int,
+    opportunity_by_behavior: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    behavior_id = _direction_behavior_id(row)
+    opportunity = opportunity_by_behavior.get(behavior_id, {})
+    routing = dict(row.get("routing_context_only") or {})
+    components = dict(routing.get("score_components") or {})
+    opportunity_score = float(opportunity.get("opportunity_score") or 0.0)
+    information_gain = float(components.get("information_gain_proxy_score") or 0.0)
+    evidence_gap = float(components.get("evidence_gap_reduction_score") or 0.0)
+    source_cache = float(components.get("source_cache_readiness_score") or 0.0)
+    behavior_diversity = float(components.get("behavior_diversity_score") or 0.0)
+    feasibility = float(components.get("feasibility_score") or 0.0)
+    prior_penalty = float(components.get("prior_failure_penalty") or 0.0)
+    compute_penalty = float(components.get("compute_cost_penalty") or 0.0)
+    usefulness = max(
+        0.0,
+        min(
+            1.0,
+            (
+                0.35 * opportunity_score
+                + 0.20 * information_gain
+                + 0.15 * evidence_gap
+                + 0.10 * source_cache
+                + 0.10 * behavior_diversity
+                + 0.10 * feasibility
+                - 0.10 * prior_penalty
+                - 0.10 * compute_penalty
+            ),
+        ),
+    )
+    return {
+        "direction_id": _text(row.get("direction_id")),
+        "behavior_id": behavior_id,
+        "route_status": _text(row.get("route_status")),
+        "artifact_index": index,
+        "blocked_reason_count": len(list(routing.get("blocked_reasons") or [])),
+        "routing_score": float(routing.get("routing_score") or 0.0),
+        "opportunity_score": round(opportunity_score, 6),
+        "opportunity_priority_band": _text(opportunity.get("priority_band")) or "missing",
+        "opportunity_next_action": _text(opportunity.get("recommended_next_action")) or "missing",
+        "decision_usefulness_proxy": round(usefulness, 6),
+        "information_gain_proxy_score": round(information_gain, 6),
+        "provenance_refs": [
+            f"{DEFAULT_ROUTER_PATH.as_posix()}#eligible_directions[{index}]",
+            *(
+                [f"{DEFAULT_OPPORTUNITY_PATH.as_posix()}#rows[{opportunity.get('_row_index')}]"]
+                if "_row_index" in opportunity
+                else []
+            ),
+        ],
+    }
+
+
+def _ranked(rows: list[dict[str, Any]], baseline_id: str) -> list[dict[str, Any]]:
+    if baseline_id == "current_routing_score":
+        return sorted(rows, key=lambda row: (-row["routing_score"], row["direction_id"]))
+    if baseline_id == "fifo_artifact_order":
+        return sorted(rows, key=lambda row: row["artifact_index"])
+    if baseline_id == "lexical_direction_id":
+        return sorted(rows, key=lambda row: row["direction_id"])
+    if baseline_id == "lexical_behavior_id":
+        return sorted(rows, key=lambda row: (row["behavior_id"], row["direction_id"]))
+    if baseline_id == "blocked_reason_count":
+        return sorted(rows, key=lambda row: (row["blocked_reason_count"], row["direction_id"]))
+    raise KeyError(baseline_id)
+
+
+def _dcg(rows: list[dict[str, Any]]) -> float:
+    total = 0.0
+    for index, row in enumerate(rows, start=1):
+        discount = 1.0 / math.log2(index + 1)
+        total += float(row["decision_usefulness_proxy"]) * discount
+    return round(total, 6)
+
+
+def _baseline_summary(baseline_id: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    ranked = _ranked(rows, baseline_id)
+    top3 = ranked[:3]
+    return {
+        "baseline_id": baseline_id,
+        "ranking": [row["direction_id"] for row in ranked],
+        "decision_usefulness_score": _dcg(ranked),
+        "top3_opportunity_capture": round(sum(float(row["opportunity_score"]) for row in top3), 6),
+        "top3_mean_information_gain_proxy": round(
+            sum(float(row["information_gain_proxy_score"]) for row in top3) / max(1, len(top3)),
+            6,
+        ),
+        "top3_high_priority_count": sum(
+            row["opportunity_priority_band"] in {"medium", "high"} for row in top3
+        ),
+        "top3_data_ready_count": sum(
+            row["opportunity_next_action"] != "resolve_data_readiness" for row in top3
+        ),
+        "top3_unique_behavior_count": len({row["behavior_id"] for row in top3}),
+        "comparison_scope": "context_only_not_execution_authority",
+    }
+
+
+def _source_status(payload: dict[str, Any] | None, *, required_field: str) -> dict[str, Any]:
+    if payload is None:
+        return {"status": "missing", "required_field": required_field, "fails_closed": True}
+    if not isinstance(payload.get(required_field), list):
+        return {"status": "invalid", "required_field": required_field, "fails_closed": True}
+    return {"status": "ready", "required_field": required_field, "fails_closed": False}
+
+
+def validate_direction(row: dict[str, Any]) -> dict[str, Any]:
+    reasons: list[str] = []
+    missing = [field for field in DIRECTION_REQUIRED_FIELDS if field not in row]
+    if missing:
+        reasons.append("missing_required_fields")
+    if _text(row.get("opportunity_priority_band")) not in PRIORITY_BAND_VALUES:
+        reasons.append("invalid_priority_band")
+    if _text(row.get("opportunity_next_action")) not in NEXT_ACTION_VALUES:
+        reasons.append("invalid_next_action")
+    if not isinstance(row.get("provenance_refs"), list) or not row.get("provenance_refs"):
+        reasons.append("missing_provenance_refs")
+    for key in ("routing_score", "opportunity_score", "decision_usefulness_proxy", "information_gain_proxy_score"):
+        try:
+            value = float(row.get(key))
+        except (TypeError, ValueError):
+            reasons.append(f"invalid_{key}")
+            continue
+        if not 0.0 <= value <= 1.0:
+            reasons.append(f"out_of_range_{key}")
+    return {"valid": not reasons, "rejection_reasons": reasons}
+
+
+def validate_baseline(row: dict[str, Any]) -> dict[str, Any]:
+    reasons: list[str] = []
+    missing = [field for field in BASELINE_REQUIRED_FIELDS if field not in row]
+    if missing:
+        reasons.append("missing_required_fields")
+    if _text(row.get("baseline_id")) not in BASELINE_IDS:
+        reasons.append("invalid_baseline_id")
+    if _text(row.get("comparison_scope")) != "context_only_not_execution_authority":
+        reasons.append("invalid_comparison_scope")
+    if not isinstance(row.get("ranking"), list):
+        reasons.append("invalid_ranking")
+    return {"valid": not reasons, "rejection_reasons": reasons}
+
+
+def build_routing_baseline_comparison(
+    *,
+    repo_root: Path | None = None,
+    router_report: dict[str, Any] | None = None,
+    opportunity_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    root = repo_root or Path.cwd()
+    router_report = router_report or _read_json(root / DEFAULT_ROUTER_PATH)
+    opportunity_report = opportunity_report or _read_json(root / DEFAULT_OPPORTUNITY_PATH)
+    source_status = {
+        "research_cycle_router": _source_status(router_report, required_field="eligible_directions"),
+        "opportunity_research_value": _source_status(opportunity_report, required_field="rows"),
+    }
+    opportunity_by_behavior = _opportunity_index(opportunity_report)
+    direction_rows = [
+        _direction_record(row, index=index, opportunity_by_behavior=opportunity_by_behavior)
+        for index, row in enumerate(_read_rows(router_report, "eligible_directions"))
+    ]
+    direction_rows.sort(key=lambda row: row["direction_id"])
+    for row in direction_rows:
+        validation = validate_direction(row)
+        if not validation["valid"]:
+            raise ValueError(
+                "qre_routing_baseline_comparison: invalid direction row for "
+                f"{row.get('direction_id')}: {validation['rejection_reasons']}"
+            )
+    baselines = [_baseline_summary(baseline_id, direction_rows) for baseline_id in BASELINE_IDS]
+    baselines.sort(key=lambda row: (-float(row["decision_usefulness_score"]), row["baseline_id"]))
+    for row in baselines:
+        validation = validate_baseline(row)
+        if not validation["valid"]:
+            raise ValueError(
+                "qre_routing_baseline_comparison: invalid baseline row for "
+                f"{row.get('baseline_id')}: {validation['rejection_reasons']}"
+            )
+    current = next(row for row in baselines if row["baseline_id"] == "current_routing_score")
+    best = baselines[0]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "source_status": source_status,
+        "artifact_references": {
+            "research_cycle_router": DEFAULT_ROUTER_PATH.as_posix(),
+            "opportunity_research_value": DEFAULT_OPPORTUNITY_PATH.as_posix(),
+        },
+        "directions": direction_rows,
+        "baselines": baselines,
+        "summary": {
+            "direction_count": len(direction_rows),
+            "baseline_count": len(baselines),
+            "current_routing_score": current["decision_usefulness_score"],
+            "best_baseline_id": best["baseline_id"],
+            "best_baseline_score": best["decision_usefulness_score"],
+            "current_minus_fifo": round(
+                current["decision_usefulness_score"]
+                - next(
+                    row["decision_usefulness_score"]
+                    for row in baselines
+                    if row["baseline_id"] == "fifo_artifact_order"
+                ),
+                6,
+            ),
+            "final_recommendation": FINAL_RECOMMENDATION,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "can_generate_executable_strategy": False,
+            "can_register_strategy": False,
+            "can_promote_candidate": False,
+            "can_launch_campaign": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "context_only_not_authority": True,
+        },
+    }
+
+
+def render_doc(report: dict[str, Any]) -> str:
+    lines = [
+        "# QRE Routing Baseline Comparison",
+        "",
+        "This surface compares the current context-only router ordering against simple deterministic baselines.",
+        "",
+        "| baseline_id | usefulness | top3_opportunity_capture | top3_high_priority_count |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in report.get("baselines", []):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _text(row.get("baseline_id")),
+                    f"{float(row.get('decision_usefulness_score') or 0.0):.3f}",
+                    f"{float(row.get('top3_opportunity_capture') or 0.0):.3f}",
+                    str(int(row.get("top3_high_priority_count") or 0)),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            f"- source router status: `{_text(((report.get('source_status') or {}).get('research_cycle_router') or {}).get('status'))}`",
+            f"- source opportunity status: `{_text(((report.get('source_status') or {}).get('opportunity_research_value') or {}).get('status'))}`",
+            "",
+            "Current routing remains context only and does not authorize campaign execution.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(report: dict[str, Any], *, repo_root: Path | None = None) -> dict[str, str]:
+    root = repo_root or Path.cwd()
+    latest = root / DEFAULT_OUTPUT_DIR / LATEST_NAME
+    doc = root / DOC_PATH
+    latest.parent.mkdir(parents=True, exist_ok=True)
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    for path in (latest, doc):
+        _validate_write_target(path)
+    tmp = latest.with_suffix(latest.suffix + ".tmp")
+    tmp.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, latest)
+    doc.write_text(render_doc(report), encoding="utf-8")
+    return {
+        "latest": latest.relative_to(root).as_posix(),
+        "doc": doc.relative_to(root).as_posix(),
+    }
+
+
+def read_status(*, repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or Path.cwd()
+    payload = _read_json(root / DEFAULT_OUTPUT_DIR / LATEST_NAME)
+    if not payload:
+        return {"status": "missing", "path": (DEFAULT_OUTPUT_DIR / LATEST_NAME).as_posix(), "fails_closed": True}
+    return {
+        "status": "ready",
+        "path": (DEFAULT_OUTPUT_DIR / LATEST_NAME).as_posix(),
+        "fails_closed": False,
+        "schema_version": payload.get("schema_version"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--status", action="store_true")
+    args = parser.parse_args(argv)
+    if args.status:
+        print(json.dumps(read_status(), indent=2, sort_keys=True))
+        return 0
+    report = build_routing_baseline_comparison()
+    if args.write:
+        print(json.dumps(write_outputs(report), indent=2, sort_keys=True))
+        return 0
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_qre_routing_baseline_comparison.py
+++ b/tests/unit/test_qre_routing_baseline_comparison.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from research import qre_routing_baseline_comparison as comparison
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _seed(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_opportunity_research_value" / "latest.json",
+        {
+            "rows": [
+                {
+                    "behavior_family": "index_regime_filter",
+                    "opportunity_score": 0.8,
+                    "priority_band": "high",
+                    "recommended_next_action": "advance_to_routing_comparison",
+                },
+                {
+                    "behavior_family": "post_shock_stabilization",
+                    "opportunity_score": 0.2,
+                    "priority_band": "low",
+                    "recommended_next_action": "resolve_data_readiness",
+                },
+                {
+                    "behavior_family": "relative_strength",
+                    "opportunity_score": 0.6,
+                    "priority_band": "medium",
+                    "recommended_next_action": "increase_evidence_density",
+                },
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_research_cycle_router" / "latest.json",
+        {
+            "eligible_directions": [
+                {
+                    "direction_id": "behavior_rotation::post_shock_stabilization",
+                    "route_status": "eligible_context_only",
+                    "target_hypothesis": {"behavior_id": "post_shock_stabilization"},
+                    "routing_context_only": {
+                        "routing_score": 0.40,
+                        "blocked_reasons": [],
+                        "score_components": {
+                            "information_gain_proxy_score": 0.4,
+                            "evidence_gap_reduction_score": 0.5,
+                            "source_cache_readiness_score": 0.6,
+                            "behavior_diversity_score": 1.0,
+                            "feasibility_score": 1.0,
+                            "prior_failure_penalty": 0.1,
+                            "compute_cost_penalty": 0.2,
+                        },
+                    },
+                },
+                {
+                    "direction_id": "behavior_rotation::index_regime_filter",
+                    "route_status": "eligible_context_only",
+                    "target_hypothesis": {"behavior_id": "index_regime_filter"},
+                    "routing_context_only": {
+                        "routing_score": 0.61,
+                        "blocked_reasons": [],
+                        "score_components": {
+                            "information_gain_proxy_score": 0.9,
+                            "evidence_gap_reduction_score": 0.6,
+                            "source_cache_readiness_score": 1.0,
+                            "behavior_diversity_score": 1.0,
+                            "feasibility_score": 1.0,
+                            "prior_failure_penalty": 0.1,
+                            "compute_cost_penalty": 0.2,
+                        },
+                    },
+                },
+                {
+                    "direction_id": "behavior_rotation::relative_strength",
+                    "route_status": "eligible_context_only",
+                    "target_hypothesis": {"behavior_id": "relative_strength"},
+                    "routing_context_only": {
+                        "routing_score": 0.51,
+                        "blocked_reasons": ["context_only"],
+                        "score_components": {
+                            "information_gain_proxy_score": 0.8,
+                            "evidence_gap_reduction_score": 0.4,
+                            "source_cache_readiness_score": 0.8,
+                            "behavior_diversity_score": 1.0,
+                            "feasibility_score": 1.0,
+                            "prior_failure_penalty": 0.2,
+                            "compute_cost_penalty": 0.3,
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+
+def test_build_is_deterministic_and_current_routing_beats_fifo(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    left = comparison.build_routing_baseline_comparison(repo_root=tmp_path)
+    right = comparison.build_routing_baseline_comparison(repo_root=tmp_path)
+
+    assert left == right
+    assert left["report_kind"] == "qre_routing_baseline_comparison"
+    assert left["summary"]["best_baseline_id"] == "current_routing_score"
+    assert left["summary"]["current_minus_fifo"] > 0
+    assert left["source_status"]["research_cycle_router"]["status"] == "ready"
+    assert left["source_status"]["opportunity_research_value"]["status"] == "ready"
+
+
+def test_baseline_vocab_and_rankings_are_closed(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    report = comparison.build_routing_baseline_comparison(repo_root=tmp_path)
+
+    assert [row["baseline_id"] for row in report["baselines"]] == sorted(
+        [row["baseline_id"] for row in report["baselines"]],
+        key=lambda baseline_id: -next(
+            row["decision_usefulness_score"]
+            for row in report["baselines"]
+            if row["baseline_id"] == baseline_id
+        ),
+    )
+    for row in report["baselines"]:
+        assert row["baseline_id"] in comparison.BASELINE_IDS
+        assert row["comparison_scope"] == "context_only_not_execution_authority"
+        assert comparison.validate_baseline(row) == {"valid": True, "rejection_reasons": []}
+    for row in report["directions"]:
+        assert comparison.validate_direction(row) == {"valid": True, "rejection_reasons": []}
+
+
+def test_missing_opportunity_surface_fails_closed(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    (tmp_path / "logs" / "qre_opportunity_research_value" / "latest.json").unlink()
+
+    report = comparison.build_routing_baseline_comparison(repo_root=tmp_path)
+
+    assert all(direction["opportunity_score"] == 0.0 for direction in report["directions"])
+    assert report["source_status"]["opportunity_research_value"]["status"] == "missing"
+
+
+def test_direction_rows_keep_provenance_and_closed_vocab(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    report = comparison.build_routing_baseline_comparison(repo_root=tmp_path)
+
+    direction = report["directions"][0]
+    assert direction["opportunity_priority_band"] in comparison.PRIORITY_BAND_VALUES
+    assert direction["opportunity_next_action"] in comparison.NEXT_ACTION_VALUES
+    assert direction["provenance_refs"]
+    assert direction["provenance_refs"][0].startswith("logs/qre_research_cycle_router/latest.json#eligible_directions[")
+
+
+def test_invalid_row_validation_fails_closed() -> None:
+    validation = comparison.validate_direction(
+        {
+            "direction_id": "bad",
+            "behavior_id": "b",
+            "route_status": "eligible_context_only",
+            "artifact_index": 0,
+            "blocked_reason_count": 0,
+            "routing_score": 1.2,
+            "opportunity_score": 0.2,
+            "opportunity_priority_band": "invented",
+            "opportunity_next_action": "invented",
+            "decision_usefulness_proxy": -0.1,
+            "information_gain_proxy_score": 0.3,
+            "provenance_refs": [],
+        }
+    )
+
+    assert validation["valid"] is False
+    assert "invalid_priority_band" in validation["rejection_reasons"]
+    assert "invalid_next_action" in validation["rejection_reasons"]
+    assert "missing_provenance_refs" in validation["rejection_reasons"]
+    assert "out_of_range_routing_score" in validation["rejection_reasons"]
+    assert "out_of_range_decision_usefulness_proxy" in validation["rejection_reasons"]
+
+
+def test_write_outputs_and_status_round_trip(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    report = comparison.build_routing_baseline_comparison(repo_root=tmp_path)
+
+    paths = comparison.write_outputs(report, repo_root=tmp_path)
+
+    assert paths == {
+        "latest": "logs/qre_routing_baseline_comparison/latest.json",
+        "doc": "docs/governance/qre_routing_baseline_comparison.md",
+    }
+    assert "QRE Routing Baseline Comparison" in (
+        tmp_path / paths["doc"]
+    ).read_text(encoding="utf-8")
+    assert comparison.read_status(repo_root=tmp_path) == {
+        "status": "ready",
+        "path": "logs/qre_routing_baseline_comparison/latest.json",
+        "fails_closed": False,
+        "schema_version": "1.0",
+    }
+
+
+def test_source_is_read_only_and_preserves_frozen_contracts() -> None:
+    source = Path(comparison.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+
+    assert imported.isdisjoint({"requests", "socket", "httpx", "urllib", "subprocess"})
+    assert "research/research_latest.json" not in source
+    assert "research/strategy_matrix.csv" not in source
+    assert "can_launch_campaign\": False" in source or "\"can_launch_campaign\": False" in source


### PR DESCRIPTION
ADE-QRE-017P

## Scope
- add a deterministic read-only routing baseline comparison artifact
- compare current context-only routing against simple deterministic baselines
- add validation, provenance, and authority-separation tests
- document the new surface in governance docs and package README

## Dependencies
- ADE-QRE-017O done

## Forbidden scope
- no routing mutation
- no campaign execution
- no strategy generation or registration
- no paper/shadow/live, broker, risk, or execution changes
- no frozen contract changes

## Validation
- python -m pytest tests/unit/test_qre_routing_baseline_comparison.py tests/unit/test_qre_opportunity_research_value.py tests/unit/test_qre_research_cycle_router.py tests/unit/test_qre_routing_score.py -q
- python -m research.qre_routing_baseline_comparison --write
- python scripts/governance_lint.py
- python -m pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

## Handoff
- after merge, mark ADE-QRE-017P done with PR/merge evidence and make ADE-QRE-017Q ready
