### PR TITLE
docs: record ADE-QRE-017Q completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3274,7 +3274,8 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017Q`
 - title: Sampling Baseline Comparison.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #653, merge SHA `11ae16354e32096a7746311d1e396fee14c4c1df`; implementation added `reporting/qre_sampling_baseline_comparison.py`, canonical doc `docs/governance/qre_sampling_baseline_comparison.md`, and focused tests in `tests/unit/test_qre_sampling_baseline_comparison.py`; validation: `python -m pytest tests/unit/test_qre_sampling_baseline_comparison.py tests/unit/test_qre_routing_sampling_readiness.py tests/unit/test_qre_sampling_readiness_from_basket.py tests/unit/test_qre_routing_baseline_comparison.py -q` (`21 passed`), `python -m reporting.qre_sampling_baseline_comparison --write`, `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q` (`157 passed`), `python -m reporting.architecture_import_scan --format summary` (`forbidden_edge_count: 0`), `git diff --check`; checks green; post-merge validation passed on `main`; frozen contracts unchanged; protected/execution paths untouched; sampling comparison remained deterministic, context-only, and non-authoritative.
 - purpose: compare sampling against deterministic baselines for signal density,
   adequacy, coverage, and compute efficiency.
 - source document:
@@ -3297,7 +3298,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017R`
 - title: Dead-Zone and Duplicate Suppression Efficacy.
-- status: `blocked until ADE-QRE-017Q done`
+- status: `ready`
 - purpose: prove whether suppression prevents repeated low-value research.
 - source document:
   `docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -378,12 +378,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17o)
     item_17p = items["ADE-QRE-017P"]
     item_17q = items["ADE-QRE-017Q"]
+    item_17r = items["ADE-QRE-017R"]
     assert item_17p.status == "done"
     assert _done_evidence_is_complete(item_17p)
-    assert item_17q.status == "ready"
+    assert item_17q.status == "done"
+    assert _done_evidence_is_complete(item_17q)
+    assert item_17r.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017Q"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017R"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017q_after_017p_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017r_after_017q_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Q"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017R"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -117,7 +117,9 @@ def test_ade_qre_017_chain_selects_017q_after_017p_completion_evidence() -> None
     assert rows["ADE-QRE-017O"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017P"]["status"] == "done"
     assert rows["ADE-QRE-017P"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017Q"]["status"] == "ready"
+    assert rows["ADE-QRE-017Q"]["status"] == "done"
+    assert rows["ADE-QRE-017Q"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017R"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017q_after_017p_completion_evidence() -> None:
+def test_current_queue_selects_017r_after_017q_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Q"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017R"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -194,7 +194,9 @@ def test_current_queue_selects_017q_after_017p_completion_evidence() -> None:
     assert rows["ADE-QRE-017O"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017P"]["status"] == "done"
     assert rows["ADE-QRE-017P"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017Q"]["status"] == "ready"
+    assert rows["ADE-QRE-017Q"]["status"] == "done"
+    assert rows["ADE-QRE-017Q"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017R"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017Q completion evidence in the canonical queue
- promote ADE-QRE-017R to the next eligible ready item
- update queue lifecycle/audit tests to match the canonical queue state

## Scope
- ADE-QRE-017Q queue evidence only
- no implementation changes beyond queue lifecycle expectations

## Dependencies
- Depends on PR #653 being merged on main

## Forbidden Scope
- no changes to research/research_latest.json or research/strategy_matrix.csv
- no .claude changes
- no paper/shadow/live/broker/risk/execution activation

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- python -m pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv
