### PR TITLE
docs: record ADE-QRE-017AC completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -3665,7 +3665,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017AC`
 - title: Repeated Independent OOS Evidence.
-- status: `ready`
+- status: `done`
 - purpose: run independent unseen OOS repetitions where existing data permits
   and record precise blockers otherwise.
 - source document:
@@ -3684,13 +3684,32 @@ live, broker, risk, or execution work.
   - frozen contracts and runtime paths listed under `ADE-QRE-017`.
 - validation required:
   - independent evidence or the exact blocker is explicit per hypothesis.
+- completion evidence:
+  - PR #679, merge SHA `806e57e9ed01464fd249661434a9043d60267b3a`;
+    implementation added `reporting/qre_repeated_independent_oos.py`,
+    focused tests in `tests/unit/test_qre_repeated_independent_oos.py`, and
+    canonical doc `docs/governance/qre_repeated_independent_oos.md`;
+    validation:
+    `python -m pytest tests/unit/test_qre_repeated_independent_oos.py tests/unit/test_qre_same_input_replay.py tests/unit/test_qre_single_class_recalibration.py tests/unit/test_qre_broad_campaign_funnel_diagnosis.py tests/unit/test_qre_broad_campaign_execution.py tests/unit/test_qre_preregistered_campaign_manifest.py -q`
+    (`28 passed`), `python -m reporting.qre_repeated_independent_oos --write`,
+    `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`
+    (`157 passed`), `python -m reporting.architecture_import_scan --format summary`
+    (`forbidden_edge_count: 0`), `git diff --check`; checks green;
+    post-merge validation passed on `main`; frozen contracts unchanged;
+    protected/execution paths untouched; deterministic independent OOS identity
+    `qrao_f32f6f503b9d60f5` recorded an evidence-backed
+    `INSUFFICIENT_EVIDENCE` outcome with `0` supported-for-review hypotheses,
+    `0` independent-ready hypotheses, `6` theses blocked before campaign
+    lineage, and the only campaign-backed thesis (`trend_pullback_v1`) already
+    fail-closed rejected after two consumed OOS windows, `0` accepted OOS, and
+    incomplete null controls.
 - next dependency: `ADE-QRE-017AD`.
 
 ### ADE-QRE-017AD - Synthesis-Readiness Review
 
 - queue id: `ADE-QRE-017AD`
 - title: Synthesis-Readiness Review.
-- status: `blocked until ADE-QRE-017AC done`
+- status: `ready`
 - purpose: produce the review-only final synthesis-readiness outcome without
   implementing synthesis.
 - source document:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -401,13 +401,14 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(items["ADE-QRE-017AA"])
     assert items["ADE-QRE-017AB"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017AB"])
-    assert items["ADE-QRE-017AC"].status == "ready"
-    assert item_17ad.status == "blocked until ADE-QRE-017AC done"
+    assert items["ADE-QRE-017AC"].status == "done"
+    assert _done_evidence_is_complete(items["ADE-QRE-017AC"])
+    assert item_17ad.status == "ready"
     assert items["ADE-QRE-017U"].status == "done"
     assert items["ADE-QRE-017V"].status == "done"
     assert items["ADE-QRE-017W"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017W"])
-    assert _next_eligible_ready_item(items) == items["ADE-QRE-017AC"]
+    assert _next_eligible_ready_item(items) == item_17ad
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -87,7 +87,7 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AC"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AD"
     assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -139,8 +139,9 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     assert rows["ADE-QRE-017AA"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017AB"]["status"] == "done"
     assert rows["ADE-QRE-017AB"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017AC"]["status"] == "ready"
-    assert rows["ADE-QRE-017AD"]["status"].startswith("blocked until ADE-QRE-017AC done")
+    assert rows["ADE-QRE-017AC"]["status"] == "done"
+    assert rows["ADE-QRE-017AC"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017AD"]["status"] == "ready"
 
 
 def test_ade_qre_017_queue_keeps_synthesis_blocked_and_protected_scope_explicit() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -119,7 +119,7 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AC"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AD"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -216,8 +216,9 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-017AA"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017AB"]["status"] == "done"
     assert rows["ADE-QRE-017AB"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017AC"]["status"] == "ready"
-    assert rows["ADE-QRE-017AD"]["status"] == "blocked until ADE-QRE-017AC done"
+    assert rows["ADE-QRE-017AC"]["status"] == "done"
+    assert rows["ADE-QRE-017AC"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-017AD"]["status"] == "ready"
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
## Summary
- record ADE-QRE-017AC completion evidence after PR #679 merged
- advance the canonical queue so ADE-QRE-017AD is the next eligible ready item
- update queue audit tests to require the final canonical state for this run

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py -q
- python scripts/governance_lint.py
- python -m pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary
- git diff --check
- python -c " from reporting import ade_queue_status_self_audit as audit