### PR TITLE
docs: record ADE-QRE-017Y completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3513,7 +3513,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017Y`
 - title: Broad Campaign Execution.
-- status: `ready`
+- status: `done`
 - purpose: execute the preregistered campaign through existing QRE research
   execution paths and persist full stage-level accounting.
 - source document:
@@ -3534,13 +3534,15 @@ live, broker, risk, or execution work.
   - campaign outputs distinguish completed, rejected, insufficient evidence,
     blocked, timed out, errored, and not executed.
   - negative campaigns remain valid when fully explained.
+- completion evidence:
+  - PR #671, merge SHA `a8fc4c9ba1deeb2e3fa9962f9bd5eee86b4dc0bd`; implementation added `reporting/qre_broad_campaign_execution.py`, focused tests in `tests/unit/test_qre_broad_campaign_execution.py`, and canonical doc `docs/governance/qre_broad_campaign_execution.md`; validation: `python -m pytest tests/unit/test_qre_broad_campaign_execution.py tests/unit/test_qre_preregistered_campaign_manifest.py tests/unit/test_qre_campaign_portfolio_plan.py tests/unit/test_qre_research_run_manifest.py -q` (`25 passed`), `python -m reporting.qre_broad_campaign_execution --write`, `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q` (`157 passed`), `python -m reporting.architecture_import_scan --format summary` (`forbidden_edge_count: 0`), `git diff --check`; checks green; post-merge validation passed on `main`; frozen contracts unchanged; protected/execution paths untouched; deterministic campaign execution identity `qcy_a638294b09fb8515` recorded `9` accounted rows with `0` executable cells, `4` blocked rows, `3` insufficient-evidence rows, `2` rejected rows, and fail-closed recommendation `broad_campaign_execution_fail_closed_no_executable_cells`.
 - next dependency: `ADE-QRE-017Z`.
 
 ### ADE-QRE-017Z - Funnel Diagnosis After Broad Campaign
 
 - queue id: `ADE-QRE-017Z`
 - title: Funnel Diagnosis After Broad Campaign.
-- status: `blocked until ADE-QRE-017Y done`
+- status: `ready`
 - purpose: diagnose the primary bottleneck after broad execution without
   changing criteria.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -393,13 +393,14 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17t)
     assert items["ADE-QRE-017X"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017X"])
-    assert item_17y.status == "ready"
+    assert item_17y.status == "done"
+    assert _done_evidence_is_complete(item_17y)
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
     assert items["ADE-QRE-017U"].status == "done"
     assert items["ADE-QRE-017V"].status == "done"
     assert items["ADE-QRE-017W"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017W"])
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017Y"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017Z"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -87,7 +87,7 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Y"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Z"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -131,7 +131,8 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     assert rows["ADE-QRE-017W"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017X"]["status"] == "done"
     assert rows["ADE-QRE-017X"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017Y"]["status"] == "ready"
+    assert rows["ADE-QRE-017Y"]["status"] == "done"
+    assert rows["ADE-QRE-017Y"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Y"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Z"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -208,7 +208,8 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-017W"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017X"]["status"] == "done"
     assert rows["ADE-QRE-017X"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017Y"]["status"] == "ready"
+    assert rows["ADE-QRE-017Y"]["status"] == "done"
+    assert rows["ADE-QRE-017Y"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017Y completion evidence in the canonical queue
- advance the queue state so ADE-QRE-017Z becomes the next eligible item
- update queue lifecycle and audit tests to pin the new canonical selector state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py::test_ade_qre_active_queue_lifecycle_is_consistent tests/unit/test_ade_qre_017_queue_admission.py::test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence tests/unit/test_ade_queue_status_self_audit.py::test_current_queue_selects_017u_after_017t_completion_evidence -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check