### PR TITLE
fix: persist orchestration lifecycle sequencing

### DIFF
--- a/packages/qre_research/autonomous_orchestration.py
+++ b/packages/qre_research/autonomous_orchestration.py
@@ -922,7 +922,7 @@ def admit_work_items(
             "EXPAND_DATA_CAPACITY": "DATA_CAPACITY_EXPANSION",
             "EXPAND_OOS_CAPACITY": "OOS_CAPACITY_EXPANSION",
             "MATERIALIZE_DATA": "DATA_CAPACITY_EXPANSION",
-            "GENERATE_HYPOTHESIS": "EXISTING_PIPELINE_REPLAY",
+            "GENERATE_HYPOTHESIS": "DEVELOPMENT_WORK_PACKAGE",
             "EXECUTE_PREREGISTERED_CAMPAIGN": "PREREGISTERED_CAMPAIGN_EXECUTION",
             "CREATE_PREREGISTRATION": "CAMPAIGN_PREREGISTRATION",
             "REASSESS_READINESS": "EXISTING_PIPELINE_REPLAY",
@@ -1517,11 +1517,32 @@ def execute_work_item(
             work_item=work_item,
         )
     elif work_class == "DEVELOPMENT_WORK_PACKAGE":
-        execution_result = _generate_work_package(
+        work_package = _generate_work_package(
             repo_root=repo_root,
             work_item=work_item,
             write_outputs=write_outputs,
         )
+        execution_result = {
+            "execution_identity": _content_id(
+                "qrx",
+                {
+                    "work_item_id": work_item["work_item_id"],
+                    "work_package_id": work_package["work_package_id"],
+                },
+            ),
+            "work_item_id": str(work_item.get("work_item_id") or ""),
+            "status": "completed",
+            "progress_status": "DOWNSTREAM_BLOCKER_EXPOSED",
+            "next_action": "implement_bounded_hypothesis_generation",
+            "blocker_delta": ["hypothesis_generation_capability_missing"],
+            "findings": [work_package],
+            "provenance": [
+                (
+                    "generated_research/orchestration/work_packages/"
+                    f"{work_package['work_package_id']}.json"
+                )
+            ],
+        }
     else:
         execution_result = {
             "execution_identity": _content_id("qrx", {"work_item": work_item["work_item_id"], "status": "deferred"}),
@@ -2187,11 +2208,55 @@ def _run_one_cycle(
     write_outputs: bool,
     report_date: str | None,
 ) -> dict[str, Any]:
+    existing_cycle_rows = list(
+        (
+            _read_json(
+                _scoped_path(CYCLE_LEDGER_PATH, repo_root=repo_root)
+            )
+            or {}
+        ).get("rows")
+        or []
+    )
+    existing_invocation_rows = list(
+        (
+            _read_json(
+                _scoped_path(INVOCATION_LEDGER_PATH, repo_root=repo_root)
+            )
+            or {}
+        ).get("rows")
+        or []
+    )
+
+    terminal_validation_outcomes = {
+        "VALIDATED_AND_COMPOSED",
+        "NO_CAUSAL_PROGRESS",
+        "EXTERNAL_BOUNDARY",
+    }
+    terminal_work_item_ids = {
+        str(row.get("selected_work_item") or "")
+        for row in existing_cycle_rows
+        if str((row.get("validation") or {}).get("outcome") or "")
+        in terminal_validation_outcomes
+    }
+    terminal_work_item_ids.discard("")
+
     portfolio = build_unified_portfolio(repo_root=repo_root)
     actions = build_typed_next_actions(portfolio=portfolio, config=config)
     work_items = admit_work_items(actions=actions, config=config)
-    dependency_graph = build_dependency_graph(portfolio=portfolio, work_items=work_items)
-    throughput_schedule = build_throughput_schedule(work_items=work_items, config=config)
+    work_items = dict(work_items)
+    work_items["rows"] = [
+        row
+        for row in work_items.get("rows", [])
+        if str(row.get("work_item_id") or "") not in terminal_work_item_ids
+    ]
+    dependency_graph = build_dependency_graph(
+        portfolio=portfolio,
+        work_items=work_items,
+    )
+    throughput_schedule = build_throughput_schedule(
+        work_items=work_items,
+        config=config,
+    )
     campaign_schedule = build_campaign_schedule(portfolio=portfolio, config=config)
     oos_budget = build_oos_budget(repo_root=repo_root, portfolio=portfolio, config=config)
     pre_oos_decisions = {
@@ -2202,11 +2267,9 @@ def _run_one_cycle(
         "pre_oos_identity": _content_id("qrpo", _validation_fixture_from_a25(repo_root)),
     }
     selected_batch = _select_batch(work_items=work_items, throughput_schedule=throughput_schedule)
-    cycle_rows: list[dict[str, Any]] = []
-    invocation_rows: list[dict[str, Any]] = []
+    new_cycle_rows: list[dict[str, Any]] = []
+    new_invocation_rows: list[dict[str, Any]] = []
     for work_item in selected_batch:
-        if str(work_item.get("work_class") or "") == "EXISTING_PIPELINE_REPLAY":
-            continue
         execution_result, validation = execute_work_item(
             repo_root=repo_root,
             work_item=work_item,
@@ -2214,7 +2277,7 @@ def _run_one_cycle(
             config=config,
             write_outputs=write_outputs,
         )
-        invocation_rows.append(
+        new_invocation_rows.append(
             {
                 "invocation_identity": _content_id(
                     "qinv",
@@ -2234,7 +2297,7 @@ def _run_one_cycle(
                 "failure_reason": "" if str(validation.get("outcome") or "") == "VALIDATED_AND_COMPOSED" else str(validation.get("outcome") or ""),
             }
         )
-        cycle_rows.append(
+        new_cycle_rows.append(
             {
                 "cycle_id": _content_id("qrcy", {"cycle": cycle_index, "work_item_id": work_item["work_item_id"]}),
                 "cycle_index": cycle_index,
@@ -2252,6 +2315,10 @@ def _run_one_cycle(
                 "execution_status": str(execution_result.get("status") or ""),
             }
         )
+
+    cycle_rows = existing_cycle_rows + new_cycle_rows
+    invocation_rows = existing_invocation_rows + new_invocation_rows
+
     daily_report = generate_daily_report(
         repo_root=repo_root,
         config=config,
@@ -2323,8 +2390,10 @@ def _run_one_cycle(
         "campaign_schedule": campaign_schedule,
         "oos_budget": oos_budget,
         "pre_oos_decisions": pre_oos_decisions,
-        "cycle_rows": cycle_rows,
-        "invocation_rows": invocation_rows,
+        "cycle_rows": new_cycle_rows,
+        "invocation_rows": new_invocation_rows,
+        "cycle_history": cycle_rows,
+        "invocation_history": invocation_rows,
         "status": status,
         "daily_report": daily_report,
         "read_model_paths": read_model_paths,

--- a/tests/unit/test_qre_autonomous_orchestration.py
+++ b/tests/unit/test_qre_autonomous_orchestration.py
@@ -421,3 +421,94 @@ def test_selection_explanation_links_to_selected_work_item(orchestration_repo: P
 
     assert explanation["status"] == "present"
     assert explanation["selected_work_item_id"] == selected_id
+
+
+def test_persisted_lifecycle_does_not_repeat_terminal_work_and_creates_work_package(
+    orchestration_repo: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        gsp,
+        "REPO_ROOT",
+        orchestration_repo,
+    )
+
+    first_closeout = ao.run_orchestration(
+        repo_root=orchestration_repo,
+        mode="LOCAL_AUTONOMOUS",
+        max_cycles=1,
+        write_outputs=True,
+        report_date="2026-06-30",
+    )
+
+    first_ledger = ao._read_json(
+        ao._scoped_path(
+            ao.CYCLE_LEDGER_PATH,
+            repo_root=orchestration_repo,
+        )
+    )
+    first_rows = list((first_ledger or {}).get("rows") or [])
+
+    assert first_closeout["work_items_executed"] == 1
+    assert len(first_rows) == 1
+
+    first_work_item_id = str(first_rows[0].get("selected_work_item") or "")
+    assert first_work_item_id
+
+    second_closeout = ao.run_orchestration(
+        repo_root=orchestration_repo,
+        mode="LOCAL_AUTONOMOUS",
+        max_cycles=1,
+        write_outputs=True,
+        report_date="2026-06-30",
+    )
+
+    second_ledger = ao._read_json(
+        ao._scoped_path(
+            ao.CYCLE_LEDGER_PATH,
+            repo_root=orchestration_repo,
+        )
+    )
+    second_rows = list((second_ledger or {}).get("rows") or [])
+
+    assert second_closeout["work_items_executed"] == 1
+    assert len(second_rows) == 2
+
+    selected_work_item_ids = [
+        str(row.get("selected_work_item") or "")
+        for row in second_rows
+    ]
+    assert selected_work_item_ids.count(first_work_item_id) == 1
+    assert len(set(selected_work_item_ids)) == len(selected_work_item_ids)
+
+    latest_row = second_rows[-1]
+    assert latest_row["remediation"] == "DEVELOPMENT_WORK_PACKAGE"
+    assert latest_row["execution_status"] == "completed"
+    assert latest_row["progress_status"] == "DOWNSTREAM_BLOCKER_EXPOSED"
+    assert latest_row["validation"]["outcome"] == "VALIDATED_AND_COMPOSED"
+    assert latest_row["next_action"] == "implement_bounded_hypothesis_generation"
+
+    work_packages_dir = ao._scoped_path(
+        ao.WORK_PACKAGES_DIR,
+        repo_root=orchestration_repo,
+    )
+    work_package_paths = list(work_packages_dir.glob("qwpk*.json"))
+
+    assert len(work_package_paths) == 1
+
+    persisted_invocations = ao._read_json(
+        ao._scoped_path(
+            ao.INVOCATION_LEDGER_PATH,
+            repo_root=orchestration_repo,
+        )
+    )
+    invocation_rows = list(
+        (persisted_invocations or {}).get("rows") or []
+    )
+    invocation_identities = [
+        str(row.get("invocation_identity") or "")
+        for row in invocation_rows
+    ]
+
+    assert len(invocation_rows) == 2
+    assert len(set(invocation_identities)) == len(invocation_identities)


### PR DESCRIPTION
## Summary

- persists orchestration cycle and invocation history across separate runs
- excludes terminally completed work before dependency and throughput scheduling
- prevents repeated execution of the same deterministic work item
- routes missing hypothesis-generation capability to an explicit development work package
- removes the silent skip of existing-pipeline replay work
- keeps current-run rows separate from persisted lifecycle history

## Evidence

- python -m ruff check packages/qre_research/autonomous_orchestration.py tests/unit/test_qre_autonomous_orchestration.py
- python -m pytest tests/unit/test_qre_autonomous_orchestration.py -q — 15 passed
- python scripts/governance_lint.py — passed
- python -m pytest tests/architecture -q — 157 passed
- git diff --check — passed

## Safety boundaries

- no changes to .claude/**
- no changes to protected empirical research artifacts
- no paper, shadow, live, broker, risk, capital, deployment, or trading behavior
- generated output remains confined to governed generated_research/** paths