### PR TITLE
docs: record ADE-QRE-017Z completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3542,7 +3542,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017Z`
 - title: Funnel Diagnosis After Broad Campaign.
-- status: `ready`
+- status: `done`
 - purpose: diagnose the primary bottleneck after broad execution without
   changing criteria.
 - source document:
@@ -3559,13 +3559,30 @@ live, broker, risk, or execution work.
   - frozen contracts and runtime paths listed under `ADE-QRE-017`.
 - validation required:
   - exactly one primary bottleneck is selected from the allowed diagnosis set.
+- completion evidence:
+  - PR #673, merge SHA `9914934fe3d02d1ba114be4b04163021cdd1688d`;
+    implementation added `reporting/qre_broad_campaign_funnel_diagnosis.py`,
+    focused tests in
+    `tests/unit/test_qre_broad_campaign_funnel_diagnosis.py`, and canonical
+    doc `docs/governance/qre_broad_campaign_funnel_diagnosis.md`; validation:
+    `python -m pytest tests/unit/test_qre_broad_campaign_funnel_diagnosis.py tests/unit/test_qre_broad_campaign_execution.py tests/unit/test_qre_campaign_portfolio_plan.py tests/unit/test_qre_preregistered_campaign_manifest.py tests/unit/test_qre_funnel_threshold_audit.py -q`
+    (`26 passed`), `python -m reporting.qre_broad_campaign_funnel_diagnosis --write`,
+    `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`
+    (`157 passed`), `python -m reporting.architecture_import_scan --format summary`
+    (`forbidden_edge_count: 0`), `git diff --check`; checks green;
+    post-merge validation passed on `main`; frozen contracts unchanged;
+    protected/execution paths untouched; deterministic diagnosis identity
+    `qcz_d856dd708bbd3468` recorded `9` raw scopes, `0` eligible-ready cells,
+    primary bottleneck `evidence_completeness`, secondary bottlenecks
+    `null_controls` and `identity_ambiguity`, and retained exactly one
+    recommendation per criterion without recalibration.
 - next dependency: `ADE-QRE-017AA`.
 
 ### ADE-QRE-017AA - Single-Class Recalibration
 
 - queue id: `ADE-QRE-017AA`
 - title: Single-Class Recalibration.
-- status: `blocked until ADE-QRE-017Z done`
+- status: `ready`
 - purpose: allow one evidence-justified criterion-class change with a
   preregistered expected effect and regression conditions.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -395,12 +395,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(items["ADE-QRE-017X"])
     assert item_17y.status == "done"
     assert _done_evidence_is_complete(item_17y)
+    assert items["ADE-QRE-017Z"].status == "done"
+    assert _done_evidence_is_complete(items["ADE-QRE-017Z"])
+    assert items["ADE-QRE-017AA"].status == "ready"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
     assert items["ADE-QRE-017U"].status == "done"
     assert items["ADE-QRE-017V"].status == "done"
     assert items["ADE-QRE-017W"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017W"])
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017Z"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017AA"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -87,7 +87,7 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Z"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AA"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -133,6 +133,9 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     assert rows["ADE-QRE-017X"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017Y"]["status"] == "done"
     assert rows["ADE-QRE-017Y"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017Z"]["status"] == "done"
+    assert rows["ADE-QRE-017Z"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017AA"]["status"] == "ready"
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017Z"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AA"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -210,6 +210,9 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-017X"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017Y"]["status"] == "done"
     assert rows["ADE-QRE-017Y"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017Z"]["status"] == "done"
+    assert rows["ADE-QRE-017Z"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017AA"]["status"] == "ready"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017Z completion evidence in the canonical queue
- advance the queue state so ADE-QRE-017AA becomes the next eligible item
- update queue lifecycle and audit tests for the new canonical state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check