### PR TITLE
fix(qre): align A26 monitoring with completed cycles

### DIFF
--- a/packages/qre_research/autonomous_orchestration.py
+++ b/packages/qre_research/autonomous_orchestration.py
@@ -1697,9 +1697,24 @@ def _compute_kpis(
     work_items: dict[str, Any],
     cycle_ledger: list[dict[str, Any]],
     oos_budget: dict[str, Any],
+    pre_oos_decisions: dict[str, Any],
 ) -> dict[str, Any]:
     executed = [row for row in cycle_ledger if str(row.get("execution_status") or "") == "completed"]
     final_decisions = 1 if portfolio.get("executed_campaign") else 0
+    latest_cycle_next_action = next(
+        (
+            str(row.get("next_action") or "")
+            for row in reversed(cycle_ledger)
+            if str(row.get("execution_status") or "") == "completed"
+            and str(row.get("next_action") or "")
+        ),
+        "",
+    )
+    deferred_by_pre_oos_gate = sum(
+        1
+        for row in pre_oos_decisions.get("rows", [])
+        if str(row.get("outcome") or "").startswith("REJECT_")
+    )
     return {
         "executive_summary": {
             "autonomous_loop_state": "active" if cycle_ledger else "idle",
@@ -1715,7 +1730,15 @@ def _compute_kpis(
                     if str(row.get("primary_blocker") or "")
                 }
             ),
-            "top_next_actions": [str(row.get("next_action") or "") for row in portfolio.get("strategy_rows", [])],
+            "top_next_actions": (
+                [latest_cycle_next_action]
+                if latest_cycle_next_action
+                else [
+                    str(row.get("next_action") or "")
+                    for row in portfolio.get("strategy_rows", [])
+                    if str(row.get("next_action") or "")
+                ]
+            ),
             "operator_attention_required": bool(
                 any(
                     str(row.get("primary_blocker") or "") in {"cache_row_missing", "oos_sample_size", "usable_history_below_minimum_policy_span"}
@@ -1750,7 +1773,7 @@ def _compute_kpis(
             "consumed_oos_without_conclusive_decision": int(oos_budget.get("summary", {}).get("consumed") or 0),
             "conclusive_decisions_per_independent_oos_window_consumed": 0.0,
             "inconclusive_campaigns_per_oos_window_consumed": 1.0 if int(oos_budget.get("summary", {}).get("consumed") or 0) else 0.0,
-            "campaigns_deferred_by_pre_oos_gate": 0,
+            "campaigns_deferred_by_pre_oos_gate": deferred_by_pre_oos_gate,
         },
     }
 
@@ -1806,7 +1829,16 @@ def generate_daily_report(
     write_outputs: bool = True,
 ) -> dict[str, Any]:
     report_date = report_date or _today_utc()
-    kpis = _compute_kpis(portfolio=portfolio, work_items=work_items, cycle_ledger=cycle_ledger, oos_budget=oos_budget)
+    pre_oos_decisions = _read_json(
+        _scoped_path(PRE_OOS_PATH, repo_root=repo_root)
+    ) or {"rows": []}
+    kpis = _compute_kpis(
+        portfolio=portfolio,
+        work_items=work_items,
+        cycle_ledger=cycle_ledger,
+        oos_budget=oos_budget,
+        pre_oos_decisions=pre_oos_decisions,
+    )
     next_24h_rows = [
         {
             "work_item_id": str(row.get("work_item_id") or ""),
@@ -1983,6 +2015,11 @@ def build_status_artifact(
     latest_daily_report: dict[str, Any],
     cycle_ledger: list[dict[str, Any]],
 ) -> dict[str, Any]:
+    completed_work_items = {
+        str(row.get("selected_work_item") or "")
+        for row in cycle_ledger
+        if str(row.get("execution_status") or "") == "completed"
+    }
     active_jobs = [
         {
             "work_item_id": work_id,
@@ -1990,6 +2027,7 @@ def build_status_artifact(
         }
         for group in throughput_schedule.get("groups", [])[:1]
         for work_id in group.get("work_item_ids", [])
+        if str(work_id) not in completed_work_items
     ]
     payload = {
         "schema_version": SCHEMA_VERSION,

--- a/tests/unit/test_qre_autonomous_orchestration.py
+++ b/tests/unit/test_qre_autonomous_orchestration.py
@@ -319,6 +319,89 @@ def test_daily_report_generation_is_idempotent_for_same_inputs(orchestration_rep
     assert first["health"] == second["health"]
 
 
+
+def test_daily_report_uses_completed_cycle_next_action_and_counts_pre_oos_rejects(
+    orchestration_repo: Path,
+) -> None:
+    config = ao.default_operations_config()
+    portfolio = ao.build_unified_portfolio(repo_root=orchestration_repo)
+    actions = ao.build_typed_next_actions(portfolio=portfolio, config=config)
+    work_items = ao.admit_work_items(actions=actions, config=config)
+    oos_budget = ao.build_oos_budget(
+        repo_root=orchestration_repo,
+        portfolio=portfolio,
+        config=config,
+    )
+    kpis = ao._compute_kpis(
+        portfolio=portfolio,
+        work_items=work_items,
+        cycle_ledger=[
+            {
+                "execution_status": "completed",
+                "next_action": "request_replacement_hypothesis",
+            }
+        ],
+        oos_budget=oos_budget,
+        pre_oos_decisions={
+            "rows": [
+                {
+                    "outcome": "REJECT_EXPECTED_SAMPLE_TOO_LOW",
+                }
+            ]
+        },
+    )
+
+    assert kpis["executive_summary"]["top_next_actions"] == [
+        "request_replacement_hypothesis"
+    ]
+    assert (
+        kpis["evidence_quality"]["campaigns_deferred_by_pre_oos_gate"]
+        == 1
+    )
+
+
+def test_status_excludes_completed_scheduled_work_item(
+    orchestration_repo: Path,
+) -> None:
+    config = ao.default_operations_config()
+    portfolio = ao.build_unified_portfolio(repo_root=orchestration_repo)
+    actions = ao.build_typed_next_actions(portfolio=portfolio, config=config)
+    work_items = ao.admit_work_items(actions=actions, config=config)
+    oos_budget = ao.build_oos_budget(
+        repo_root=orchestration_repo,
+        portfolio=portfolio,
+        config=config,
+    )
+    completed_work_item = work_items["rows"][0]["work_item_id"]
+
+    status = ao.build_status_artifact(
+        config=config,
+        portfolio=portfolio,
+        work_items=work_items,
+        throughput_schedule={
+            "groups": [
+                {
+                    "group_id": "qrg_fixture",
+                    "work_item_ids": [completed_work_item],
+                }
+            ]
+        },
+        oos_budget=oos_budget,
+        alerts_payload={"rows": []},
+        latest_daily_report={"daily_report_identity": "qrdr_fixture"},
+        cycle_ledger=[
+            {
+                "execution_status": "completed",
+                "selected_work_item": completed_work_item,
+                "progress_status": "IRREDUCIBLE_BLOCKER_PROVEN",
+            }
+        ],
+    )
+
+    assert status["active_jobs"] == []
+    assert status["next_selected_work"] == ""
+
+
 def test_pause_resume_payloads_are_deterministic(orchestration_repo: Path) -> None:
     paused = ao.set_pause_state(repo_root=orchestration_repo, paused=True, write_outputs=False)
     resumed = ao.set_pause_state(repo_root=orchestration_repo, paused=False, write_outputs=False)


### PR DESCRIPTION
## Summary

Repairs monitoring consistency after an ADE-QRE-026 autonomous cycle.

- derives daily next actions from the latest completed cycle
- counts actual pre-OOS gate rejections
- excludes completed scheduled work from active status
- prevents completed work from remaining 
ext_selected_work
- adds regression coverage for KPI and status behavior

## Evidence

- python -m ruff check packages/qre_research/autonomous_orchestration.py tests/unit/test_qre_autonomous_orchestration.py
- python -m pytest tests/unit/test_qre_autonomous_orchestration.py -q
- 14 tests passed
- frozen and protected surfaces unchanged
- no generated runtime artifacts committed

## Safety

No paper, shadow, live, broker, risk, execution, capital, or deployment behavior changed.