### PR TITLE
docs: record ADE-QRE-017X completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3486,7 +3486,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017X`
 - title: Preregistered Campaign Manifest.
-- status: `ready`
+- status: `done`
 - purpose: freeze hypotheses, data identities, windows, costs, criteria,
   controls, and vocabularies before campaign execution.
 - source document:
@@ -3505,13 +3505,15 @@ live, broker, risk, or execution work.
 - validation required:
   - campaign input identity is immutable or content-addressed where
     repository-native.
+- completion evidence:
+  - PR #669, merge SHA `e7cde4bb0b2fcb37853d08f14e3c0ec4681ab156`; implementation added `reporting/qre_preregistered_campaign_manifest.py`, focused tests in `tests/unit/test_qre_preregistered_campaign_manifest.py`, and canonical doc `docs/governance/qre_preregistered_campaign_manifest.md`; validation: `python -m pytest tests/unit/test_qre_preregistered_campaign_manifest.py tests/unit/test_qre_campaign_portfolio_plan.py tests/unit/test_qre_research_run_manifest.py -q` (`19 passed`), `python -m reporting.qre_preregistered_campaign_manifest --write`, `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q` (`157 passed`), `python -m reporting.architecture_import_scan --format summary` (`forbidden_edge_count: 0`), `git diff --check`; checks green; post-merge validation passed on `main`; frozen contracts unchanged; protected/execution paths untouched; deterministic manifest identity `qcm_70ac2732af273ff6`, replay identity `qcr_415cfd5a6a305b28`, `0` executable cells, and `9` blocked-appendix rows; final recommendation `no_executable_cells_available_for_preregistration`.
 - next dependency: `ADE-QRE-017Y`.
 
 ### ADE-QRE-017Y - Broad Campaign Execution
 
 - queue id: `ADE-QRE-017Y`
 - title: Broad Campaign Execution.
-- status: `blocked until ADE-QRE-017X done`
+- status: `ready`
 - purpose: execute the preregistered campaign through existing QRE research
   execution paths and persist full stage-level accounting.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -391,13 +391,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17s)
     assert item_17t.status == "done"
     assert _done_evidence_is_complete(item_17t)
-    assert item_17y.status == "blocked until ADE-QRE-017X done"
+    assert items["ADE-QRE-017X"].status == "done"
+    assert _done_evidence_is_complete(items["ADE-QRE-017X"])
+    assert item_17y.status == "ready"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
     assert items["ADE-QRE-017U"].status == "done"
     assert items["ADE-QRE-017V"].status == "done"
     assert items["ADE-QRE-017W"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017W"])
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017X"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017Y"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -87,7 +87,7 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017X"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Y"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -129,7 +129,9 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     assert rows["ADE-QRE-017V"]["status"] == "done"
     assert rows["ADE-QRE-017W"]["status"] == "done"
     assert rows["ADE-QRE-017W"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017Y"]["status"].startswith("blocked until ADE-QRE-017X done")
+    assert rows["ADE-QRE-017X"]["status"] == "done"
+    assert rows["ADE-QRE-017X"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017Y"]["status"] == "ready"
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017X"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Y"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -206,7 +206,9 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-017V"]["status"] == "done"
     assert rows["ADE-QRE-017W"]["status"] == "done"
     assert rows["ADE-QRE-017W"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017Y"]["status"] == "blocked until ADE-QRE-017X done"
+    assert rows["ADE-QRE-017X"]["status"] == "done"
+    assert rows["ADE-QRE-017X"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017Y"]["status"] == "ready"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017X completion evidence in the canonical queue
- advance the queue state so ADE-QRE-017Y becomes the next eligible item
- update queue-state tests to match the new canonical state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py::test_ade_qre_active_queue_lifecycle_is_consistent tests/unit/test_ade_qre_017_queue_admission.py::test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence tests/unit/test_ade_queue_status_self_audit.py::test_current_queue_selects_017u_after_017t_completion_evidence -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check