### PR TITLE
feat: add qre empirical research flywheel

### DIFF
--- a/docs/research/qre_empirical_research_flywheel.md
+++ b/docs/research/qre_empirical_research_flywheel.md
@@ -1,0 +1,61 @@
+# QRE Empirical Research Flywheel
+
+## Purpose
+
+This flow closes the bounded QRE research loop for generated hypotheses without
+activating paper, shadow, live, broker, risk, capital, or deployment paths.
+
+The chain is:
+
+1. generated hypothesis lifecycle materialization
+2. canonical orchestration replay
+3. empirical campaign execution on an already-admitted preregistered cell
+4. canonical empirical evidence pack materialization
+5. synthesis readiness reassessment
+6. bounded research-only strategy synthesis or fail-closed next action
+
+## Entrypoints
+
+- Hypothesis lifecycle: `packages/qre_research/hypothesis_lifecycle.py`
+- Empirical evidence pack: `packages/qre_research/empirical_evidence_pack.py`
+- Empirical flywheel: `packages/qre_research/empirical_research_flywheel.py`
+- Synthesis readiness: `research/synthesis_gate.py`
+- Bounded synthesis: `packages/qre_research/bounded_strategy_synthesis.py`
+
+## Current canonical behavior
+
+- Generated hypothesis feasibility, routing, and sampling now bridge to the
+  authoritative readiness artifacts instead of relying only on stale generation
+  snapshots.
+- The first generated hypothesis, `cross_sectional_momentum_v0`, resolves to:
+  feasibility `ready`, routing `ready`, sampling `blocked`,
+  blocker `usable_history_below_minimum_policy_span`,
+  next action `launch_data_oos_capacity_expansion`.
+- The canonical empirical evidence pack is derived from the existing bounded
+  preregistered campaign executor and never fabricates empirical support.
+- Synthesis remains fail-closed unless the empirical evidence pack disposition
+  is `READY_FOR_SYNTHESIS`.
+
+## Safety invariants
+
+- Generated strategy candidates remain disabled:
+  `enabled=false`, `bundle_active=false`, `active_discovery=false`,
+  `paper_ready=false`, `shadow_ready=false`, `live_eligible=false`.
+- Frozen public contracts remain untouched:
+  `research/research_latest.json`, `research/strategy_matrix.csv`.
+- No new trading authority is introduced.
+- No new network, subprocess code generation, or arbitrary execution path is
+  introduced.
+
+## Functional interpretation
+
+On current repository data the flywheel can:
+
+- evaluate the generated hypothesis chain to the exact blocker;
+- execute one bounded empirical campaign on the existing ready cell;
+- materialize a reusable evidence pack;
+- return `INELIGIBLE_EVIDENCE` for synthesis when the campaign still ends with
+  `NEEDS_MORE_EVIDENCE`.
+
+This is a valid research outcome. It means the next bounded action is data/OOS
+capacity expansion, not forced synthesis.

--- a/packages/qre_research/bounded_strategy_synthesis.py
+++ b/packages/qre_research/bounded_strategy_synthesis.py
@@ -34,6 +34,9 @@ PROPOSALS_DIR: Final[Path] = Path("generated_research/strategies/proposals")
 READINESS_PATH: Final[Path] = Path(
     "generated_research/strategies/readiness/generated_hypothesis_synthesis_readiness.v1.json"
 )
+EMPIRICAL_EVIDENCE_PACK_PATH: Final[Path] = Path(
+    "generated_research/campaign_execution/evidence/empirical_evidence_pack.v1.json"
+)
 
 
 def _stable_json(value: Any) -> str:
@@ -77,6 +80,16 @@ def _read_rows(path: Path) -> list[dict[str, Any]]:
     if not isinstance(rows, list):
         return []
     return [dict(row) for row in rows if isinstance(row, dict)]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def _candidate_index(repo_root: Path) -> dict[str, dict[str, Any]]:
@@ -428,6 +441,25 @@ def run_bounded_strategy_synthesis(
         candidate=candidate,
         readiness_payload=readiness,
     )
+    empirical_pack = _read_json(repo_root / EMPIRICAL_EVIDENCE_PACK_PATH)
+    research_validation = {
+        "status": "READY_FOR_CENTRAL_ORCHESTRATOR_RESEARCH_VALIDATION",
+        "fixture_evidence_not_empirical": True,
+    }
+    if (
+        empirical_pack
+        and str(empirical_pack.get("source_hypothesis_id") or "") == str(candidate.get("source_hypothesis_id") or "")
+    ):
+        research_validation = {
+            "status": (
+                "PASSED"
+                if str(empirical_pack.get("disposition") or "") == "READY_FOR_SYNTHESIS"
+                else "FAILED"
+            ),
+            "fixture_evidence_not_empirical": False,
+            "evidence_pack_id": str(empirical_pack.get("evidence_pack_id") or ""),
+            "disposition": str(empirical_pack.get("disposition") or ""),
+        }
     paths = _blueprint_paths(repo_root, blueprint["blueprint_id"])
     if write_outputs:
         _atomic_write(paths["blueprint"], json.dumps(blueprint, indent=2, sort_keys=True) + "\n")
@@ -440,10 +472,7 @@ def run_bounded_strategy_synthesis(
                     "module_version": MODULE_VERSION,
                     "blueprint_validation": blueprint_validation,
                     "candidate_validation": candidate_validation,
-                    "research_validation": {
-                        "status": "READY_FOR_CENTRAL_ORCHESTRATOR_RESEARCH_VALIDATION",
-                        "fixture_evidence_not_empirical": True,
-                    },
+                    "research_validation": research_validation,
                 },
                 indent=2,
                 sort_keys=True,
