### PR TITLE
docs: record ADE-QRE-017R completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3298,7 +3298,8 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017R`
 - title: Dead-Zone and Duplicate Suppression Efficacy.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #656, merge SHA `aad09dc59713f528f7d166decd6625a7f14adeab`; implementation added `reporting/qre_suppression_efficacy.py`, canonical doc `docs/governance/qre_suppression_efficacy.md`, and focused tests in `tests/unit/test_qre_suppression_efficacy.py`; validation: `python -m pytest tests/unit/test_qre_suppression_efficacy.py tests/unit/test_qre_routing_baseline_comparison.py tests/unit/test_qre_sampling_baseline_comparison.py tests/unit/test_qre_prior_failure_retrieval.py -q` (`26 passed`), `python -m reporting.qre_suppression_efficacy --write`, `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q` (`157 passed`), `python -m reporting.architecture_import_scan --format summary` (`forbidden_edge_count: 0`), `git diff --check`; checks green; post-merge validation passed on `main`; frozen contracts unchanged; protected/execution paths untouched; suppression efficacy remained deterministic, read-only, context-only, and fail-closed where no same-population no-suppression baseline exists.
 - purpose: prove whether suppression prevents repeated low-value research.
 - source document:
   `docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md`.
@@ -3321,7 +3322,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017S`
 - title: Contradiction Graph and Hypothesis Lineage.
-- status: `blocked until ADE-QRE-017R done`
+- status: `ready`
 - purpose: produce a deterministic inspectable lineage from source through next
   action without introducing unnecessary graph infrastructure.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -379,14 +379,17 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     item_17p = items["ADE-QRE-017P"]
     item_17q = items["ADE-QRE-017Q"]
     item_17r = items["ADE-QRE-017R"]
+    item_17s = items["ADE-QRE-017S"]
     assert item_17p.status == "done"
     assert _done_evidence_is_complete(item_17p)
     assert item_17q.status == "done"
     assert _done_evidence_is_complete(item_17q)
-    assert item_17r.status == "ready"
+    assert item_17r.status == "done"
+    assert _done_evidence_is_complete(item_17r)
+    assert item_17s.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017R"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017S"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017r_after_017q_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017s_after_017r_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017R"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017S"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -119,7 +119,9 @@ def test_ade_qre_017_chain_selects_017r_after_017q_completion_evidence() -> None
     assert rows["ADE-QRE-017P"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017Q"]["status"] == "done"
     assert rows["ADE-QRE-017Q"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017R"]["status"] == "ready"
+    assert rows["ADE-QRE-017R"]["status"] == "done"
+    assert rows["ADE-QRE-017R"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017S"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017r_after_017q_completion_evidence() -> None:
+def test_current_queue_selects_017s_after_017r_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017R"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017S"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -196,7 +196,9 @@ def test_current_queue_selects_017r_after_017q_completion_evidence() -> None:
     assert rows["ADE-QRE-017P"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017Q"]["status"] == "done"
     assert rows["ADE-QRE-017Q"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017R"]["status"] == "ready"
+    assert rows["ADE-QRE-017R"]["status"] == "done"
+    assert rows["ADE-QRE-017R"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017S"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-017R done in the canonical ADE queue with PR #656 merge evidence
- advance ADE-QRE-017S to ready as the next eligible queue item
- update queue audit and admission tests to reflect the new canonical state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check