### PR TITLE
docs: record ADE-QRE-017AD completion evidence

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2680,7 +2680,27 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017`
 - title: Trusted Research Intelligence Maturity Program.
-- status: `blocked until ADE-QRE-017AD done`
+- status: `done`
+- completion evidence:
+  - PR #681, merge SHA `be29ccaf0d9cab898194bb5cfe81f190af8a8c5f`;
+    final review-only synthesis-readiness implementation added
+    `reporting/qre_synthesis_readiness_review.py`, focused tests in
+    `tests/unit/test_qre_synthesis_readiness_review.py`, and canonical doc
+    `docs/governance/qre_synthesis_readiness_review.md`; validation:
+    `python -m pytest tests/unit/test_qre_synthesis_readiness_review.py tests/unit/test_qre_repeated_independent_oos.py tests/unit/test_qre_same_input_replay.py tests/unit/test_qre_single_class_recalibration.py tests/unit/test_qre_broad_campaign_funnel_diagnosis.py tests/unit/test_qre_broad_campaign_execution.py tests/unit/test_qre_preregistered_campaign_manifest.py -q`
+    (`32 passed`), `python -m reporting.qre_synthesis_readiness_review --write`,
+    `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`
+    (`157 passed`), `python -m reporting.architecture_import_scan --format summary`
+    (`forbidden_edge_count: 0`), `git diff --check`; checks green;
+    post-merge validation passed on `main`; frozen contracts unchanged;
+    protected/execution paths untouched; deterministic synthesis-readiness
+    identity `qrsr_1ca565566a3c96e3` recorded final outcome
+    `CONTINUE_BLOCKED`, confirmed `0` supported-for-review hypotheses, `0`
+    accepted OOS, `0` independent-ready hypotheses, `0` completed null
+    controls, six blocked theses missing campaign lineage, one rejected thesis
+    (`trend_pullback_v1`) after two consumed OOS windows, and exact next
+    permitted action
+    `launch_separate_remediation_program_for_lineage_identity_controls_evidence_and_capacity_before_any_synthesis_design_review`.
 - purpose: govern the full scaffold-to-trust maturity program selected by
   `ADE-QRE-016H` without collapsing the work into one giant implementation
   release.
@@ -2714,7 +2734,7 @@ live, broker, risk, or execution work.
   - parent stays non-executable and is completed only after `ADE-QRE-017A`
     through `ADE-QRE-017AD` are done with PR, merge, CI, and post-merge
     evidence recorded.
-- next dependency: `ADE-QRE-017A`.
+- next dependency: none.
 
 ### ADE-QRE-017A - Baseline Reconciliation and Maturity Matrix
 
@@ -3709,7 +3729,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-017AD`
 - title: Synthesis-Readiness Review.
-- status: `ready`
+- status: `done`
 - purpose: produce the review-only final synthesis-readiness outcome without
   implementing synthesis.
 - source document:
@@ -3731,4 +3751,29 @@ live, broker, risk, or execution work.
     `INSUFFICIENT_EVIDENCE`.
   - synthesis remains blocked unless a separate later design review is
     explicitly selected.
+- completion evidence:
+  - PR #681, merge SHA `be29ccaf0d9cab898194bb5cfe81f190af8a8c5f`;
+    implementation added `reporting/qre_synthesis_readiness_review.py`,
+    focused tests in `tests/unit/test_qre_synthesis_readiness_review.py`, and
+    canonical doc `docs/governance/qre_synthesis_readiness_review.md`;
+    validation:
+    `python -m pytest tests/unit/test_qre_synthesis_readiness_review.py tests/unit/test_qre_repeated_independent_oos.py tests/unit/test_qre_same_input_replay.py tests/unit/test_qre_single_class_recalibration.py tests/unit/test_qre_broad_campaign_funnel_diagnosis.py tests/unit/test_qre_broad_campaign_execution.py tests/unit/test_qre_preregistered_campaign_manifest.py -q`
+    (`32 passed`), `python -m reporting.qre_synthesis_readiness_review --write`,
+    `python scripts/governance_lint.py`, `python -m pytest tests/architecture -q`
+    (`157 passed`), `python -m reporting.architecture_import_scan --format summary`
+    (`forbidden_edge_count: 0`), `git diff --check`; checks green;
+    post-merge validation passed on `main`; frozen contracts unchanged;
+    protected/execution paths untouched; deterministic synthesis-readiness
+    identity `qrsr_1ca565566a3c96e3` recorded final readiness outcome
+    `CONTINUE_BLOCKED` with failed mandatory gates
+    `evidence_density_maturity`, `reason_record_completeness`,
+    `suppression_usefulness`, `identity_readiness`,
+    `campaign_lineage_completeness`, `hypothesis_lineage_completeness`,
+    `reproducibility`, `evidence_freshness`, `accepted_oos`,
+    `repeated_independent_oos`, `null_control_completeness`,
+    `validation_completeness`, `operator_decision_report_completeness`, and
+    `evidence_authority_ambiguity_absent`; only `routing_usefulness`,
+    `sampling_usefulness`, `source_quality`, `data_readiness`,
+    `contradiction_visibility`, and `trading_authority_leakage_absent`
+    satisfied.
 - next dependency: none.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -326,9 +326,10 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(item_16h)
     assert _auto_selectable_status(item_16h) is False
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert item_17.status == "blocked until ADE-QRE-017AD done"
+    assert item_17.status == "done"
     assert item_17.dependencies == ("ADE-QRE-016H",)
     assert _dependencies_done(item_17, items) is True
