### PR TITLE
docs: record ADE-QRE-017S completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3322,7 +3322,8 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017S`
 - title: Contradiction Graph and Hypothesis Lineage.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #658, merge SHA `f2b28b44f3d73667792b6f0f1e5d0e226c100595`; implementation added `reporting/qre_contradiction_hypothesis_lineage.py`, canonical doc `docs/governance/qre_contradiction_hypothesis_lineage.md`, and focused tests in `tests/unit/test_qre_contradiction_hypothesis_lineage.py`; validation: `python -m pytest tests/unit/test_qre_contradiction_hypothesis_lineage.py tests/unit/test_qre_lineage_graph_v1.py tests/unit/test_qre_contradiction_staleness_intelligence.py tests/unit/test_qre_behavior_thesis_registry.py tests/unit/test_qre_behavior_thesis_evidence.py -q` (`27 passed`), `python -m reporting.qre_contradiction_hypothesis_lineage --write`, `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q` (`157 passed`), `python -m reporting.architecture_import_scan --format summary` (`forbidden_edge_count: 0`), `git diff --check`; checks green; post-merge validation passed on `main`; frozen contracts unchanged; protected/execution paths untouched; contradiction and hypothesis lineage remained deterministic, read-only, context-only, and explicit about orphan and missing-lineage states.
 - purpose: produce a deterministic inspectable lineage from source through next
   action without introducing unnecessary graph infrastructure.
 - source document:
@@ -3346,7 +3347,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017T`
 - title: Evidence Decay.
-- status: `blocked until ADE-QRE-017S done`
+- status: `ready`
 - purpose: implement freshness and decay semantics without rewriting history.
 - source document:
   `docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -380,16 +380,19 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     item_17q = items["ADE-QRE-017Q"]
     item_17r = items["ADE-QRE-017R"]
     item_17s = items["ADE-QRE-017S"]
+    item_17t = items["ADE-QRE-017T"]
     assert item_17p.status == "done"
     assert _done_evidence_is_complete(item_17p)
     assert item_17q.status == "done"
     assert _done_evidence_is_complete(item_17q)
     assert item_17r.status == "done"
     assert _done_evidence_is_complete(item_17r)
-    assert item_17s.status == "ready"
+    assert item_17s.status == "done"
+    assert _done_evidence_is_complete(item_17s)
+    assert item_17t.status == "ready"
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017S"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017T"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017s_after_017r_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017t_after_017s_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017S"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017T"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -121,7 +121,9 @@ def test_ade_qre_017_chain_selects_017s_after_017r_completion_evidence() -> None
     assert rows["ADE-QRE-017Q"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017R"]["status"] == "done"
     assert rows["ADE-QRE-017R"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017S"]["status"] == "ready"
+    assert rows["ADE-QRE-017S"]["status"] == "done"
+    assert rows["ADE-QRE-017S"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017T"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017s_after_017r_completion_evidence() -> None:
+def test_current_queue_selects_017t_after_017s_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017S"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017T"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -198,7 +198,9 @@ def test_current_queue_selects_017s_after_017r_completion_evidence() -> None:
     assert rows["ADE-QRE-017Q"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017R"]["status"] == "done"
     assert rows["ADE-QRE-017R"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017S"]["status"] == "ready"
+    assert rows["ADE-QRE-017S"]["status"] == "done"
+    assert rows["ADE-QRE-017S"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017T"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-017S done in the canonical ADE queue with PR #658 merge evidence
- advance ADE-QRE-017T to ready as the next eligible queue item
- update queue audit and admission tests to reflect the new canonical state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check