### PR TITLE
docs: record ADE-QRE-017W completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3447,7 +3447,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017W`
 - title: Campaign Portfolio and Signal-Density Planning.
-- status: `ready`
+- status: `done`
 - purpose: construct a bounded multi-hypothesis campaign portfolio using
   mechanistically distinct existing capabilities.
 - source document:
@@ -3465,13 +3465,28 @@ live, broker, risk, or execution work.
   - frozen contracts and runtime paths listed under `ADE-QRE-017`.
 - validation required:
   - portfolio is bounded, preregistration-ready, and signal-density planned.
+- completion evidence: PR #667, merge SHA
+  `e0a1befbb9d4be1489319114af6641fd7497421c`; implementation added
+  `reporting/qre_campaign_portfolio_plan.py`, canonical doc
+  `docs/governance/qre_campaign_portfolio_plan.md`, and focused tests in
+  `tests/unit/test_qre_campaign_portfolio_plan.py`; validation:
+  `python -m pytest tests/unit/test_qre_campaign_portfolio_plan.py tests/unit/test_qre_operator_decision_report.py tests/unit/test_qre_why_surfaces.py tests/unit/test_qre_suppression_efficacy.py tests/unit/test_qre_behavior_thesis_registry.py -q`
+  (`31 passed`), `python -m reporting.qre_campaign_portfolio_plan --write`,
+  `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`
+  (`157 passed`), `python -m reporting.architecture_import_scan --format summary`
+  (`forbidden_edge_count: 0`), `git diff --check`; checks green; post-merge
+  validation passed on `main`; frozen contracts unchanged; protected/execution
+  paths untouched; the deterministic portfolio artifact recorded `9` cells with
+  `0` preregistration-ready scopes, `5` blocked cells, `3`
+  insufficient-evidence cells, and `1` dead-zone exclusion, preserving the
+  fail-closed result without adding execution authority.
 - next dependency: `ADE-QRE-017X`.
 
 ### ADE-QRE-017X - Preregistered Campaign Manifest
 
 - queue id: `ADE-QRE-017X`
 - title: Preregistered Campaign Manifest.
-- status: `blocked until ADE-QRE-017W done`
+- status: `ready`
 - purpose: freeze hypotheses, data identities, windows, costs, criteria,
   controls, and vocabularies before campaign execution.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -395,8 +395,9 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
     assert items["ADE-QRE-017U"].status == "done"
     assert items["ADE-QRE-017V"].status == "done"
-    assert items["ADE-QRE-017W"].status == "ready"
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017W"]
+    assert items["ADE-QRE-017W"].status == "done"
+    assert _done_evidence_is_complete(items["ADE-QRE-017W"])
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017X"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -87,7 +87,7 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017W"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017X"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -127,7 +127,8 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     assert rows["ADE-QRE-017T"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017U"]["status"] == "done"
     assert rows["ADE-QRE-017V"]["status"] == "done"
-    assert rows["ADE-QRE-017W"]["status"] == "ready"
+    assert rows["ADE-QRE-017W"]["status"] == "done"
+    assert rows["ADE-QRE-017W"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017W"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017X"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -204,7 +204,8 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-017T"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017U"]["status"] == "done"
     assert rows["ADE-QRE-017V"]["status"] == "done"
-    assert rows["ADE-QRE-017W"]["status"] == "ready"
+    assert rows["ADE-QRE-017W"]["status"] == "done"
+    assert rows["ADE-QRE-017W"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- record canonical queue completion evidence for ADE-QRE-017W
- mark ADE-QRE-017W done and ADE-QRE-017X ready in the queue document
- preserve the fail-closed portfolio result with zero preregistration-ready cells

## Validation
- `python -m reporting.ade_queue_status_self_audit --no-write`
- queue audit summary shows `ADE-QRE-017W` done and `ADE-QRE-017X` as the next eligible ready item
- `python scripts/governance_lint.py`
- `git diff --check`