### PR TITLE
ADE-QRE-017Q: add sampling baseline comparison

### DIFF
--- a/docs/governance/qre_sampling_baseline_comparison.md
+++ b/docs/governance/qre_sampling_baseline_comparison.md
@@ -1,0 +1,16 @@
+# QRE Sampling Baseline Comparison
+
+This surface compares the current read-only sampling ordering against simple deterministic baselines.
+
+| baseline_id | usefulness | signal_density_capture | oos_ready_count |
+| --- | --- | --- | --- |
+| current_sampling_score | 2.546 | 0.000 | 0 |
+| routing_score_order | 2.546 | 0.000 | 0 |
+| fifo_artifact_order | 2.477 | 0.000 | 0 |
+| lexical_behavior_family | 1.995 | 0.000 | 0 |
+| lexical_candidate_id | 1.995 | 0.000 | 0 |
+
+- source sampling status: `ready`
+- source joined status: `ready`
+
+Current sampling remains context only and does not authorize campaign execution.

--- a/reporting/qre_sampling_baseline_comparison.py
+++ b/reporting/qre_sampling_baseline_comparison.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any, Final
+
+
+REPORT_KIND: Final[str] = "qre_sampling_baseline_comparison"
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "ade-qre-017q-2026-06-26"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_sampling_baseline_comparison")
+LATEST_NAME: Final[str] = "latest.json"
+DOC_PATH: Final[Path] = Path("docs/governance/qre_sampling_baseline_comparison.md")
+WRITE_PREFIXES: Final[tuple[str, ...]] = (
+    "logs/qre_sampling_baseline_comparison/",
+    "docs/governance/qre_sampling_baseline_comparison.md",
+)
+DEFAULT_SAMPLING_PATH: Final[Path] = Path("logs/qre_sampling_readiness_from_basket/latest.json")
+DEFAULT_JOINED_PATH: Final[Path] = Path("logs/qre_routing_sampling_readiness/latest.json")
+BASELINE_IDS: Final[tuple[str, ...]] = (
+    "current_sampling_score",
+    "fifo_artifact_order",
+    "routing_score_order",
+    "lexical_candidate_id",
+    "lexical_behavior_family",
+)
+STATE_VALUES: Final[frozenset[str]] = frozenset({"ready", "blocked", "deferred", "fail_closed"})
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _read_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get(field)
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, dict)]
+
+
+def _validate_write_target(path: Path) -> None:
+    normalized = path.as_posix()
+    if not any(prefix in normalized for prefix in WRITE_PREFIXES):
+        raise ValueError(
+            f"qre_sampling_baseline_comparison: refusing write outside allowlist: {path!r}"
+        )
+
+
+def _source_status(payload: dict[str, Any] | None, *, required_field: str) -> dict[str, Any]:
+    if payload is None:
+        return {"status": "missing", "required_field": required_field, "fails_closed": True}
+    if not isinstance(payload.get(required_field), list):
+        return {"status": "invalid", "required_field": required_field, "fails_closed": True}
+    return {"status": "ready", "required_field": required_field, "fails_closed": False}
+
+
+def _max_oos_trades(counts: dict[str, Any]) -> int:
+    if int(counts.get("sufficient_oos_evidence") or 0) > 0:
+        return 12
+    if int(counts.get("insufficient_oos_trades") or 0) > 0:
+        return 5
+    return 0
+
+
+def _candidate_record(
+    row: dict[str, Any],
+    *,
+    index: int,
+    joined_by_candidate: dict[str, dict[str, Any]],
+    max_timeframe_count: int,
+) -> dict[str, Any]:
+    candidate_id = _text(row.get("candidate_id"))
+    joined = joined_by_candidate.get(candidate_id, {})
+    validation_counts = dict(row.get("validation_evidence_status_counts") or {})
+    timeframe_count = len(list(row.get("timeframes") or []))
+    signal_density_proxy = min(1.0, _max_oos_trades(validation_counts) / 12.0)
+    sample_adequacy_proxy = min(1.0, float(row.get("sampling_readiness_score_pct") or 0) / 100.0)
+    regime_coverage_proxy = min(1.0, timeframe_count / max(1, max_timeframe_count))
+    oos_readiness_proxy = (
+        1.0
+        if int(validation_counts.get("sufficient_oos_evidence") or 0) > 0
+        else 0.5
+        if bool((row.get("evidence_presence") or {}).get("oos_evidence_known"))
+        else 0.0
+    )
+    failure_discovery_proxy = (
+        1.0
+        if _text(row.get("sampling_readiness_state")) in {"blocked", "deferred"}
+        and bool(joined.get("sampling_reason_record_present"))
+        else 0.0
+    )
+    compute_efficiency_proxy = (
+        1.0
+        if bool(joined.get("shared_ready"))
+        else 0.6
+        if _text(row.get("sampling_readiness_state")) == "ready"
+        else 0.25
+    )
+    usefulness = max(
+        0.0,
+        min(
+            1.0,
+            0.25 * sample_adequacy_proxy
+            + 0.20 * (float(joined.get("routing_score_pct") or 0) / 100.0)
+            + 0.20 * signal_density_proxy
+            + 0.15 * oos_readiness_proxy
+            + 0.10 * regime_coverage_proxy
+            + 0.05 * failure_discovery_proxy
+            + 0.05 * compute_efficiency_proxy,
+        ),
+    )
+    return {
+        "candidate_id": candidate_id,
+        "behavior_family": _text(row.get("behavior_family")),
+        "sampling_state": _text(row.get("sampling_readiness_state")),
+        "sampling_score_pct": int(row.get("sampling_readiness_score_pct") or 0),
+        "routing_score_pct": int(joined.get("routing_score_pct") or row.get("routing_readiness_score_pct") or 0),
+        "artifact_index": index,
+        "timeframe_count": timeframe_count,
+        "signal_density_proxy": round(signal_density_proxy, 6),
+        "sample_adequacy_proxy": round(sample_adequacy_proxy, 6),
+        "regime_coverage_proxy": round(regime_coverage_proxy, 6),
+        "oos_readiness_proxy": round(oos_readiness_proxy, 6),
+        "failure_discovery_proxy": round(failure_discovery_proxy, 6),
+        "compute_efficiency_proxy": round(compute_efficiency_proxy, 6),
+        "decision_usefulness_proxy": round(usefulness, 6),
+        "shared_ready": bool(joined.get("shared_ready")),
+        "sampling_reason_record_present": bool(joined.get("sampling_reason_record_present")),
+        "provenance_refs": [
+            f"{DEFAULT_SAMPLING_PATH.as_posix()}#rows[{index}]",
+            *(
+                [f"{DEFAULT_JOINED_PATH.as_posix()}#candidate_examples_top[{joined.get('_row_index')}]"]
+                if "_row_index" in joined
+                else []
+            ),
+        ],
+    }
+
+
+def _ranked(rows: list[dict[str, Any]], baseline_id: str) -> list[dict[str, Any]]:
+    if baseline_id == "current_sampling_score":
+        return sorted(rows, key=lambda row: (-row["sampling_score_pct"], row["candidate_id"]))
+    if baseline_id == "fifo_artifact_order":
+        return sorted(rows, key=lambda row: row["artifact_index"])
+    if baseline_id == "routing_score_order":
+        return sorted(rows, key=lambda row: (-row["routing_score_pct"], row["candidate_id"]))
+    if baseline_id == "lexical_candidate_id":
+        return sorted(rows, key=lambda row: row["candidate_id"])
+    if baseline_id == "lexical_behavior_family":
+        return sorted(rows, key=lambda row: (row["behavior_family"], row["candidate_id"]))
+    raise KeyError(baseline_id)
+
+
+def _dcg(rows: list[dict[str, Any]]) -> float:
+    total = 0.0
+    for index, row in enumerate(rows, start=1):
+        total += float(row["decision_usefulness_proxy"]) / math.log2(index + 1)
+    return round(total, 6)
+
+
+def _baseline_summary(baseline_id: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    ranked = _ranked(rows, baseline_id)
+    top3 = ranked[:3]
+    return {
+        "baseline_id": baseline_id,
+        "ranking": [row["candidate_id"] for row in ranked],
+        "decision_usefulness_score": _dcg(ranked),
+        "top3_signal_density_capture": round(sum(float(row["signal_density_proxy"]) for row in top3), 6),
+        "top3_sample_adequacy_capture": round(sum(float(row["sample_adequacy_proxy"]) for row in top3), 6),
+        "top3_oos_ready_count": sum(float(row["oos_readiness_proxy"]) >= 1.0 for row in top3),
+        "top3_blocker_discovery_count": sum(float(row["failure_discovery_proxy"]) > 0.0 for row in top3),
+        "top3_mean_compute_efficiency": round(
+            sum(float(row["compute_efficiency_proxy"]) for row in top3) / max(1, len(top3)),
+            6,
+        ),
+        "comparison_scope": "context_only_not_execution_authority",
+    }
+
+
+def build_sampling_baseline_comparison(
+    *,
+    repo_root: Path | None = None,
+    sampling_report: dict[str, Any] | None = None,
+    joined_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    root = repo_root or Path.cwd()
+    sampling_report = sampling_report or _read_json(root / DEFAULT_SAMPLING_PATH)
+    joined_report = joined_report or _read_json(root / DEFAULT_JOINED_PATH)
+    source_status = {
+        "sampling_readiness_from_basket": _source_status(sampling_report, required_field="rows"),
+        "routing_sampling_readiness": _source_status(joined_report, required_field="candidate_examples_top"),
+    }
+    joined_rows = _read_rows(joined_report, "candidate_examples_top")
+    joined_by_candidate = {
+        _text(row.get("candidate_id")): {**row, "_row_index": index}
+        for index, row in enumerate(joined_rows)
+        if _text(row.get("candidate_id"))
+    }
+    sampling_rows = _read_rows(sampling_report, "rows")
+    max_timeframe_count = max((len(list(row.get("timeframes") or [])) for row in sampling_rows), default=1)
+    candidate_rows = [
+        _candidate_record(
+            row,
+            index=index,
+            joined_by_candidate=joined_by_candidate,
+            max_timeframe_count=max_timeframe_count,
+        )
+        for index, row in enumerate(sampling_rows)
+    ]
+    candidate_rows.sort(key=lambda row: row["candidate_id"])
+    baselines = [_baseline_summary(baseline_id, candidate_rows) for baseline_id in BASELINE_IDS]
+    baselines.sort(key=lambda row: (-float(row["decision_usefulness_score"]), row["baseline_id"]))
+    current = next(row for row in baselines if row["baseline_id"] == "current_sampling_score")
+    routing = next(row for row in baselines if row["baseline_id"] == "routing_score_order")
+    best = baselines[0]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "source_status": source_status,
+        "artifact_references": {
+            "sampling_readiness_from_basket": DEFAULT_SAMPLING_PATH.as_posix(),
+            "routing_sampling_readiness": DEFAULT_JOINED_PATH.as_posix(),
+        },
+        "candidate_rows": candidate_rows,
+        "baselines": baselines,
+        "summary": {
+            "candidate_count": len(candidate_rows),
+            "baseline_count": len(baselines),
+            "current_sampling_score": current["decision_usefulness_score"],
+            "best_baseline_id": best["baseline_id"],
+            "best_baseline_score": best["decision_usefulness_score"],
+            "current_minus_routing_order": round(
+                current["decision_usefulness_score"] - routing["decision_usefulness_score"],
+                6,
+            ),
+            "final_recommendation": "sampling_baseline_comparison_ready",
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_sampling": False,
+            "can_launch_campaign": False,
+            "can_register_strategy": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "context_only_not_authority": True,
+        },
+    }
+
+
+def render_doc(report: dict[str, Any]) -> str:
+    lines = [
+        "# QRE Sampling Baseline Comparison",
+        "",
+        "This surface compares the current read-only sampling ordering against simple deterministic baselines.",
+        "",
+        "| baseline_id | usefulness | signal_density_capture | oos_ready_count |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in report.get("baselines", []):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _text(row.get("baseline_id")),
+                    f"{float(row.get('decision_usefulness_score') or 0.0):.3f}",
+                    f"{float(row.get('top3_signal_density_capture') or 0.0):.3f}",
+                    str(int(row.get("top3_oos_ready_count") or 0)),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            f"- source sampling status: `{_text(((report.get('source_status') or {}).get('sampling_readiness_from_basket') or {}).get('status'))}`",
+            f"- source joined status: `{_text(((report.get('source_status') or {}).get('routing_sampling_readiness') or {}).get('status'))}`",
+            "",
+            "Current sampling remains context only and does not authorize campaign execution.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(report: dict[str, Any], *, repo_root: Path | None = None) -> dict[str, str]:
+    root = repo_root or Path.cwd()
+    latest = root / DEFAULT_OUTPUT_DIR / LATEST_NAME
+    doc = root / DOC_PATH
+    latest.parent.mkdir(parents=True, exist_ok=True)
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    for path in (latest, doc):
+        _validate_write_target(path)
+    tmp = latest.with_suffix(latest.suffix + ".tmp")
+    tmp.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, latest)
+    doc.write_text(render_doc(report), encoding="utf-8")
+    return {"latest": latest.relative_to(root).as_posix(), "doc": doc.relative_to(root).as_posix()}
+
+
+def read_status(*, repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or Path.cwd()
+    payload = _read_json(root / DEFAULT_OUTPUT_DIR / LATEST_NAME)
+    if not payload:
+        return {"status": "missing", "path": (DEFAULT_OUTPUT_DIR / LATEST_NAME).as_posix(), "fails_closed": True}
+    return {
+        "status": "ready",
+        "path": (DEFAULT_OUTPUT_DIR / LATEST_NAME).as_posix(),
+        "fails_closed": False,
+        "schema_version": payload.get("schema_version"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--status", action="store_true")
+    args = parser.parse_args(argv)
+    if args.status:
+        print(json.dumps(read_status(), indent=2, sort_keys=True))
+        return 0
+    report = build_sampling_baseline_comparison()
+    if args.write:
+        print(json.dumps(write_outputs(report), indent=2, sort_keys=True))
+        return 0
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_qre_sampling_baseline_comparison.py
+++ b/tests/unit/test_qre_sampling_baseline_comparison.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from reporting import qre_sampling_baseline_comparison as comparison
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _seed(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_sampling_readiness_from_basket" / "latest.json",
+        {
+            "rows": [
+                {
+                    "candidate_id": "cand_b",
+                    "behavior_family": "post_shock_stabilization",
+                    "sampling_readiness_state": "ready",
+                    "sampling_readiness_score_pct": 92,
+                    "routing_readiness_score_pct": 81,
+                    "timeframes": ["1d", "1w"],
+                    "evidence_presence": {"oos_evidence_known": True},
+                    "validation_evidence_status_counts": {"sufficient_oos_evidence": 1},
+                },
+                {
+                    "candidate_id": "cand_a",
+                    "behavior_family": "index_regime_filter",
+                    "sampling_readiness_state": "blocked",
+                    "sampling_readiness_score_pct": 40,
+                    "routing_readiness_score_pct": 78,
+                    "timeframes": ["1d"],
+                    "evidence_presence": {"oos_evidence_known": False},
+                    "validation_evidence_status_counts": {"insufficient_oos_trades": 1},
+                },
+                {
+                    "candidate_id": "cand_c",
+                    "behavior_family": "relative_strength",
+                    "sampling_readiness_state": "ready",
+                    "sampling_readiness_score_pct": 80,
+                    "routing_readiness_score_pct": 65,
+                    "timeframes": ["1d", "4h", "1w"],
+                    "evidence_presence": {"oos_evidence_known": True},
+                    "validation_evidence_status_counts": {"sufficient_oos_evidence": 1},
+                },
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_routing_sampling_readiness" / "latest.json",
+        {
+            "candidate_examples_top": [
+                {
+                    "candidate_id": "cand_b",
+                    "routing_score_pct": 81,
+                    "shared_ready": True,
+                    "sampling_reason_record_present": True,
+                },
+                {
+                    "candidate_id": "cand_a",
+                    "routing_score_pct": 78,
+                    "shared_ready": False,
+                    "sampling_reason_record_present": True,
+                },
+                {
+                    "candidate_id": "cand_c",
+                    "routing_score_pct": 65,
+                    "shared_ready": True,
+                    "sampling_reason_record_present": False,
+                },
+            ]
+        },
+    )
+
+
+def test_build_is_deterministic_and_current_sampling_beats_routing_order(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    left = comparison.build_sampling_baseline_comparison(repo_root=tmp_path)
+    right = comparison.build_sampling_baseline_comparison(repo_root=tmp_path)
+
+    assert left == right
+    assert left["report_kind"] == "qre_sampling_baseline_comparison"
+    assert left["summary"]["best_baseline_id"] == "current_sampling_score"
+    assert left["summary"]["current_minus_routing_order"] >= 0
+
+
+def test_baseline_vocab_and_source_status_are_closed(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    report = comparison.build_sampling_baseline_comparison(repo_root=tmp_path)
+
+    assert report["source_status"]["sampling_readiness_from_basket"]["status"] == "ready"
+    assert report["source_status"]["routing_sampling_readiness"]["status"] == "ready"
+    assert [row["baseline_id"] for row in report["baselines"]] == sorted(
+        [row["baseline_id"] for row in report["baselines"]],
+        key=lambda baseline_id: -next(
+            row["decision_usefulness_score"]
+            for row in report["baselines"]
+            if row["baseline_id"] == baseline_id
+        ),
+    )
+
+
+def test_missing_joined_surface_fails_closed(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    (tmp_path / "logs" / "qre_routing_sampling_readiness" / "latest.json").unlink()
+
+    report = comparison.build_sampling_baseline_comparison(repo_root=tmp_path)
+
+    assert report["source_status"]["routing_sampling_readiness"]["status"] == "missing"
+    assert all(row["shared_ready"] is False for row in report["candidate_rows"])
+
+
+def test_candidate_rows_keep_provenance_and_useful_proxies(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    report = comparison.build_sampling_baseline_comparison(repo_root=tmp_path)
+
+    row = report["candidate_rows"][0]
+    assert row["sampling_state"] in comparison.STATE_VALUES
+    assert row["provenance_refs"]
+    assert 0.0 <= row["decision_usefulness_proxy"] <= 1.0
+    assert 0.0 <= row["signal_density_proxy"] <= 1.0
+    assert 0.0 <= row["compute_efficiency_proxy"] <= 1.0
+
+
+def test_write_outputs_and_status_round_trip(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    report = comparison.build_sampling_baseline_comparison(repo_root=tmp_path)
+
+    paths = comparison.write_outputs(report, repo_root=tmp_path)
+
+    assert paths == {
+        "latest": "logs/qre_sampling_baseline_comparison/latest.json",
+        "doc": "docs/governance/qre_sampling_baseline_comparison.md",
+    }
+    assert "QRE Sampling Baseline Comparison" in (
+        tmp_path / paths["doc"]
+    ).read_text(encoding="utf-8")
+    assert comparison.read_status(repo_root=tmp_path) == {
+        "status": "ready",
+        "path": "logs/qre_sampling_baseline_comparison/latest.json",
+        "fails_closed": False,
+        "schema_version": "1.0",
+    }
+
+
+def test_source_is_read_only_and_preserves_frozen_contracts() -> None:
+    source = Path(comparison.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+
+    assert imported.isdisjoint({"requests", "socket", "httpx", "urllib", "subprocess"})
+    assert "research/research_latest.json" not in source
+    assert "research/strategy_matrix.csv" not in source
+    assert "\"can_launch_campaign\": False" in source


### PR DESCRIPTION
ADE-QRE-017Q

## Scope
- add a deterministic read-only sampling baseline comparison artifact
- compare current sampling ordering against simple deterministic baselines
- score signal-density, sample-adequacy, OOS-readiness, blocker-discovery, and compute-efficiency proxies from existing evidence
- add focused tests and canonical governance doc output

## Dependencies
- ADE-QRE-017P done

## Forbidden scope
- no hidden adaptive sampling selectors
- no campaign execution or routing mutation
- no strategy generation or registration
- no paper/shadow/live, broker, risk, or execution changes
- no frozen contract changes

## Validation
- python -m pytest tests/unit/test_qre_sampling_baseline_comparison.py tests/unit/test_qre_routing_sampling_readiness.py tests/unit/test_qre_sampling_readiness_from_basket.py tests/unit/test_qre_routing_baseline_comparison.py -q
- python -m reporting.qre_sampling_baseline_comparison --write
- python scripts/governance_lint.py
- python -m pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

## Handoff
- after merge, mark ADE-QRE-017Q done with PR/merge evidence and make ADE-QRE-017R ready
