### PR TITLE
docs: record ADE-QRE-017AA completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3582,7 +3582,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017AA`
 - title: Single-Class Recalibration.
-- status: `ready`
+- status: `done`
 - purpose: allow one evidence-justified criterion-class change with a
   preregistered expected effect and regression conditions.
 - source document:
@@ -3602,13 +3602,29 @@ live, broker, risk, or execution work.
 - validation required:
   - if evidence does not justify recalibration, record rejection or
     insufficient evidence instead of fabricating a change.
+- completion evidence:
+  - PR #675, merge SHA `4553b6d8b7b09c24e979f110cc0312c04bf0a665`;
+    implementation added `reporting/qre_single_class_recalibration.py`,
+    focused tests in `tests/unit/test_qre_single_class_recalibration.py`, and
+    canonical doc `docs/governance/qre_single_class_recalibration.md`;
+    validation: `python -m pytest tests/unit/test_qre_single_class_recalibration.py tests/unit/test_qre_broad_campaign_funnel_diagnosis.py tests/unit/test_qre_broad_campaign_execution.py tests/unit/test_qre_preregistered_campaign_manifest.py -q`
+    (`20 passed`), `python -m reporting.qre_single_class_recalibration --write`,
+    `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`
+    (`157 passed`), `python -m reporting.architecture_import_scan --format summary`
+    (`forbidden_edge_count: 0`), `git diff --check`; checks green;
+    post-merge validation passed on `main`; frozen contracts unchanged;
+    protected/execution paths untouched; deterministic recalibration identity
+    `qraa_aba55d8715c34e84` recorded an evidence-backed no-change outcome with
+    decision `INSUFFICIENT_EVIDENCE`, `0` executable cells, `0`
+    eligibility-ready cells, `0` accepted OOS, `0` completed null controls,
+    and no threshold-distance evidence justifying a criterion change.
 - next dependency: `ADE-QRE-017AB`.
 
 ### ADE-QRE-017AB - Same-Input Replay
 
 - queue id: `ADE-QRE-017AB`
 - title: Same-Input Replay.
-- status: `blocked until ADE-QRE-017AA done`
+- status: `ready`
 - purpose: replay the campaign with the exact same inputs, permitting only the
   approved single criterion-class change.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -397,13 +397,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_17y)
     assert items["ADE-QRE-017Z"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017Z"])
-    assert items["ADE-QRE-017AA"].status == "ready"
+    assert items["ADE-QRE-017AA"].status == "done"
+    assert _done_evidence_is_complete(items["ADE-QRE-017AA"])
+    assert items["ADE-QRE-017AB"].status == "ready"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
     assert items["ADE-QRE-017U"].status == "done"
     assert items["ADE-QRE-017V"].status == "done"
     assert items["ADE-QRE-017W"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017W"])
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017AA"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017AB"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -87,7 +87,7 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AA"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AB"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -135,7 +135,9 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     assert rows["ADE-QRE-017Y"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017Z"]["status"] == "done"
     assert rows["ADE-QRE-017Z"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017AA"]["status"] == "ready"
+    assert rows["ADE-QRE-017AA"]["status"] == "done"
+    assert rows["ADE-QRE-017AA"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017AB"]["status"] == "ready"
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AA"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AB"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -212,7 +212,9 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-017Y"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017Z"]["status"] == "done"
     assert rows["ADE-QRE-017Z"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017AA"]["status"] == "ready"
+    assert rows["ADE-QRE-017AA"]["status"] == "done"
+    assert rows["ADE-QRE-017AA"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017AB"]["status"] == "ready"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017AA completion evidence in the canonical queue
- advance the queue state so ADE-QRE-017AB becomes the next eligible item
- update queue lifecycle and audit tests for the new canonical state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python -m reporting.ade_queue_status_self_audit --no-write
- python scripts/governance_lint.py
- git diff --check