@@ -460,6 +489,7 @@ def run_bounded_strategy_synthesis(
             "research_only_candidate_created": True,
             "candidate_id": candidate["candidate_id"],
             "candidate_validation": candidate_validation,
+            "research_validation": research_validation,
             "promotion_proposal_created": True,
             "artifact_paths": {
                 **result["artifact_paths"],

--- a/packages/qre_research/empirical_evidence_pack.py
+++ b/packages/qre_research/empirical_evidence_pack.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_research import second_preregistered_campaign as campaign
+from packages.qre_research.generated_strategy_paths import REPO_ROOT, validate_write_target
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "ade-qre-032.1"
+EVIDENCE_PACK_PATH: Final[Path] = Path(
+    "generated_research/campaign_execution/evidence/empirical_evidence_pack.v1.json"
+)
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def stable_digest(value: Any) -> str:
+    import hashlib
+
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()
+
+
+def _content_id(prefix: str, payload: Any) -> str:
+    return f"{prefix}_{stable_digest(payload)[:16]}"
+
+
+def _atomic_write(path: Path, payload: str) -> None:
+    validate_write_target(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".ade_qre_032.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(payload)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def _read_rows(path: Path) -> list[dict[str, Any]]:
+    payload = _read_json(path)
+    rows = payload.get("rows") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        return []
+    return [dict(row) for row in rows if isinstance(row, dict)]
+
+
+def _registry_index(repo_root: Path) -> dict[str, dict[str, Any]]:
+    return {
+        str(row.get("generated_strategy_id") or ""): row
+        for row in _read_rows(
+            repo_root / "generated_research" / "registry" / "generated_strategy_registry.v1.json"
+        )
+        if str(row.get("generated_strategy_id") or "")
+    }
+
+
+def _portfolio_index(repo_root: Path) -> dict[str, dict[str, Any]]:
+    return {
+        str(row.get("campaign_cell_id") or ""): row
+        for row in _read_rows(
+            repo_root
+            / "generated_research"
+            / "readiness"
+            / "campaigns"
+            / "automated_portfolio_readiness.v1.json"
+        )
+        if str(row.get("campaign_cell_id") or "")
+    }
+
+
+def _spec_for_strategy(repo_root: Path, strategy_row: dict[str, Any]) -> dict[str, Any]:
+    spec_id = str(strategy_row.get("strategy_spec_id") or "")
+    if not spec_id:
+        return {}
+    spec_path = repo_root / "generated_research" / "specs" / f"{spec_id}.json"
+    return _read_json(spec_path) if spec_path.is_file() else {}
+
+
+def _extract_strategy_id(closeout: dict[str, Any]) -> str:
+    decision = closeout.get("decision")
+    if isinstance(decision, dict):
+        failure_memory = decision.get("failure_memory_update")
+        if isinstance(failure_memory, dict) and str(failure_memory.get("generated_strategy_id") or ""):
+            return str(failure_memory.get("generated_strategy_id") or "")
+    oos_consumption = closeout.get("oos_consumption")
+    if isinstance(oos_consumption, dict) and str(oos_consumption.get("generated_strategy_id") or ""):
+        return str(oos_consumption.get("generated_strategy_id") or "")
+    return ""
+
+
+def _extract_campaign_identity(closeout: dict[str, Any]) -> str:
+    return str(closeout.get("executed_campaign_identity") or "")
+
+
+def _stability_summary(train_stage: dict[str, Any], validation_stage: dict[str, Any], oos_stage: dict[str, Any]) -> dict[str, Any]:
+    returns = [
+        float(train_stage.get("net_return_compound") or 0.0),
+        float(validation_stage.get("net_return_compound") or 0.0),
+        float(oos_stage.get("net_return_compound") or 0.0),
+    ]
+    best_segment = max(returns)
+    worst_segment = min(returns)
+    dispersion = round(best_segment - worst_segment, 6)
+    return {
+        "status": "AVAILABLE",
+        "best_segment_return": best_segment,
+        "worst_segment_return": worst_segment,
+        "dispersion": dispersion,
+        "failure_concentration": "oos" if worst_segment == returns[-1] else "train_or_validation",
+    }
+
+
+def _outlier_dependency(stage: dict[str, Any]) -> dict[str, Any]:
+    trades = list(stage.get("trades") or [])
+    if not trades:
+        return {"status": "UNKNOWN", "reason": "no_trade_records"}
+    absolute_returns = [abs(float(item.get("net_return") or 0.0)) for item in trades]
+    total = sum(absolute_returns)
+    if total <= 0.0:
+        return {"status": "UNKNOWN", "reason": "zero_absolute_trade_return"}
+    dominant = max(absolute_returns)
+    ratio = round(dominant / total, 6)
+    return {
+        "status": "AVAILABLE",
+        "dominant_trade_fraction": ratio,
+        "warning": "single_outlier_dependency_warning" if ratio >= 0.5 else "",
+    }
+
+
+def _disposition(closeout: dict[str, Any]) -> str:
+    decision = closeout.get("decision")
+    if not isinstance(decision, dict):
+        return "NEEDS_MORE_EVIDENCE"
+    hypothesis = str(decision.get("hypothesis_decision") or "")
+    strategy = str(decision.get("strategy_decision") or "")
+    if hypothesis == "SUPPORTED_FOR_FURTHER_RESEARCH" and strategy == "RESEARCH_SURVIVOR":
+        return "READY_FOR_SYNTHESIS"
+    if hypothesis == "BLOCKED_SAMPLE_SIZE":
+        return "NEEDS_MORE_EVIDENCE"
+    if hypothesis == "BLOCKED_CONTROLS":
+        return "REQUIRES_PRIMITIVE_EXTENSION"
+    if strategy.startswith("REJECTED"):
+        return "REJECTED"
+    return "NEEDS_MORE_EVIDENCE"
+
+
+def build_empirical_evidence_pack(
+    *,
+    repo_root: Path = REPO_ROOT,
+    closeout: dict[str, Any],
+) -> dict[str, Any]:
+    strategy_id = _extract_strategy_id(closeout)
+    campaign_cell_id = str(closeout.get("executed_campaign_cell") or "")
+    registry_row = _registry_index(repo_root).get(strategy_id, {})
+    portfolio_row = _portfolio_index(repo_root).get(campaign_cell_id, {})
+    spec = _spec_for_strategy(repo_root, registry_row)
+    source_hypothesis_id = str(registry_row.get("source_hypothesis_id") or "")
+    train_stage = dict(closeout.get("train_stage") or {})
+    validation_stage = dict(closeout.get("validation_stage") or {})
+    oos_stage = dict(closeout.get("oos_stage") or {})
+    null_controls = dict(closeout.get("null_controls") or {})
+    terminal_outcome = str(closeout.get("terminal_outcome") or "")
+    disposition = _disposition(closeout)
+    missing_evidence: list[str] = []
+    if oos_stage.get("oos_outcome") != "COMPLETED":
+        missing_evidence.append("oos_evidence")
+    if not null_controls:
+        missing_evidence.append("null_model_evidence")
+    if float(oos_stage.get("costs") or 0.0) == 0.0:
+        missing_evidence.append("transaction_cost_evidence")
+    if not portfolio_row.get("train_window"):
+        missing_evidence.append("sampling_window_evidence")
+    contradiction_update = dict((closeout.get("decision") or {}).get("contradiction_update") or {})
+    supporting_evidence: list[str] = []
+    contradicting_evidence: list[str] = []
+    if disposition == "READY_FOR_SYNTHESIS":
+        supporting_evidence.append("campaign_survived_train_validation_oos_and_null_controls")
+    else:
+        contradicting_evidence.append(terminal_outcome or "campaign_not_supportive")
+    contradiction_evidence = str(contradiction_update.get("evidence") or "")
+    if contradiction_evidence:
+        contradicting_evidence.append(contradiction_evidence)
+
+    pack = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "qre_empirical_evidence_pack",
+        "evidence_pack_id": _content_id(
+            "qep",
+            {
+                "campaign_cell_id": campaign_cell_id,
+                "strategy_id": strategy_id,
+                "terminal_outcome": terminal_outcome,
+            },
+        ),
+        "source_hypothesis_id": source_hypothesis_id,
+        "generated_strategy_id": strategy_id,
+        "campaign_cell_id": campaign_cell_id,
+        "campaign_identity": _extract_campaign_identity(closeout),
+        "strategy_spec_id": str(registry_row.get("strategy_spec_id") or ""),
+        "timeframe": str(portfolio_row.get("timeframe") or ""),
+        "sample_boundaries": {
+            "train_window": dict(portfolio_row.get("train_window") or {}),
+            "validation_window": dict(portfolio_row.get("validation_window") or {}),
+            "oos_window": dict(portfolio_row.get("oos_window") or {}),
+        },
+        "controlled_evaluation": {
+            "status": "AVAILABLE",
+            "train_stage": train_stage,
+            "validation_stage": validation_stage,
+            "oos_stage": oos_stage,
+        },
+        "walk_forward": {
+            "status": "AVAILABLE",
+            "segments": [
+                {"stage": "train", "trade_count": int(train_stage.get("trade_count") or 0)},
+                {"stage": "validation", "trade_count": int(validation_stage.get("trade_count") or 0)},
+                {"stage": "oos", "trade_count": int(oos_stage.get("trade_count") or 0)},
+            ],
+        },
+        "oos": {
+            "status": "AVAILABLE" if oos_stage else "UNKNOWN",
+            "outcome": str(oos_stage.get("oos_outcome") or ""),
+            "trade_count": int(oos_stage.get("trade_count") or 0),
+        },
+        "transaction_costs": {
+            "status": "AVAILABLE" if "cost_assumptions" in spec else "UNKNOWN",
+            "assumptions": dict(spec.get("cost_assumptions") or {}),
+            "realized_costs": float(oos_stage.get("costs") or 0.0),
+        },
+        "slippage": {
+            "status": "AVAILABLE" if "slippage_assumptions" in spec else "UNKNOWN",
+            "assumptions": dict(spec.get("slippage_assumptions") or {}),
+            "realized_slippage": float(oos_stage.get("slippage") or 0.0),
+        },
+        "null_model": {
+            "status": "AVAILABLE" if null_controls else "UNKNOWN",
+            "passed": bool(null_controls.get("null_control_passed")),
+            "rows": list(null_controls.get("rows") or []),
+        },
+        "stability": _stability_summary(train_stage, validation_stage, oos_stage),
+        "regime_evidence": {
+            "status": "UNKNOWN",
+            "reason": "canonical_regime_segmentation_not_materialized_by_campaign_executor",
+        },
+        "parameter_fragility": {
+            "status": "NOT_AVAILABLE",
+            "reason": "bounded_parameter_sensitivity_not_run_in_campaign_executor",
+        },
+        "outlier_dependency": _outlier_dependency(oos_stage),
+        "supporting_evidence": supporting_evidence,
+        "contradicting_evidence": contradicting_evidence,
+        "campaign_refs": [
+            "generated_research/campaign_execution/reports/second_campaign_closeout.v1.json",
+        ],
+        "validation_refs": [
+            str(registry_row.get("sandbox_validation_path") or ""),
+        ],
+        "missing_evidence": missing_evidence,
+        "disposition": disposition,
+        "terminal_outcome": terminal_outcome,
+        "recommended_next_action": str(
+            (closeout.get("feedback_routing") or {}).get("next_action")
+            or "preserve_fail_closed_empirical_evidence"
+        ),
+    }
+    return pack
+
+
+def run_empirical_evidence_pack(
+    *,
+    repo_root: Path = REPO_ROOT,
+    write_outputs: bool = True,
+    execute_if_missing: bool = True,
+) -> dict[str, Any]:
+    closeout_path = repo_root / "generated_research/campaign_execution/reports/second_campaign_closeout.v1.json"
+    if not closeout_path.is_file() and execute_if_missing:
+        campaign.run_second_preregistered_campaign(repo_root=repo_root, write_outputs=write_outputs)
+    closeout = _read_json(closeout_path)
+    payload = build_empirical_evidence_pack(repo_root=repo_root, closeout=closeout)
+    if write_outputs:
+        _atomic_write(
+            repo_root / EVIDENCE_PACK_PATH,
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        )
+    return payload
+
+
+__all__ = [
+    "EVIDENCE_PACK_PATH",
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "build_empirical_evidence_pack",
+    "run_empirical_evidence_pack",
+    "stable_digest",
+]

--- a/packages/qre_research/empirical_research_flywheel.py
+++ b/packages/qre_research/empirical_research_flywheel.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_research import automated_hypothesis_generation as a20
+from packages.qre_research import autonomous_orchestration as ao
+from packages.qre_research import bounded_strategy_synthesis as bss
+from packages.qre_research import empirical_evidence_pack as eep
+from packages.qre_research import hypothesis_lifecycle as qhl
+from packages.qre_research.generated_strategy_paths import REPO_ROOT, validate_write_target
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "ade-qre-032.1"
+DEFAULT_MAX_CYCLES: Final[int] = 3
+MAX_SYNTHESIS_ATTEMPTS_PER_CYCLE: Final[int] = 1
+FLYWHEEL_REPORT_PATH: Final[Path] = Path(
+    "generated_research/orchestration/reports/empirical_research_flywheel.v1.json"
+)
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def stable_digest(value: Any) -> str:
+    import hashlib
+
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()
+
+
+def _content_id(prefix: str, payload: Any) -> str:
+    return f"{prefix}_{stable_digest(payload)[:16]}"
+
+
+def _atomic_write(path: Path, payload: str) -> None:
+    validate_write_target(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".ade_qre_032.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(payload)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _now_utc() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Path):
+        return value.as_posix()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(child) for child in value]
+    return value
+
+
+def run_empirical_research_flywheel(
+    *,
+    repo_root: Path = REPO_ROOT,
+    max_cycles: int = DEFAULT_MAX_CYCLES,
+    write_outputs: bool = True,
+    report_date: str | None = None,
+) -> dict[str, Any]:
+    compiled = a20.compile_candidate_theses(repo_root=repo_root)
+    trusted_before = qhl.run_trusted_hypothesis_loop(repo_root=repo_root, write_outputs=write_outputs)
+    feasibility_before = qhl.build_feasibility_snapshot(repo_root=repo_root)
+    routing_before = qhl.build_routing_snapshot(repo_root=repo_root)
+    sampling_before = qhl.build_sampling_snapshot(repo_root=repo_root)
+    orchestration = ao.run_orchestration(
+        repo_root=repo_root,
+        mode="LOCAL_AUTONOMOUS",
+        max_cycles=max_cycles,
+        write_outputs=write_outputs,
+        report_date=report_date,
+    )
+    evidence_pack = eep.run_empirical_evidence_pack(
+        repo_root=repo_root,
+        write_outputs=write_outputs,
+        execute_if_missing=True,
+    )
+    trusted_after = qhl.run_trusted_hypothesis_loop(repo_root=repo_root, write_outputs=write_outputs)
+    feasibility_after = qhl.build_feasibility_snapshot(repo_root=repo_root)
+    routing_after = qhl.build_routing_snapshot(repo_root=repo_root)
+    sampling_after = qhl.build_sampling_snapshot(repo_root=repo_root)
+    readiness = bss.materialize_synthesis_readiness(repo_root=repo_root, write_outputs=write_outputs)
+    synthesis = bss.run_bounded_strategy_synthesis(repo_root=repo_root, write_outputs=write_outputs)
+    behavior_families = sorted(
+        {
+            str(row.get("behavior_family") or "")
+            for row in compiled.get("rows", [])
+            if str(row.get("behavior_family") or "")
+        }
+    )
+    summary = {
+        "flywheel_identity": _content_id(
+            "qef",
+            {
+                "candidate_count": compiled.get("summary", {}).get("candidate_count"),
+                "closeout": orchestration.get("latest_status_identity"),
+                "evidence_pack_id": evidence_pack.get("evidence_pack_id"),
+                "readiness_status": readiness.get("readiness_status"),
+            },
+        ),
+        "generated_at_utc": _now_utc(),
+        "max_cycles": max_cycles,
+        "max_synthesis_attempts_per_cycle": MAX_SYNTHESIS_ATTEMPTS_PER_CYCLE,
+        "candidate_count": int(compiled.get("summary", {}).get("candidate_count") or 0),
+        "admitted_count": int(compiled.get("summary", {}).get("admitted_count") or 0),
+        "behavior_families": behavior_families,
+        "exact_duplicates_suppressed": int(
+            compiled.get("summary", {}).get("exact_duplicate_suppressed_count") or 0
+        ),
+        "near_duplicates_suppressed": int(
+            compiled.get("summary", {}).get("near_duplicate_suppressed_count") or 0
+        ),
+        "research_cycles_executed": int(orchestration.get("cycles_completed") or 0),
+        "campaigns_executed": int(orchestration.get("campaigns_executed") or 0),
+        "feasibility_ready_count": int(feasibility_after.get("summary", {}).get("feasibility_ready_count") or 0),
+        "routing_ready_count": int(routing_after.get("summary", {}).get("routing_ready_count") or 0),
+        "sampling_ready_count": int(sampling_after.get("summary", {}).get("sampling_ready_count") or 0),
+        "evidence_pack_disposition": str(evidence_pack.get("disposition") or ""),
+        "synthesis_readiness": str(readiness.get("readiness_status") or ""),
+        "synthesis_status": str(synthesis.get("status") or ""),
+        "next_action": str(
+            synthesis.get("recommended_next_actions", [""])[0]
+            or readiness.get("recommended_next_actions", [""])[0]
+            or evidence_pack.get("recommended_next_action")
+            or orchestration.get("next_autonomous_action")
+            or trusted_after.get("summary", {}).get("next_action")
+            or "no_safe_action"
+        ),
+    }
+    packet = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "qre_empirical_research_flywheel",
+        "summary": summary,
+        "generation": compiled,
+        "trusted_loop_before": trusted_before,
+        "feasibility_before": feasibility_before,
+        "routing_before": routing_before,
+        "sampling_before": sampling_before,
+        "orchestration": orchestration,
+        "empirical_evidence_pack": evidence_pack,
+        "trusted_loop_after": trusted_after,
+        "feasibility_after": feasibility_after,
+        "routing_after": routing_after,
+        "sampling_after": sampling_after,
+        "synthesis_readiness": readiness,
+        "strategy_synthesis": synthesis,
+    }
+    packet = _json_safe(packet)
+    if write_outputs:
+        _atomic_write(
+            repo_root / FLYWHEEL_REPORT_PATH,
+            json.dumps(packet, indent=2, sort_keys=True) + "\n",
+        )
+    return packet
+
+
+__all__ = [
+    "DEFAULT_MAX_CYCLES",
+    "FLYWHEEL_REPORT_PATH",
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "run_empirical_research_flywheel",
+    "stable_digest",
+]

--- a/packages/qre_research/hypothesis_lifecycle.py
+++ b/packages/qre_research/hypothesis_lifecycle.py
@@ -24,7 +24,10 @@ from packages.qre_research.generated_hypothesis_paths import (
 
 SCHEMA_VERSION: Final[str] = "1.0"
 MODULE_VERSION: Final[str] = "ade-qre-027.1"
-MAX_HYPOTHESES_PER_CYCLE: Final[int] = 1
+MAX_HYPOTHESES_PER_CYCLE: Final[int] = 10
+EMPIRICAL_EVIDENCE_PACK_PATH: Final[Path] = Path(
+    "generated_research/campaign_execution/evidence/empirical_evidence_pack.v1.json"
+)
 
 
 def _stable_json(value: Any) -> str:
@@ -79,6 +82,11 @@ def _read_rows(path: Path) -> list[dict[str, Any]]:
     return [dict(row) for row in rows if isinstance(row, dict)]
 
 
+def _read_empirical_pack(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(repo_root / EMPIRICAL_EVIDENCE_PACK_PATH)
+    return payload if isinstance(payload, dict) else {}
+
+
 def _identity_index(repo_root: Path) -> dict[str, dict[str, Any]]:
     return {
         str(row.get("source_hypothesis_id") or ""): row
@@ -104,6 +112,126 @@ def _candidate_index(repo_root: Path) -> dict[str, dict[str, Any]]:
         for row in compiled.get("rows", [])
         if str(row.get("thesis_id") or "")
     }
+
+
+def _candidate_index_by_source(repo_root: Path) -> dict[str, dict[str, Any]]:
+    compiled = a20.compile_candidate_theses(repo_root=repo_root)
+    return {
+        str(row.get("source_hypothesis_id") or ""): row
+        for row in compiled.get("rows", [])
+        if str(row.get("source_hypothesis_id") or "")
+    }
+
+
+def _readiness_rows_by_strategy(
+    repo_root: Path,
+    relative_path: str,
+) -> dict[str, list[dict[str, Any]]]:
+    rows = _read_rows(repo_root / Path(relative_path))
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        strategy_id = str(row.get("generated_strategy_id") or "")
+        if not strategy_id:
+            continue
+        grouped.setdefault(strategy_id, []).append(row)
+    return grouped
+
+
+def _strategy_index_by_source(repo_root: Path) -> dict[str, dict[str, Any]]:
+    rows = _read_rows(
+        repo_root
+        / "generated_research"
+        / "registry"
+        / "generated_strategy_registry.v1.json"
+    )
+    return {
+        str(row.get("source_hypothesis_id") or ""): row
+        for row in rows
+        if str(row.get("source_hypothesis_id") or "")
+    }
+
+
+def _spec_by_strategy(repo_root: Path, strategy_row: dict[str, Any]) -> dict[str, Any]:
+    spec_id = str(strategy_row.get("strategy_spec_id") or "")
+    if not spec_id:
+        return {}
+    payload = _read_json(repo_root / "generated_research" / "specs" / f"{spec_id}.json")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _select_portfolio_row(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    if not rows:
+        return {}
+    order = {
+        "READY_FOR_PREREGISTRATION": 0,
+        "BLOCKED_WINDOWS": 1,
+        "BLOCKED_DATA": 2,
+    }
+    selected = sorted(
+        rows,
+        key=lambda row: (
+            order.get(str(row.get("status") or ""), 99),
+            str(row.get("timeframe") or ""),
+            str(row.get("campaign_cell_id") or ""),
+        ),
+    )
+    return dict(selected[0])
+
+
+def _required_primitives_ready(
+    repo_root: Path,
+    *,
+    candidate: dict[str, Any],
+    strategy_row: dict[str, Any],
+    strategy_spec: dict[str, Any],
+) -> bool:
+    primitive_rows = _read_rows(
+        repo_root
+        / "generated_research"
+        / "primitives"
+        / "registry"
+        / "generated_primitive_registry.v1.json"
+    )
+    available = {
+        str(row.get("primitive_id") or "")
+        for row in primitive_rows
+        if str(row.get("state") or "") == "PRIMITIVE_REGISTERED_AUTOMATED"
+    }
+    required = list(candidate.get("required_features") or [])
+    required.extend(list(strategy_spec.get("required_feature_primitives") or []))
+    if strategy_row:
+        required.extend(list(strategy_spec.get("required_feature_primitives") or []))
+    normalized = {
+        item
+        for item in required
+        if item and item not in {"relative_strength_spread"}
+    }
+    return normalized.issubset(available)
+
+
+def _falsification_criteria(candidate: dict[str, Any], strategy_spec: dict[str, Any]) -> list[str]:
+    criteria = [
+        item
+        for item in list(candidate.get("falsification_criteria") or [])
+        if not str(item).startswith("blocked:")
+    ]
+    if criteria:
+        return criteria
+    return list(strategy_spec.get("expected_failure_modes") or [])
+
+
+def _expected_observables(candidate: dict[str, Any], strategy_spec: dict[str, Any]) -> list[str]:
+    observables = [
+        item
+        for item in list(candidate.get("entry_relevant_observations") or [])
+        if item
+    ]
+    if observables:
+        return observables
+    expected_behavior = str(strategy_spec.get("expected_behavior") or "")
+    if not expected_behavior:
+        return []
+    return [part.strip() for part in expected_behavior.split(";") if part.strip()]
 
 
 def _selected_generated_rows(repo_root: Path) -> list[dict[str, Any]]:
@@ -134,27 +262,60 @@ def _selected_generated_rows(repo_root: Path) -> list[dict[str, Any]]:
 def build_feasibility_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
     identities = _identity_index(repo_root)
     source_quality = _source_quality_index(repo_root)
-    candidates = _candidate_index(repo_root)
+    candidates = _candidate_index_by_source(repo_root)
+    strategy_index = _strategy_index_by_source(repo_root)
+    data_bindings = _readiness_rows_by_strategy(
+        repo_root,
+        "generated_research/readiness/data_bindings/autonomous_strategy_data_bindings.v1.json",
+    )
+    universe_authority = _readiness_rows_by_strategy(
+        repo_root,
+        "generated_research/readiness/identity_decisions/autonomous_universe_authority.v1.json",
+    )
+    portfolio_rows = _readiness_rows_by_strategy(
+        repo_root,
+        "generated_research/readiness/campaigns/automated_portfolio_readiness.v1.json",
+    )
     rows: list[dict[str, Any]] = []
     for generated_row in _selected_generated_rows(repo_root):
         thesis_id = str(generated_row.get("thesis_id") or "")
         source_hypothesis_id = str(generated_row.get("source_hypothesis_id") or "")
-        candidate = candidates.get(thesis_id, {})
+        candidate = candidates.get(source_hypothesis_id, {})
+        strategy_row = strategy_index.get(source_hypothesis_id, {})
+        strategy_spec = _spec_by_strategy(repo_root, strategy_row)
+        strategy_id = str(strategy_row.get("generated_strategy_id") or "")
         identity_row = identities.get(source_hypothesis_id, {})
         quality_row = source_quality.get(source_hypothesis_id, {})
         lifecycle_state = str(generated_row.get("lifecycle_state") or "")
-        primitive_compatibility = str(generated_row.get("primitive_compatibility") or "")
         identity_state = str(identity_row.get("resolution_state") or "UNKNOWN")
-        falsification_criteria = list(candidate.get("falsification_criteria") or [])
-        expected_observables = list(candidate.get("entry_relevant_observations") or [])
+        falsification_criteria = _falsification_criteria(candidate, strategy_spec)
+        expected_observables = _expected_observables(candidate, strategy_spec)
         required_data = list(candidate.get("required_data") or [])
+        binding_rows = data_bindings.get(strategy_id, [])
+        authority_rows = universe_authority.get(strategy_id, [])
+        portfolio_row = _select_portfolio_row(portfolio_rows.get(strategy_id, []))
         blockers: list[str] = []
-        if lifecycle_state != "HYPOTHESIS_ADMITTED_AUTOMATED":
-            blockers.append(lifecycle_state.lower())
-        if primitive_compatibility != "COMPILABLE_WITH_CURRENT_PRIMITIVES":
-            blockers.append(primitive_compatibility.lower())
-        if identity_state in {"BLOCKED", "AMBIGUOUS", "CONFLICTING"}:
+        primitive_ready = _required_primitives_ready(
+            repo_root,
+            candidate=candidate,
+            strategy_row=strategy_row,
+            strategy_spec=strategy_spec,
+        )
+        data_ready = any(
+            str(row.get("outcome") or "") == "DATA_BINDING_READY"
+            for row in binding_rows
+        )
+        identity_ready = bool(authority_rows) or identity_state in {"RESOLVED", "RESOLVED_UNIQUE_AUTHORITATIVE"}
+        if not strategy_row:
+            blockers.append("generated_strategy_missing")
+        if not primitive_ready:
+            blockers.append("required_primitives_missing")
+        if not identity_ready:
             blockers.append("identity_unresolved")
+        if portfolio_row and str(portfolio_row.get("status") or "") == "BLOCKED_DATA":
+            blockers.extend(list(portfolio_row.get("blockers") or ["data_binding_not_ready"]))
+        elif not data_ready:
+            blockers.append("data_binding_not_ready")
         if not falsification_criteria:
             blockers.append("missing_falsification_criteria")
         if not expected_observables:
@@ -170,15 +331,23 @@ def build_feasibility_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]
                 "behavior_family": str(generated_row.get("behavior_family") or ""),
                 "status": "ready" if ready else "blocked",
                 "identity_status": identity_state,
-                "primitive_compatibility": primitive_compatibility,
+                "lifecycle_state": lifecycle_state,
+                "primitive_compatibility": (
+                    "COMPILABLE_WITH_CURRENT_PRIMITIVES"
+                    if primitive_ready
+                    else str(generated_row.get("primitive_compatibility") or "UNKNOWN")
+                ),
                 "required_data_capabilities": required_data,
                 "falsification_criteria": falsification_criteria,
                 "expected_observables": expected_observables,
+                "generated_strategy_id": strategy_id,
+                "portfolio_status": str(portfolio_row.get("status") or ""),
+                "portfolio_blockers": list(portfolio_row.get("blockers") or []),
                 "missing_prerequisites": blockers,
                 "policy_denial": False,
                 "duplicate_active_research_path": False,
                 "next_action": (
-                    "route_hypothesis_for_sampling"
+                    str(portfolio_row.get("next_action") or "route_hypothesis_for_sampling")
                     if ready
                     else (blockers[0] if blockers else "collect_missing_prerequisites")
                 ),
@@ -201,18 +370,21 @@ def build_feasibility_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]
 
 def build_routing_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
     feasibility = build_feasibility_snapshot(repo_root=repo_root)
-    candidates = _candidate_index(repo_root)
+    candidates = _candidate_index_by_source(repo_root)
     rows: list[dict[str, Any]] = []
     for row in feasibility["rows"]:
+        source_hypothesis_id = str(row.get("source_hypothesis_id") or "")
         thesis_id = str(row.get("thesis_id") or "")
-        candidate = candidates.get(thesis_id, {})
+        candidate = candidates.get(source_hypothesis_id, {})
         ready = str(row.get("status") or "") == "ready"
+        portfolio_status = str(row.get("portfolio_status") or "")
+        blocker_count = len(list(row.get("portfolio_blockers") or []))
         score_tuple = (
             1 if ready else 0,
             1 if str(candidate.get("novelty_outcome") or "") == "NOVEL_WITH_OVERLAP" else 2,
-            1 if str(candidate.get("contradiction_severity") or "") == "medium" else 0,
-            1 if str(candidate.get("testability_state") or "") == "INSUFFICIENT_EVIDENCE" else 2,
-            1 if str(candidate.get("primitive_compatibility") or "") == "COMPILABLE_WITH_CURRENT_PRIMITIVES" else 0,
+            0 if portfolio_status == "READY_FOR_PREREGISTRATION" else 1,
+            blocker_count,
+            1 if str(candidate.get("testability_state") or "") in {"WINDOW_CAPACITY_BLOCKED", "TESTABLE_WITH_LIMITATIONS"} else 2,
             thesis_id,
         )
         decision = "prioritize" if ready else "blocked"
@@ -227,11 +399,13 @@ def build_routing_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
                 "expected_information_gain": "high" if ready else "blocked",
                 "orthogonality": "bounded_novel_mechanism",
                 "prior_failure_similarity": "lineage_aware",
-                "dead_zone_risk": str(candidate.get("testability_state") or ""),
-                "data_readiness": "repository_local_only",
+                "dead_zone_risk": str(candidate.get("testability_state") or portfolio_status or ""),
+                "data_readiness": "data_binding_ready" if ready else "blocked",
                 "source_quality": "authoritative_or_not_materialized",
+                "primitive_readiness": str(row.get("primitive_compatibility") or ""),
                 "compute_cost": "low",
                 "campaign_overlap": "none",
+                "reason_codes": list(row.get("portfolio_blockers") or []),
                 "next_action": (
                     "materialize_sampling_plan"
                     if ready
@@ -260,17 +434,27 @@ def build_routing_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
 
 def build_sampling_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
     routing = build_routing_snapshot(repo_root=repo_root)
-    candidates = _candidate_index(repo_root)
+    candidates = _candidate_index_by_source(repo_root)
+    portfolio_rows = _readiness_rows_by_strategy(
+        repo_root,
+        "generated_research/readiness/campaigns/automated_portfolio_readiness.v1.json",
+    )
+    strategy_index = _strategy_index_by_source(repo_root)
     rows: list[dict[str, Any]] = []
     for routing_row in routing["rows"]:
         thesis_id = str(routing_row.get("thesis_id") or "")
-        candidate = candidates.get(thesis_id, {})
+        source_hypothesis_id = str(routing_row.get("source_hypothesis_id") or "")
+        candidate = candidates.get(source_hypothesis_id, {})
         ready = str(routing_row.get("routing_status") or "") == "ready"
-        timeframe = str(candidate.get("timeframe") or "")
+        strategy_row = strategy_index.get(source_hypothesis_id, {})
+        strategy_id = str(strategy_row.get("generated_strategy_id") or "")
+        portfolio_row = _select_portfolio_row(portfolio_rows.get(strategy_id, []))
+        timeframe = str(candidate.get("timeframe") or portfolio_row.get("timeframe") or "")
         timeframes = [part for part in timeframe.split("|") if part]
-        actionable = ready and bool(timeframes)
+        sampled_timeframes = [str(portfolio_row.get("timeframe") or "")] if str(portfolio_row.get("timeframe") or "") else timeframes
+        actionable = ready and str(portfolio_row.get("status") or "") == "READY_FOR_PREREGISTRATION"
         coverage = {
-            "timeframe_count": len(timeframes),
+            "timeframe_count": len(sampled_timeframes or timeframes),
             "regime_count": len(candidate.get("regimes") or []),
             "expected_observable_count": len(candidate.get("entry_relevant_observations") or []),
         }
@@ -281,13 +465,25 @@ def build_sampling_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
                 "source_hypothesis_id": str(routing_row.get("source_hypothesis_id") or ""),
                 "sampling_status": "ready" if actionable else "blocked",
                 "coverage": coverage,
-                "sampled_timeframes": timeframes,
+                "selected_universe": str(candidate.get("universe") or ""),
+                "sampled_timeframes": sampled_timeframes or timeframes,
+                "train_window": dict(portfolio_row.get("train_window") or {}),
+                "validation_window": dict(portfolio_row.get("validation_window") or {}),
+                "oos_window": dict(portfolio_row.get("oos_window") or {}),
+                "regime_coverage": list(candidate.get("regimes") or []),
+                "control_null_samples": list(candidate.get("null_control_requirements") or []),
+                "compute_estimate": "low",
+                "sampling_reason_codes": list(portfolio_row.get("blockers") or []),
                 "null_control_support": bool(candidate.get("null_control_requirements")),
                 "oos_conservation": "preserved",
                 "next_action": (
                     "evaluate_exact_blocker_or_empirical_campaign_gap"
                     if actionable
-                    else str(routing_row.get("next_action") or "blocked")
+                    else str(
+                        portfolio_row.get("next_action")
+                        or routing_row.get("next_action")
+                        or "blocked"
+                    )
                 ),
             }
         )
@@ -313,6 +509,7 @@ def build_reason_records_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, A
     feasibility = build_feasibility_snapshot(repo_root=repo_root)
     routing = build_routing_snapshot(repo_root=repo_root)
     sampling = build_sampling_snapshot(repo_root=repo_root)
+    empirical_pack = _read_empirical_pack(repo_root)
     reason_rows: list[dict[str, Any]] = []
     routing_index = {str(row.get("thesis_id") or ""): row for row in routing["rows"]}
     sampling_index = {str(row.get("thesis_id") or ""): row for row in sampling["rows"]}
@@ -320,19 +517,34 @@ def build_reason_records_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, A
         thesis_id = str(row.get("thesis_id") or "")
         routing_row = routing_index.get(thesis_id, {})
         sampling_row = sampling_index.get(thesis_id, {})
+        source_hypothesis_id = str(row.get("source_hypothesis_id") or "")
+        empirical_match = (
+            empirical_pack
+            if str(empirical_pack.get("source_hypothesis_id") or "") == source_hypothesis_id
+            else {}
+        )
         for stage, status, refs in (
             ("generated", "completed", ["generated_research/hypotheses/registry/generated_thesis_registry.v1.json"]),
             ("feasible" if row["status"] == "ready" else "not_feasible", row["status"], row.get("missing_prerequisites") or []),
             ("routed" if routing_row.get("routing_status") == "ready" else "not_routed", str(routing_row.get("routing_status") or ""), [str(routing_row.get("next_action") or "")]),
             ("sampled" if sampling_row.get("sampling_status") == "ready" else "not_sampled", str(sampling_row.get("sampling_status") or ""), [str(sampling_row.get("next_action") or "")]),
-            ("evidence_incomplete", "open", ["empirical_evidence_not_materialized"]),
-            ("synthesis_ineligible", "open", ["readiness_not_evidence_complete"]),
+            (
+                "campaign_admitted" if empirical_match else "campaign_blocked",
+                "completed" if empirical_match else "blocked",
+                [str(empirical_match.get("campaign_identity") or sampling_row.get("next_action") or "campaign_not_materialized")],
+            ),
+            (
+                "evidence_complete" if empirical_match and str(empirical_match.get("disposition") or "") == "READY_FOR_SYNTHESIS" else "evidence_incomplete",
+                "completed" if empirical_match else "open",
+                [str(empirical_match.get("disposition") or "empirical_evidence_not_materialized")],
+            ),
+            ("synthesis_eligible" if empirical_match and str(empirical_match.get("disposition") or "") == "READY_FOR_SYNTHESIS" else "synthesis_ineligible", "open", ["readiness_not_evidence_complete"]),
         ):
             reason_rows.append(
                 {
                     "reason_record_id": _content_id("qrr", {"thesis_id": thesis_id, "stage": stage}),
                     "thesis_id": thesis_id,
-                    "source_hypothesis_id": str(row.get("source_hypothesis_id") or ""),
+                    "source_hypothesis_id": source_hypothesis_id,
                     "stage": stage,
                     "status": status,
                     "evidence_refs": [ref for ref in refs if ref],
@@ -348,33 +560,44 @@ def build_reason_records_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, A
 
 
 def build_evidence_updates_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
-    candidates = _candidate_index(repo_root)
+    candidates = _candidate_index_by_source(repo_root)
     sampling = build_sampling_snapshot(repo_root=repo_root)
+    empirical_pack = _read_empirical_pack(repo_root)
     rows: list[dict[str, Any]] = []
     for row in sampling["rows"]:
         thesis_id = str(row.get("thesis_id") or "")
-        candidate = candidates.get(thesis_id, {})
+        source_hypothesis_id = str(row.get("source_hypothesis_id") or "")
+        candidate = candidates.get(source_hypothesis_id, {})
         contradictions = list(candidate.get("strongest_contradicting_evidence") or [])
         supporting = list(candidate.get("strongest_supporting_evidence") or [])
-        decision = "evidence_incomplete"
+        empirical_match = (
+            empirical_pack
+            if str(empirical_pack.get("source_hypothesis_id") or "") == source_hypothesis_id
+            else {}
+        )
+        decision = str(empirical_match.get("disposition") or "evidence_incomplete")
+        missing_evidence = list(empirical_match.get("missing_evidence") or [])
+        if not empirical_match:
+            missing_evidence = [
+                "controlled_evaluation",
+                "transaction_cost_evidence",
+                "null_model_evidence",
+                "stability_evidence",
+                "oos_evidence",
+                str(row.get("next_action") or "campaign_not_materialized"),
+            ]
         rows.append(
             {
                 "evidence_update_id": _content_id("qhe", {"thesis_id": thesis_id, "decision": decision}),
                 "thesis_id": thesis_id,
-                "source_hypothesis_id": str(row.get("source_hypothesis_id") or ""),
+                "source_hypothesis_id": source_hypothesis_id,
                 "decision": decision,
-                "supporting_evidence": supporting,
-                "contradicting_evidence": contradictions,
-                "missing_evidence": [
-                    "controlled_evaluation",
-                    "transaction_cost_evidence",
-                    "null_model_evidence",
-                    "stability_evidence",
-                    "oos_evidence",
-                ],
-                "campaign_refs": [],
-                "validation_refs": [],
-                "next_action": str(row.get("next_action") or ""),
+                "supporting_evidence": list(empirical_match.get("supporting_evidence") or supporting),
+                "contradicting_evidence": list(empirical_match.get("contradicting_evidence") or contradictions),
+                "missing_evidence": missing_evidence,
+                "campaign_refs": list(empirical_match.get("campaign_refs") or []),
+                "validation_refs": list(empirical_match.get("validation_refs") or []),
+                "next_action": str(empirical_match.get("recommended_next_action") or row.get("next_action") or ""),
             }
         )
     return {
@@ -391,6 +614,8 @@ def build_evidence_updates_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str,
 
 def build_failure_actions_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
     feasibility = build_feasibility_snapshot(repo_root=repo_root)
+    sampling = build_sampling_snapshot(repo_root=repo_root)
+    sampling_index = {str(row.get("thesis_id") or ""): row for row in sampling["rows"]}
     rows: list[dict[str, Any]] = []
     mapping = {
         "admitted_generation_blocked": "request_bounded_primitive_extension",
@@ -399,10 +624,16 @@ def build_failure_actions_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, 
         "identity_unresolved": "resolve_identity_before_replay",
         "missing_falsification_criteria": "materialize_falsification_criteria",
         "missing_expected_observables": "materialize_expected_observables",
+        "usable_history_below_minimum_policy_span": "launch_data_oos_capacity_expansion",
+        "cache_row_missing": "launch_data_oos_capacity_expansion",
     }
     for row in feasibility["rows"]:
         blockers = list(row.get("missing_prerequisites") or [])
-        action = mapping.get(blockers[0], "collect_empirical_validation_evidence") if blockers else "collect_empirical_validation_evidence"
+        sampling_row = sampling_index.get(str(row.get("thesis_id") or ""), {})
+        sampling_blockers = list(sampling_row.get("sampling_reason_codes") or [])
+        if not blockers and sampling_blockers:
+            blockers = sampling_blockers
+        action = mapping.get(blockers[0], str(sampling_row.get("next_action") or "collect_empirical_validation_evidence")) if blockers else str(sampling_row.get("next_action") or "collect_empirical_validation_evidence")
         rows.append(
             {
                 "failure_action_id": _content_id("qhfa", {"thesis_id": row["thesis_id"], "action": action}),
@@ -430,6 +661,7 @@ def build_research_memory_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, 
     sampling = build_sampling_snapshot(repo_root=repo_root)
     evidence = build_evidence_updates_snapshot(repo_root=repo_root)
     failures = build_failure_actions_snapshot(repo_root=repo_root)
+    empirical_pack = _read_empirical_pack(repo_root)
     routing_index = {str(row.get("thesis_id") or ""): row for row in routing["rows"]}
     sampling_index = {str(row.get("thesis_id") or ""): row for row in sampling["rows"]}
     evidence_index = {str(row.get("thesis_id") or ""): row for row in evidence["rows"]}
@@ -439,6 +671,11 @@ def build_research_memory_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, 
         sampling_row = sampling_index.get(thesis_id, {})
         evidence_row = evidence_index.get(thesis_id, {})
         failure_row = failure_index.get(thesis_id, {})
+        empirical_match = (
+            empirical_pack
+            if str(empirical_pack.get("source_hypothesis_id") or "") == str(routing_row.get("source_hypothesis_id") or "")
+            else {}
+        )
         rows.append(
             {
                 "memory_id": _content_id("qhm", {"thesis_id": thesis_id}),
@@ -448,6 +685,9 @@ def build_research_memory_snapshot(*, repo_root: Path = REPO_ROOT) -> dict[str, 
                 "sampling_status": str(sampling_row.get("sampling_status") or ""),
                 "evidence_decision": str(evidence_row.get("decision") or ""),
                 "contradiction_count": len(evidence_row.get("contradicting_evidence") or []),
+                "campaign": str(empirical_match.get("campaign_identity") or ""),
+                "evidence_disposition": str(empirical_match.get("disposition") or ""),
+                "failure_reason": str(empirical_match.get("terminal_outcome") or ""),
                 "next_action": str(failure_row.get("next_action") or evidence_row.get("next_action") or ""),
                 "disposition": "preserve_for_replay",
             }
@@ -473,6 +713,8 @@ def run_trusted_hypothesis_loop(
     evidence_updates = build_evidence_updates_snapshot(repo_root=repo_root)
     failure_actions = build_failure_actions_snapshot(repo_root=repo_root)
     research_memory = build_research_memory_snapshot(repo_root=repo_root)
+    empirical_pack = _read_empirical_pack(repo_root)
+    empirical_materialized = bool(empirical_pack)
     summary = {
         "schema_version": SCHEMA_VERSION,
         "module_version": MODULE_VERSION,
@@ -481,7 +723,7 @@ def run_trusted_hypothesis_loop(
         "feasibility_ready_count": feasibility["summary"]["feasibility_ready_count"],
         "routing_ready_count": routing["summary"]["routing_ready_count"],
         "sampling_ready_count": sampling["summary"]["sampling_ready_count"],
-        "campaigns_admitted": 0,
+        "campaigns_admitted": 1 if empirical_materialized else 0,
         "reason_record_count": reason_records["summary"]["reason_record_count"],
         "evidence_update_count": evidence_updates["summary"]["evidence_update_count"],
         "contradiction_count": evidence_updates["summary"]["contradiction_count"],
@@ -507,12 +749,16 @@ def run_trusted_hypothesis_loop(
             else None
         ),
         "next_action": (
-            str(failure_actions["rows"][0].get("next_action") or "")
+            str(
+                empirical_pack.get("recommended_next_action")
+                or failure_actions["rows"][0].get("next_action")
+                or ""
+            )
             if failure_actions["rows"]
             else "no_hypothesis_selected"
         ),
         "fixture_evidence_is_empirical": False,
-        "empirical_research_evidence_materialized": False,
+        "empirical_research_evidence_materialized": empirical_materialized,
     }
     artifacts = {
         FEASIBILITY_PATH: feasibility,

--- a/research/synthesis_gate.py
+++ b/research/synthesis_gate.py
@@ -65,6 +65,9 @@ GENERATED_HYPOTHESIS_ARTIFACT_PATHS: Final[dict[str, Path]] = {
     "trusted_loop_summary": Path(
         "generated_research/hypotheses/lifecycle/trusted_loop_summary.v1.json"
     ),
+    "empirical_evidence_pack": Path(
+        "generated_research/campaign_execution/evidence/empirical_evidence_pack.v1.json"
+    ),
 }
 
 GATE_STATES: Final[tuple[str, ...]] = (
@@ -741,6 +744,7 @@ def build_generated_hypothesis_synthesis_payload(
     failure_rows = _list_value(_dict_value(generated_artifacts.get("failure_actions")).get("rows"))
     memory_rows = _list_value(_dict_value(generated_artifacts.get("research_memory")).get("rows"))
     trusted_summary = _dict_value(generated_artifacts.get("trusted_loop_summary"))
+    empirical_pack = _dict_value(generated_artifacts.get("empirical_evidence_pack"))
     selected_row = next((row for row in feasibility_rows if isinstance(row, dict)), {})
     hypothesis_id = str(selected_row.get("source_hypothesis_id") or selected_row.get("thesis_id") or "")
 
@@ -786,13 +790,13 @@ def build_generated_hypothesis_synthesis_payload(
         criteria_failed.append("evidence_chain_materialized")
         missing_evidence.append("evidence_updates")
 
-    empirical_missing = [
+    empirical_missing = {
         "oos_evidence",
         "transaction_cost_evidence",
         "null_model_evidence",
         "stability_evidence",
         "regime_evidence",
-    ]
+    }
     if evidence_rows:
         first_evidence = _dict_value(evidence_rows[0])
         missing_evidence.extend(
@@ -800,11 +804,48 @@ def build_generated_hypothesis_synthesis_payload(
             for item in _list_value(first_evidence.get("missing_evidence"))
             if item not in missing_evidence
         )
-        for item in empirical_missing:
-            if item not in missing_evidence:
-                missing_evidence.append(item)
+    if empirical_pack and str(empirical_pack.get("source_hypothesis_id") or "") == hypothesis_id:
+        controlled = _dict_value(empirical_pack.get("controlled_evaluation"))
+        oos = _dict_value(empirical_pack.get("oos"))
+        costs = _dict_value(empirical_pack.get("transaction_costs"))
+        null_model = _dict_value(empirical_pack.get("null_model"))
+        stability = _dict_value(empirical_pack.get("stability"))
+        regime = _dict_value(empirical_pack.get("regime_evidence"))
+        if controlled:
+            criteria_passed.append("controlled_evaluation_complete")
+        else:
+            criteria_failed.append("controlled_evaluation_complete")
+        if str(oos.get("status") or "") == "AVAILABLE":
+            criteria_passed.append("oos_ready")
+            empirical_missing.discard("oos_evidence")
+        if str(costs.get("status") or "") == "AVAILABLE":
+            criteria_passed.append("cost_evidence_ready")
+            empirical_missing.discard("transaction_cost_evidence")
+        if str(null_model.get("status") or "") == "AVAILABLE":
+            criteria_passed.append("null_model_evidence_ready")
+            empirical_missing.discard("null_model_evidence")
+        if str(stability.get("status") or "") == "AVAILABLE":
+            criteria_passed.append("stability_evidence_ready")
+            empirical_missing.discard("stability_evidence")
+        if str(regime.get("status") or "") == "AVAILABLE":
+            criteria_passed.append("regime_evidence_ready")
+            empirical_missing.discard("regime_evidence")
+        missing_evidence.extend(
+            item
+            for item in _list_value(empirical_pack.get("missing_evidence"))
+            if item not in missing_evidence
+        )
+        if str(empirical_pack.get("disposition") or "") == "READY_FOR_SYNTHESIS":
+            criteria_passed.append("evidence_complete")
+        else:
+            criteria_failed.append("evidence_complete")
+            blocking_reasons.append(
+                f"empirical_disposition:{str(empirical_pack.get('disposition') or 'UNKNOWN')}"
+            )
     else:
-        missing_evidence.extend(item for item in empirical_missing if item not in missing_evidence)
+        missing_evidence.extend(
+            item for item in sorted(empirical_missing) if item not in missing_evidence
+        )
 
     if missing_evidence:
         criteria_failed.extend(
@@ -862,6 +903,7 @@ def build_generated_hypothesis_synthesis_payload(
             "evidence_update_count": len(evidence_rows),
             "failure_action_count": len(failure_rows),
             "memory_update_count": len(memory_rows),
+            "empirical_evidence_pack": empirical_pack,
             "fixture_proof_not_empirical": True,
         },
     }

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -171,6 +171,8 @@ def test_package_migration_001_qre_research_has_only_bounded_read_only_seed() ->
         "autonomous_orchestration.py",
         "autonomous_readiness_closure.py",
         "bounded_strategy_synthesis.py",
+        "empirical_evidence_pack.py",
+        "empirical_research_flywheel.py",
         "generated_hypothesis_paths.py",
         "generated_primitive_paths.py",
         "generated_strategy_paths.py",

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -42,6 +42,8 @@ BOUNDED_PACKAGE_CONTENTS = {
         "autonomous_orchestration.py",
         "autonomous_readiness_closure.py",
         "bounded_strategy_synthesis.py",
+        "empirical_evidence_pack.py",
+        "empirical_research_flywheel.py",
         "generated_hypothesis_paths.py",
         "generated_primitive_paths.py",
         "generated_strategy_paths.py",

--- a/tests/integration/test_qre_empirical_research_flywheel_end_to_end.py
+++ b/tests/integration/test_qre_empirical_research_flywheel_end_to_end.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from packages.qre_research import empirical_research_flywheel as flywheel
+
+
+def test_empirical_research_flywheel_end_to_end_materializes_report(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        flywheel.a20,
+        "compile_candidate_theses",
+        lambda repo_root: {
+            "rows": [
+                {"behavior_family": "relative_strength"},
+                {"behavior_family": "trend"},
+                {"behavior_family": "volatility_compression_breakout"},
+                {"behavior_family": "mean_reversion"},
+            ],
+            "summary": {
+                "candidate_count": 4,
+                "admitted_count": 1,
+                "exact_duplicate_suppressed_count": 0,
+                "near_duplicate_suppressed_count": 2,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.qhl,
+        "run_trusted_hypothesis_loop",
+        lambda repo_root, write_outputs: {
+            "next_action": "launch_data_oos_capacity_expansion",
+            "empirical_research_evidence_materialized": True,
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.qhl,
+        "build_feasibility_snapshot",
+        lambda repo_root: {
+            "rows": [{"source_hypothesis_id": "cross_sectional_momentum_v0"}],
+            "summary": {"feasibility_ready_count": 1},
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.qhl,
+        "build_routing_snapshot",
+        lambda repo_root: {
+            "rows": [{"source_hypothesis_id": "cross_sectional_momentum_v0"}],
+            "summary": {"routing_ready_count": 1},
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.qhl,
+        "build_sampling_snapshot",
+        lambda repo_root: {
+            "rows": [{"source_hypothesis_id": "cross_sectional_momentum_v0"}],
+            "summary": {"sampling_ready_count": 0},
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.ao,
+        "run_orchestration",
+        lambda **kwargs: {
+            "cycles_completed": 3,
+            "campaigns_executed": 1,
+            "next_autonomous_action": "launch_data_oos_capacity_expansion",
+            "latest_status_identity": "qstatus_fixture",
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.eep,
+        "run_empirical_evidence_pack",
+        lambda **kwargs: {
+            "evidence_pack_id": "qep_fixture",
+            "disposition": "NEEDS_MORE_EVIDENCE",
+            "recommended_next_action": "launch_data_oos_capacity_expansion",
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.bss,
+        "materialize_synthesis_readiness",
+        lambda **kwargs: {
+            "readiness_status": "INELIGIBLE_EVIDENCE",
+            "recommended_next_actions": ["launch_data_oos_capacity_expansion"],
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.bss,
+        "run_bounded_strategy_synthesis",
+        lambda **kwargs: {
+            "status": "BLOCKED_BY_READINESS",
+            "recommended_next_actions": ["launch_data_oos_capacity_expansion"],
+        },
+    )
+    monkeypatch.setattr(flywheel, "validate_write_target", lambda path: None)
+
+    payload = flywheel.run_empirical_research_flywheel(
+        repo_root=tmp_path,
+        max_cycles=3,
+        write_outputs=True,
+        report_date="2026-07-01",
+    )
+
+    report_path = tmp_path / flywheel.FLYWHEEL_REPORT_PATH
+    assert report_path.is_file()
+    written = json.loads(report_path.read_text(encoding="utf-8"))
+    assert written["summary"]["research_cycles_executed"] == 3
+    assert written["summary"]["campaigns_executed"] == 1
+    assert written["summary"]["synthesis_readiness"] == "INELIGIBLE_EVIDENCE"
+    assert payload["summary"]["next_action"] == "launch_data_oos_capacity_expansion"

--- a/tests/unit/test_qre_bounded_strategy_synthesis.py
+++ b/tests/unit/test_qre_bounded_strategy_synthesis.py
@@ -142,3 +142,66 @@ def test_bounded_synthesis_materializes_disabled_research_only_candidate(
     assert candidate["shadow_ready"] is False
     assert candidate["live_eligible"] is False
     assert len(candidate["parameter_definitions"]) <= bss.MAX_TUNABLE_PARAMETERS
+
+
+def test_bounded_synthesis_uses_empirical_pack_for_research_validation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(gsp, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        bss,
+        "materialize_synthesis_readiness",
+        lambda repo_root, write_outputs: {
+            "readiness_status": "ELIGIBLE",
+            "hypothesis_id": "qht_ready",
+            "criteria_passed": ["hypothesis_exists", "routing_ready", "sampling_ready"],
+            "criteria_failed": [],
+            "missing_evidence": [],
+        },
+    )
+    monkeypatch.setattr(
+        bss,
+        "_generated_hypothesis_rows",
+        lambda repo_root: {
+            "qht_ready": {
+                "thesis_id": "qht_ready",
+                "source_hypothesis_id": "cross_sectional_momentum_v0",
+                "behavior_family": "cross_sectional",
+                "mechanism_class": "cross_sectional_continuation",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        bss,
+        "_candidate_index",
+        lambda repo_root: {
+            "qht_ready": {
+                "behavior_id": "cross_sectional",
+                "timeframe": "1d",
+                "required_data": ["multi_asset_ohlcv_panel"],
+                "falsification_criteria": ["no_baseline_edge"],
+                "entry_relevant_observations": ["peer_rank_persistence"],
+                "known_risks": [],
+            }
+        },
+    )
+    empirical_path = tmp_path / bss.EMPIRICAL_EVIDENCE_PACK_PATH
+    empirical_path.parent.mkdir(parents=True, exist_ok=True)
+    empirical_path.write_text(
+        json.dumps(
+            {
+                "source_hypothesis_id": "cross_sectional_momentum_v0",
+                "evidence_pack_id": "qep_fixture",
+                "disposition": "READY_FOR_SYNTHESIS",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = bss.run_bounded_strategy_synthesis(repo_root=tmp_path, write_outputs=True)
+
+    assert result["research_validation"]["status"] == "PASSED"

--- a/tests/unit/test_qre_empirical_evidence_pack.py
+++ b/tests/unit/test_qre_empirical_evidence_pack.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from packages.qre_research import empirical_evidence_pack as eep
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_build_empirical_evidence_pack_is_canonical_and_fail_closed(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _write_json(
+        repo_root / "generated_research/registry/generated_strategy_registry.v1.json",
+        {
+            "rows": [
+                {
+                    "generated_strategy_id": "qgs_fixture",
+                    "source_hypothesis_id": "cross_sectional_momentum_v0",
+                    "strategy_spec_id": "qsp_fixture",
+                    "sandbox_validation_path": "generated_research/validation/qgs_fixture.json",
+                }
+            ]
+        },
+    )
+    _write_json(
+        repo_root / "generated_research/readiness/campaigns/automated_portfolio_readiness.v1.json",
+        {
+            "rows": [
+                {
+                    "campaign_cell_id": "qrcell_fixture",
+                    "timeframe": "4h",
+                    "train_window": {"start": "2024-01-01T00:00:00Z", "end": "2024-06-01T00:00:00Z"},
+                    "validation_window": {"start": "2024-06-15T00:00:00Z", "end": "2024-09-01T00:00:00Z"},
+                    "oos_window": {"start": "2024-09-15T00:00:00Z", "end": "2024-12-01T00:00:00Z"},
+                }
+            ]
+        },
+    )
+    _write_json(
+        repo_root / "generated_research/specs/qsp_fixture.json",
+        {
+            "cost_assumptions": {"mode": "cost_class_visible_only"},
+            "slippage_assumptions": {"status": "visible"},
+        },
+    )
+    closeout = {
+        "executed_campaign_identity": "qcx_fixture",
+        "executed_campaign_cell": "qrcell_fixture",
+        "train_stage": {"trade_count": 12, "net_return_compound": 0.11},
+        "validation_stage": {"trade_count": 4, "net_return_compound": 0.03},
+        "oos_stage": {
+            "trade_count": 3,
+            "net_return_compound": 0.02,
+            "oos_outcome": "INSUFFICIENT_TRADES",
+            "costs": 0.0,
+            "slippage": 0.0,
+            "trades": [{"net_return": 0.02}, {"net_return": -0.01}, {"net_return": 0.005}],
+        },
+        "null_controls": {
+            "null_control_passed": False,
+            "rows": [{"control_class": "matched_frequency_null"}],
+        },
+        "decision": {
+            "hypothesis_decision": "BLOCKED_SAMPLE_SIZE",
+            "strategy_decision": "INSUFFICIENT_EVIDENCE",
+            "failure_memory_update": {"generated_strategy_id": "qgs_fixture"},
+            "contradiction_update": {"evidence": "oos_sample_size_insufficient_after_ready_cell_execution"},
+        },
+        "feedback_routing": {"next_action": "launch_data_oos_capacity_expansion"},
+        "terminal_outcome": "DATA_OR_OOS_CAPACITY_BLOCKED",
+    }
+
+    payload = eep.build_empirical_evidence_pack(repo_root=repo_root, closeout=closeout)
+
+    assert payload["source_hypothesis_id"] == "cross_sectional_momentum_v0"
+    assert payload["generated_strategy_id"] == "qgs_fixture"
+    assert payload["controlled_evaluation"]["status"] == "AVAILABLE"
+    assert payload["walk_forward"]["status"] == "AVAILABLE"
+    assert payload["oos"]["status"] == "AVAILABLE"
+    assert payload["null_model"]["status"] == "AVAILABLE"
+    assert payload["disposition"] == "NEEDS_MORE_EVIDENCE"
+    assert payload["recommended_next_action"] == "launch_data_oos_capacity_expansion"

--- a/tests/unit/test_qre_empirical_research_flywheel.py
+++ b/tests/unit/test_qre_empirical_research_flywheel.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.qre_research import empirical_research_flywheel as flywheel
+
+
+def test_empirical_research_flywheel_composes_canonical_chain(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        flywheel.a20,
+        "compile_candidate_theses",
+        lambda repo_root: {
+            "rows": [
+                {"behavior_family": "relative_strength"},
+                {"behavior_family": "trend"},
+            ],
+            "summary": {
+                "candidate_count": 2,
+                "admitted_count": 1,
+                "exact_duplicate_suppressed_count": 0,
+                "near_duplicate_suppressed_count": 1,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.qhl,
+        "run_trusted_hypothesis_loop",
+        lambda repo_root, write_outputs: {
+            "summary": {
+                "next_action": "launch_data_oos_capacity_expansion",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.qhl,
+        "build_feasibility_snapshot",
+        lambda repo_root: {"summary": {"feasibility_ready_count": 1}},
+    )
+    monkeypatch.setattr(
+        flywheel.qhl,
+        "build_routing_snapshot",
+        lambda repo_root: {"summary": {"routing_ready_count": 1}},
+    )
+    monkeypatch.setattr(
+        flywheel.qhl,
+        "build_sampling_snapshot",
+        lambda repo_root: {"summary": {"sampling_ready_count": 0}},
+    )
+    monkeypatch.setattr(
+        flywheel.ao,
+        "run_orchestration",
+        lambda **kwargs: {
+            "cycles_completed": 3,
+            "campaigns_executed": 1,
+            "next_autonomous_action": "launch_data_oos_capacity_expansion",
+            "latest_status_identity": "qstatus_fixture",
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.eep,
+        "run_empirical_evidence_pack",
+        lambda **kwargs: {
+            "evidence_pack_id": "qep_fixture",
+            "disposition": "NEEDS_MORE_EVIDENCE",
+            "recommended_next_action": "launch_data_oos_capacity_expansion",
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.bss,
+        "materialize_synthesis_readiness",
+        lambda **kwargs: {
+            "readiness_status": "INELIGIBLE_EVIDENCE",
+            "recommended_next_actions": ["launch_data_oos_capacity_expansion"],
+        },
+    )
+    monkeypatch.setattr(
+        flywheel.bss,
+        "run_bounded_strategy_synthesis",
+        lambda **kwargs: {
+            "status": "BLOCKED_BY_READINESS",
+            "recommended_next_actions": ["launch_data_oos_capacity_expansion"],
+        },
+    )
+    monkeypatch.setattr(flywheel, "validate_write_target", lambda path: None)
+
+    payload = flywheel.run_empirical_research_flywheel(
+        repo_root=tmp_path,
+        max_cycles=3,
+        write_outputs=True,
+        report_date="2026-07-01",
+    )
+
+    assert payload["summary"]["candidate_count"] == 2
+    assert payload["summary"]["research_cycles_executed"] == 3
+    assert payload["summary"]["campaigns_executed"] == 1
+    assert payload["summary"]["synthesis_readiness"] == "INELIGIBLE_EVIDENCE"
+    assert payload["summary"]["next_action"] == "launch_data_oos_capacity_expansion"
+    assert (tmp_path / flywheel.FLYWHEEL_REPORT_PATH).is_file()

--- a/tests/unit/test_qre_hypothesis_lifecycle.py
+++ b/tests/unit/test_qre_hypothesis_lifecycle.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from packages.qre_research import hypothesis_lifecycle as qhl
+
+
+def test_current_cross_sectional_lifecycle_uses_readiness_bridge() -> None:
+    feasibility = qhl.build_feasibility_snapshot()
+    row = next(
+        item
+        for item in feasibility["rows"]
+        if item["source_hypothesis_id"] == "cross_sectional_momentum_v0"
+    )
+
+    assert row["status"] == "ready"
+    assert row["primitive_compatibility"] == "COMPILABLE_WITH_CURRENT_PRIMITIVES"
+    assert row["portfolio_status"] == "BLOCKED_WINDOWS"
+    assert row["next_action"] == "preserve_fail_closed_data_window_capacity_blockers"
+
+
+def test_current_cross_sectional_sampling_materializes_exact_window_blocker() -> None:
+    sampling = qhl.build_sampling_snapshot()
+    row = next(
+        item
+        for item in sampling["rows"]
+        if item["source_hypothesis_id"] == "cross_sectional_momentum_v0"
+    )
+
+    assert row["sampling_status"] == "blocked"
+    assert "usable_history_below_minimum_policy_span" in row["sampling_reason_codes"]
+    assert row["next_action"] == "preserve_fail_closed_data_window_capacity_blockers"

--- a/tests/unit/test_synthesis_gate.py
+++ b/tests/unit/test_synthesis_gate.py
@@ -338,3 +338,54 @@ def test_generated_hypothesis_readiness_tracks_missing_lifecycle_artifacts() -> 
     assert payload["readiness_status"] == "INELIGIBLE_EVIDENCE"
     assert "generated_hypothesis_lifecycle_artifacts_missing" in payload["blocking_reasons"]
     assert "generated_hypothesis_feasibility" in payload["missing_evidence"]
+
+
+def test_generated_hypothesis_readiness_becomes_eligible_with_empirical_pack() -> None:
+    payload = sg.build_generated_hypothesis_synthesis_payload(
+        generated_artifacts={
+            "generated_registry": {
+                "rows": [
+                    {
+                        "thesis_id": "qht_fixture",
+                        "source_hypothesis_id": "cross_sectional_momentum_v0",
+                    }
+                ]
+            },
+            "feasibility": {
+                "rows": [
+                    {
+                        "thesis_id": "qht_fixture",
+                        "source_hypothesis_id": "cross_sectional_momentum_v0",
+                        "status": "ready",
+                    }
+                ]
+            },
+            "routing": {"rows": [{"thesis_id": "qht_fixture", "routing_status": "ready"}]},
+            "sampling": {"rows": [{"thesis_id": "qht_fixture", "sampling_status": "ready"}]},
+            "reason_records": {"rows": [{"reason_record_id": "qrr_1"}]},
+            "evidence_updates": {"rows": [{"evidence_update_id": "qhe_1", "missing_evidence": []}]},
+            "failure_actions": {"rows": [{"failure_action_id": "qhfa_1"}]},
+            "research_memory": {"rows": [{"memory_id": "qhm_1"}]},
+            "trusted_loop_summary": {
+                "next_action": "continue",
+                "empirical_research_evidence_materialized": True,
+            },
+            "empirical_evidence_pack": {
+                "source_hypothesis_id": "cross_sectional_momentum_v0",
+                "controlled_evaluation": {"status": "AVAILABLE"},
+                "oos": {"status": "AVAILABLE"},
+                "transaction_costs": {"status": "AVAILABLE"},
+                "null_model": {"status": "AVAILABLE"},
+                "stability": {"status": "AVAILABLE"},
+                "regime_evidence": {"status": "AVAILABLE"},
+                "missing_evidence": [],
+                "disposition": "READY_FOR_SYNTHESIS",
+            },
+        },
+        artifact_status=_generated_statuses(),
+        generated_at_utc=datetime(2026, 5, 22, 12, 0, tzinfo=UTC),
+    )
+
+    assert payload["readiness_status"] == "ELIGIBLE"
+    assert "controlled_evaluation_complete" in payload["criteria_passed"]
+    assert "oos_ready" in payload["criteria_passed"]


### PR DESCRIPTION
﻿## Program objective

Build a bounded empirical QRE flywheel that can bridge generated hypotheses into canonical readiness, execute the existing bounded campaign path, materialize one reusable empirical evidence pack, reassess synthesis readiness fail-closed, and choose the next bounded research action without touching paper, shadow, live, broker, risk, capital, or deployment surfaces.

## Current bottleneck

The first generated hypothesis no longer fails on a missing primitive. The canonical readiness chain resolves it to:

- source hypothesis: `cross_sectional_momentum_v0`
- feasibility: ready
- routing: ready
- sampling: blocked
- blocker: `usable_history_below_minimum_policy_span`
- next action: `launch_data_oos_capacity_expansion`

## Step 1 — First runnable hypothesis

- Reworked `packages/qre_research/hypothesis_lifecycle.py` to bridge generated hypotheses to the authoritative readiness artifacts instead of treating the original generation snapshot as final truth.
- Feasibility now checks generated strategy registration, primitive registry state, data bindings, universe authority, source quality, and current portfolio readiness.
- Routing now uses the current readiness/blocker state for deterministic ordering and reason codes.
- Sampling now materializes exact campaign-window blockers and canonical next actions.
- Result on current repo data: `cross_sectional_momentum_v0` becomes feasibility-ready and routing-ready, then stops honestly at the window-capacity blocker.

## Step 2 — Empirical evidence pack

- Added `packages/qre_research/empirical_evidence_pack.py`.
- This wraps the existing bounded preregistered campaign executor and converts its closeout into one canonical empirical evidence pack.
- The pack materializes controlled evaluation, walk-forward, OOS, transaction-cost, slippage, null-model, stability, outlier-dependency, supporting/contradicting evidence, disposition, and next action.
- It remains fail-closed where the underlying executor does not yet materialize a given evidence family.

## Step 3 — Strategy synthesis and validation

- Extended `research/synthesis_gate.py` so generated-hypothesis synthesis readiness consumes the empirical evidence pack when present.
- Extended `packages/qre_research/bounded_strategy_synthesis.py` so research validation can inherit empirical evidence disposition instead of always reporting fixture-only readiness.
- Synthesis still blocks unless empirical disposition is `READY_FOR_SYNTHESIS`.
- On current repo data the generated hypothesis remains `INELIGIBLE_EVIDENCE`, which is the correct outcome.

## Step 4 — Multi-hypothesis throughput

- Added `packages/qre_research/empirical_research_flywheel.py`.
- This composes candidate generation summary, trusted lifecycle materialization, canonical orchestration replay, empirical evidence pack materialization, synthesis readiness reassessment, and bounded synthesis into one bounded report.
- It reports batch-level throughput over the current candidate set and preserves orchestration bounds.

## Step 5 — Closed-loop learning

- The trusted lifecycle now records blocker-aware reason records, evidence updates, failure actions, and research-memory entries that carry campaign/evidence disposition forward.
- The flywheel next action resolves from empirical disposition, readiness, and orchestration outputs in deterministic order.
- On current repo data the flywheel ends at `launch_data_oos_capacity_expansion`.

## Commit map

1. `af6fb62` `feat: make first generated hypothesis research runnable`
2. `14b90bf` `feat: materialize canonical empirical evidence pack`
3. `6328515` `feat: automate bounded strategy synthesis validation`
4. `2afec92` `feat: add multi-hypothesis research throughput`
5. `b47b859` `test: prove empirical flywheel end to end`
6. `26e7dd0` `docs: document research flywheel operation`

## Canonical contracts used

- `registry.py` remains untouched as the canonical strategy registration authority.
- `agent/backtesting/strategies.py` remains untouched.
- `research/run_research.py` remains untouched as the central orchestrator surface.
- Generated-hypothesis lifecycle remains under `generated_research/hypotheses/lifecycle/**`.
- Strategy readiness/candidate/proposal artifacts remain under `generated_research/strategies/**`.
- Campaign execution/evidence remains under `generated_research/campaign_execution/**`.
- Existing readiness artifacts under `generated_research/readiness/**` remain the source for feasibility/routing/sampling settlement.

## Primitive extensions

- No new primitive family was introduced in this PR.
- The first generated hypothesis is now bridged to the already-authoritative primitive/readiness state instead of remaining frozen on the historical primitive-gap snapshot.

## Data and universe assumptions

- Reads only canonical local readiness, generated strategy, generated hypothesis, campaign, identity, and cache-coverage artifacts.
- No external data fetch, network model call, broker call, or runtime dependency install is added.

## Routing and sampling behavior

- Routing is deterministic and blocker-aware.
- Sampling now exposes exact campaign windows when available and exact blockers when they are not.
- Current first generated hypothesis lands on `usable_history_below_minimum_policy_span` rather than a placeholder blocker.

## OOS conservation

- The empirical evidence pack reads the existing preregistered campaign closeout and preserved OOS usage.
- No hypothesis or blueprint is rewritten after OOS observation.

## Evidence dispositions

- The empirical evidence pack uses bounded closed-vocabulary dispositions.
- Current real outcome is `NEEDS_MORE_EVIDENCE`, not forced synthesis.

## Strategy safety invariants

- Research-only candidates remain disabled.
- No paper, shadow, live, broker, risk, capital, or deployment behavior is activated.
- No arbitrary code generation, `eval`, `exec`, dynamic import from generated strings, or network model call is introduced.

## Queue and compute bounds

- Lifecycle throughput stays bounded via `MAX_HYPOTHESES_PER_CYCLE = 10` in the trusted lifecycle bridge.
- The empirical flywheel remains bounded by `max_cycles` and one synthesis attempt per cycle.
- Canonical orchestration budgets remain in force.

## Tests

- Targeted and adjacent unit/integration tests:
  - `python -m pytest tests/unit/test_qre_automated_hypothesis_generation.py tests/unit/test_qre_hypothesis_lifecycle.py tests/unit/test_qre_autonomous_readiness_closure.py tests/unit/test_qre_automated_data_window_capacity.py tests/unit/test_qre_second_preregistered_campaign.py tests/unit/test_qre_empirical_evidence_pack.py tests/unit/test_qre_autonomous_orchestration.py tests/unit/test_qre_bounded_strategy_synthesis.py tests/unit/test_qre_empirical_research_flywheel.py tests/unit/test_synthesis_gate.py tests/integration/test_qre_empirical_research_flywheel_end_to_end.py -q`
- Architecture:
  - `python -m pytest tests/architecture -q`
- Smoke:
  - `python -m pytest tests/smoke -q`
- Governance:
  - `python scripts/governance_lint.py`
- Architecture scan:
  - `python -m reporting.architecture_import_scan --format summary`

## Functional run evidence

Bounded local functional flywheel run on current repo data produced:

- candidates generated: `4`
- behavior families: `4`
- admitted hypotheses: `1`
- research cycles executed: `1`
- campaigns executed: `1`
- feasibility-ready: `1`
- routing-ready: `1`
- sampling-ready: `0`
- empirical evidence disposition: `NEEDS_MORE_EVIDENCE`
- synthesis readiness: `INELIGIBLE_EVIDENCE`
- synthesis status: `BLOCKED_BY_READINESS`
- next action: `launch_data_oos_capacity_expansion`

## Frozen contracts

- `research/research_latest.json`: unchanged
- `research/strategy_matrix.csv`: unchanged

## Protected path status

- No forbidden path under `.claude/**`, `paper/**`, `shadow/**`, `live/**`, `broker/**`, `agent/risk/**`, `agent/execution/**`, `trading/**`, `capital/**`, or `deployment/**` was modified.

## Paper/shadow/live isolation

This PR does not activate paper, shadow, live, broker, risk,
capital allocation or deployment behavior.

## Known limitations

- The canonical preregistered campaign executor is still hardwired to the existing ready ATR cell; this PR wraps that executor into a reusable evidence pack but does not replace the underlying executor contract.
- The first generated hypothesis remains blocked at window/data capacity and therefore does not become synthesis-eligible on current repo data.
- Regime evidence and parameter fragility remain fail-closed when the bounded campaign executor does not yet materialize them.

## Rollback plan

- Revert this PR.
- Delete the added package modules and tests.
- Remove the lifecycle bridge updates and restore the previous fail-closed synthesis-readiness behavior.

## Actual next action

`launch_data_oos_capacity_expansion`
