### PR TITLE
fix: prevent opportunity loop from self-triggering on its own artifacts

### DIFF
--- a/packages/qre_research/autonomous_opportunity_loop.py
+++ b/packages/qre_research/autonomous_opportunity_loop.py
@@ -1733,7 +1733,6 @@ def run_opportunity_loop(
                 "summary": {"resolved_request_count": 0},
                 "content_identity": _content_id("qrafb", []),
             }
-            qhl.run_trusted_hypothesis_loop(repo_root=repo_root, write_outputs=write_outputs)
         else:
             opportunities = discover_opportunities(
                 repo_root=repo_root,

--- a/tests/unit/test_qre_autonomous_opportunity_loop.py
+++ b/tests/unit/test_qre_autonomous_opportunity_loop.py
@@ -447,7 +447,7 @@ def test_run_opportunity_loop_stops_early_on_no_material_change(
     assert payload["hypotheses"]["generated"] == 0
     assert payload["campaigns"]["executed"] == 0
     assert payload["ade_requests"]["new_requests"] == 0
-    assert trusted_calls == ["trusted"]
+    assert trusted_calls == []
 
 
 def test_run_opportunity_loop_second_identical_invocation_is_no_op(
@@ -478,7 +478,7 @@ def test_run_opportunity_loop_second_identical_invocation_is_no_op(
     assert second["campaigns"]["executed"] == 0
     assert second["ade_requests"]["new_requests"] == 0
     assert first["watermark"]["watermark_id"] == second["watermark"]["watermark_id"]
-    assert trusted_calls == ["trusted", "trusted"]
+    assert trusted_calls == []
 
 
 def test_run_opportunity_loop_executes_material_opportunity_and_writes_artifacts(


### PR DESCRIPTION
Follow-up hotfix for the post-merge idempotence regression discovered during replay verification.

Fix:
- skip the trusted hypothesis loop on the NO_MATERIAL_CHANGE path
- preserve identical watermark identity across repeated invocations
- keep the replay path fully quiescent when external state is unchanged

Validation:
- targeted opportunity-loop unit tests
- idempotence integration test
- architecture boundary test
- ruff
- git diff --check