### PR TITLE
docs: record ADE-QRE-017T completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3347,7 +3347,8 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017T`
 - title: Evidence Decay.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #660, merge SHA `da72a1d7f9e86ad9d07455e1757679f27cb4039c`; implementation added `reporting/qre_evidence_decay.py`, canonical doc `docs/governance/qre_evidence_decay.md`, and focused tests in `tests/unit/test_qre_evidence_decay.py`; validation: `python -m pytest tests/unit/test_qre_evidence_decay.py tests/unit/test_qre_contradiction_hypothesis_lineage.py tests/unit/test_qre_contradiction_staleness_intelligence.py tests/unit/test_qre_behavior_thesis_evidence.py -q` (`18 passed`), `python -m reporting.qre_evidence_decay --write`, `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q` (`157 passed`), `python -m reporting.architecture_import_scan --format summary` (`forbidden_edge_count: 0`), `git diff --check`; checks green; post-merge validation passed on `main`; frozen contracts unchanged; protected/execution paths untouched; evidence decay remained deterministic, read-only, context-only, and fail-closed where freshness or lineage could not actually support readiness.
 - purpose: implement freshness and decay semantics without rewriting history.
 - source document:
   `docs/roadmap/qre_trusted_research_intelligence_roadmap_manifest.md`.
@@ -3370,7 +3371,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017U`
 - title: Operator Decision Report.
-- status: `blocked until ADE-QRE-017T done`
+- status: `ready`
 - purpose: produce one concise operator report per thesis with a closed final
   decision vocabulary and exactly one next action.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -389,10 +389,11 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17r)
     assert item_17s.status == "done"
     assert _done_evidence_is_complete(item_17s)
-    assert item_17t.status == "ready"
+    assert item_17t.status == "done"
+    assert _done_evidence_is_complete(item_17t)
     assert item_17y.status == "blocked until ADE-QRE-017X done"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017T"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017U"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,11 +83,11 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017t_after_017s_completion_evidence() -> None:
+def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017T"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017U"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -123,7 +123,9 @@ def test_ade_qre_017_chain_selects_017t_after_017s_completion_evidence() -> None
     assert rows["ADE-QRE-017R"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017S"]["status"] == "done"
     assert rows["ADE-QRE-017S"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017T"]["status"] == "ready"
+    assert rows["ADE-QRE-017T"]["status"] == "done"
+    assert rows["ADE-QRE-017T"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017U"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017t_after_017s_completion_evidence() -> None:
+def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017T"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017U"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -200,7 +200,9 @@ def test_current_queue_selects_017t_after_017s_completion_evidence() -> None:
     assert rows["ADE-QRE-017R"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017S"]["status"] == "done"
     assert rows["ADE-QRE-017S"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017T"]["status"] == "ready"
+    assert rows["ADE-QRE-017T"]["status"] == "done"
+    assert rows["ADE-QRE-017T"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017U"]["status"] == "ready"
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-017T done in the canonical queue with implementation PR and merge evidence
- advance the next eligible queue item from ADE-QRE-017T to ADE-QRE-017U
- update queue-audit tests to recognize the new canonical state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check