+    assert _done_evidence_is_complete(item_17)
     assert _auto_selectable_status(item_17) is False
     assert item_17a.status == "done"
     assert item_17a.dependencies == ("ADE-QRE-016H",)
@@ -403,12 +404,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _done_evidence_is_complete(items["ADE-QRE-017AB"])
     assert items["ADE-QRE-017AC"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017AC"])
-    assert item_17ad.status == "ready"
+    assert item_17ad.status == "done"
+    assert item_17ad.dependencies == ("ADE-QRE-017AC",)
+    assert _dependencies_done(item_17ad, items) is True
+    assert _done_evidence_is_complete(item_17ad)
     assert items["ADE-QRE-017U"].status == "done"
     assert items["ADE-QRE-017V"].status == "done"
     assert items["ADE-QRE-017W"].status == "done"
     assert _done_evidence_is_complete(items["ADE-QRE-017W"])
-    assert _next_eligible_ready_item(items) == item_17ad
+    assert _next_eligible_ready_item(items) is None
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_qre_017_queue_admission.py
+++ b/tests/unit/test_ade_qre_017_queue_admission.py
@@ -83,12 +83,13 @@ def test_ade_qre_017_dependencies_reference_existing_queue_items() -> None:
             assert dep in known, (item_id, dep)
 
 
-def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None:
+def test_ade_qre_017_chain_is_complete_after_017ad_completion_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-06-25T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AD"
-    assert rows["ADE-QRE-017"]["status"].startswith("blocked until ADE-QRE-017AD done")
+    assert snap["summary"]["next_eligible_ready_item"] is None
+    assert rows["ADE-QRE-017"]["status"] == "done"
+    assert rows["ADE-QRE-017"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017B"]["status"] == "done"
     assert rows["ADE-QRE-017C"]["status"] == "done"
@@ -141,7 +142,8 @@ def test_ade_qre_017_chain_selects_017u_after_017t_completion_evidence() -> None
     assert rows["ADE-QRE-017AB"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017AC"]["status"] == "done"
     assert rows["ADE-QRE-017AC"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017AD"]["status"] == "ready"
+    assert rows["ADE-QRE-017AD"]["status"] == "done"
+    assert rows["ADE-QRE-017AD"]["done_evidence"]["complete"] is True
 
 
 def test_ade_qre_017_queue_keeps_synthesis_blocked_and_protected_scope_explicit() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
+def test_current_queue_marks_017_program_complete_after_017ad_evidence() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-017AD"
+    assert snap["summary"]["next_eligible_ready_item"] is None
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -164,7 +164,8 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-016H"]["status"] == "done"
     assert rows["ADE-QRE-016H"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-016H"]["auto_selectable"] is False
-    assert rows["ADE-QRE-017"]["status"] == "blocked until ADE-QRE-017AD done"
+    assert rows["ADE-QRE-017"]["status"] == "done"
+    assert rows["ADE-QRE-017"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017A"]["status"] == "done"
     assert rows["ADE-QRE-017A"]["auto_selectable"] is False
     assert rows["ADE-QRE-017B"]["status"] == "done"
@@ -218,7 +219,8 @@ def test_current_queue_selects_017u_after_017t_completion_evidence() -> None:
     assert rows["ADE-QRE-017AB"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-017AC"]["status"] == "done"
     assert rows["ADE-QRE-017AC"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-017AD"]["status"] == "ready"
+    assert rows["ADE-QRE-017AD"]["status"] == "done"
+    assert rows["ADE-QRE-017AD"]["done_evidence"]["complete"] is True
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-017AD done in the canonical ADE queue
- mark the parent ADE-QRE-017 program done now that 017A through 017AD are evidenced
- update queue lifecycle and audit tests for the terminal 017 state

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_ade_qre_017_queue_admission.py tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_qre_synthesis_readiness_review.py -q
- python -m pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary
- python scripts/governance_lint.py
- git diff --check