### PR TITLE
docs: record ADE-QRE-017AB completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3624,7 +3624,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017AB`
 - title: Same-Input Replay.
-- status: `ready`
+- status: `done`
 - purpose: replay the campaign with the exact same inputs, permitting only the
   approved single criterion-class change.
 - source document:
@@ -3643,13 +3643,29 @@ live, broker, risk, or execution work.
   - frozen contracts and runtime paths listed under `ADE-QRE-017`.
 - validation required:
   - complete before/after funnel comparison is explicit.
+- completion evidence:
+  - PR #677, merge SHA `24e7fa9a18545a36a1c3b02e276609d4651609d5`;
+    implementation added `reporting/qre_same_input_replay.py`, focused tests in
+    `tests/unit/test_qre_same_input_replay.py`, and canonical doc
+    `docs/governance/qre_same_input_replay.md`; validation:
+    `python -m pytest tests/unit/test_qre_same_input_replay.py tests/unit/test_qre_single_class_recalibration.py tests/unit/test_qre_broad_campaign_funnel_diagnosis.py tests/unit/test_qre_broad_campaign_execution.py tests/unit/test_qre_preregistered_campaign_manifest.py -q`
+    (`24 passed`), `python -m reporting.qre_same_input_replay --write`,
+    `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`
+    (`157 passed`), `python -m reporting.architecture_import_scan --format summary`
+    (`forbidden_edge_count: 0`), `git diff --check`; checks green;
+    post-merge validation passed on `main`; frozen contracts unchanged;
+    protected/execution paths untouched; deterministic replay assessment
+    identity `qrab_566ba546394bb73d` recorded a no-change control confirmation
+    with decision `INSUFFICIENT_EVIDENCE`, unchanged manifest/replay/execution
+    identities, identical before/after funnel counts, and no new false-positive
+    surface.
 - next dependency: `ADE-QRE-017AC`.
 
 ### ADE-QRE-017AC - Repeated Independent OOS Evidence
 
 - queue id: `ADE-QRE-017AC`
 - title: Repeated Independent OOS Evidence.
-- status: `blocked until ADE-QRE-017AB done`
+- status: `ready`
 - purpose: run independent unseen OOS repetitions where existing data permits
   and record precise blockers otherwise.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -399,13 +399,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(items["ADE-QRE-017Z"])
     assert items["ADE-QRE-017AA"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017AA"])
-    assert items["ADE-QRE-017AB"].status == "ready"
+    assert items["ADE-QRE-017AB"].status == "done"
+    assert _done_evidence_is_complete(items["ADE-QRE-017AB"])
+    assert items["ADE-QRE-017AC"].status == "ready"
     assert item_17ad.status == "blocked until ADE-QRE-017AC done"
     assert items["ADE-QRE-017U"].status == "done"
     assert items["ADE-QRE-017V"].status == "done"
     assert items["ADE-QRE-017W"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017W"])
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017AB"]
+    assert _next_eligible_ready_item(items) == items["ADE-QRE-017AC"]
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -87,7 +87,7 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AB"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AC"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -137,7 +137,9 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     assert rows["ADE-QRE-017Z"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017AA"]["status"] == "done"
     assert rows["ADE-QRE-017AA"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017AB"]["status"] == "ready"
+    assert rows["ADE-QRE-017AB"]["status"] == "done"
+    assert rows["ADE-QRE-017AB"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017AC"]["status"] == "ready"
     assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
 
 

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AB"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AC"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -214,7 +214,9 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-017Z"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017AA"]["status"] == "done"
     assert rows["ADE-QRE-017AA"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017AB"]["status"] == "ready"
+    assert rows["ADE-QRE-017AB"]["status"] == "done"
+    assert rows["ADE-QRE-017AB"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017AC"]["status"] == "ready"
     assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017AB completion evidence after PR #677 merged
- advance the canonical queue so ADE-QRE-017AC is the next eligible ready item
- update queue audit tests to require the new canonical state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python scripts/governance_lint.py
- python -m pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary
- git diff --check