### PR TITLE
fix: restore deterministic qre supervisor cold starts

### DIFF
--- a/agent/brain/agent.py
+++ b/agent/brain/agent.py
@@ -15,11 +15,11 @@ Alles configureer je via config/config.yaml
 
 import asyncio
 import logging
-import yaml
 from datetime import datetime
 from pathlib import Path
 
 # Interne modules
+from agent.runtime_config import load_runtime_config
 from agent.brain.regime_detector import RegimeDetector
 from agent.brain.signal_aggregator import SignalAggregator
 from agent.risk.risk_manager import RiskManager
@@ -56,8 +56,7 @@ class TradingAgent:
 
     def __init__(self, config_pad: str = "config/config.yaml"):
         # Laad configuratie
-        with open(config_pad) as f:
-            self.config = yaml.safe_load(f)
+        self.config = load_runtime_config(config_pad)
 
         log.info(f"Agent gestart: {self.config['agent']['naam']}")
         log.info(f"Startkapitaal: €{self.config['kapitaal']['start']}")

--- a/agent/runtime_config.py
+++ b/agent/runtime_config.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+POLYMARKET_SECRET_ENV_MAP = {
+    "private_key": ("POLYMARKET_PRIVATE_KEY", "POLYMARKET_PRIVATE_KEY_FILE"),
+    "alchemy_rpc": ("POLYMARKET_ALCHEMY_RPC_URL", "POLYMARKET_ALCHEMY_RPC_URL_FILE"),
+    "proxy_wallet": ("POLYMARKET_PROXY_WALLET", "POLYMARKET_PROXY_WALLET_FILE"),
+}
+_PLACEHOLDER_VALUES = {"", "INVULLEN", "env", "secret"}
+_SENSITIVE_FIELD_NAMES = {"private_key", "alchemy_rpc", "api_key", "api_secret", "secret", "token", "password"}
+
+
+class RuntimeConfigError(RuntimeError):
+    """Raised when runtime configuration is incomplete for an active exchange."""
+
+
+def _read_secret_value(env_name: str, file_env_name: str) -> str:
+    direct = str(os.environ.get(env_name) or "").strip()
+    if direct:
+        return direct
+    file_path = str(os.environ.get(file_env_name) or "").strip()
+    if not file_path:
+        return ""
+    candidate = Path(file_path)
+    if not candidate.is_file():
+        raise RuntimeConfigError(f"runtime secret file missing for {env_name}: {file_env_name}")
+    return candidate.read_text(encoding="utf-8").strip()
+
+
+def _looks_like_placeholder(value: Any) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return True
+    lowered = text.lower()
+    if lowered in {item.lower() for item in _PLACEHOLDER_VALUES}:
+        return True
+    if lowered.startswith("env:") or lowered.startswith("${"):
+        return True
+    return False
+
+
+def load_runtime_config(config_path: str = "config/config.yaml") -> dict[str, Any]:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+    if not isinstance(payload, dict):
+        return {}
+    return apply_runtime_secrets(payload)
+
+
+def apply_runtime_secrets(config: dict[str, Any]) -> dict[str, Any]:
+    exchanges = config.get("exchanges")
+    if not isinstance(exchanges, dict):
+        return config
+    polymarket = exchanges.get("polymarket")
+    if not isinstance(polymarket, dict):
+        return config
+    missing: list[str] = []
+    for field, (env_name, file_env_name) in POLYMARKET_SECRET_ENV_MAP.items():
+        resolved = _read_secret_value(env_name, file_env_name)
+        if resolved:
+            polymarket[field] = resolved
+            continue
+        if _looks_like_placeholder(polymarket.get(field)):
+            polymarket[field] = ""
+        if bool(polymarket.get("actief")) and not str(polymarket.get(field) or "").strip():
+            missing.append(env_name)
+    if bool(polymarket.get("actief")) and missing:
+        joined = ", ".join(missing)
+        raise RuntimeConfigError(f"Polymarket actief maar runtime secrets ontbreken: {joined}")
+    return config
+
+
+def redact_sensitive_values(payload: Any, *, config: dict[str, Any] | None = None) -> Any:
+    secrets = {
+        value
+        for env_name, file_env_name in POLYMARKET_SECRET_ENV_MAP.values()
+        for value in (
+            str(os.environ.get(env_name) or "").strip(),
+            str(os.environ.get(file_env_name) or "").strip(),
+        )
+        if value
+    }
+    if config:
+        exchanges = config.get("exchanges") if isinstance(config, dict) else {}
+        polymarket = exchanges.get("polymarket") if isinstance(exchanges, dict) else {}
+        if isinstance(polymarket, dict):
+            for field in POLYMARKET_SECRET_ENV_MAP:
+                value = str(polymarket.get(field) or "").strip()
+                if value:
+                    secrets.add(value)
+    return _redact(payload, secrets=secrets)
+
+
+def _redact(payload: Any, *, secrets: set[str]) -> Any:
+    if isinstance(payload, dict):
+        redacted: dict[str, Any] = {}
+        for key, value in payload.items():
+            if str(key).lower() in _SENSITIVE_FIELD_NAMES:
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = _redact(value, secrets=secrets)
+        return redacted
+    if isinstance(payload, list):
+        return [_redact(item, secrets=secrets) for item in payload]
+    if isinstance(payload, tuple):
+        return tuple(_redact(item, secrets=secrets) for item in payload)
+    if isinstance(payload, str):
+        redacted = payload
+        for secret in sorted(secrets, key=len, reverse=True):
+            redacted = redacted.replace(secret, "[REDACTED]")
+        return redacted
+    return payload
+
+
+__all__ = [
+    "POLYMARKET_SECRET_ENV_MAP",
+    "RuntimeConfigError",
+    "apply_runtime_secrets",
+    "load_runtime_config",
+    "redact_sensitive_values",
+]

--- a/config/config.template.yaml
+++ b/config/config.template.yaml
@@ -38,9 +38,9 @@ exchanges:
     paper_trading: true
   polymarket:
     actief: false
-    private_key: "INVULLEN"
-    proxy_wallet: "INVULLEN"
-    alchemy_rpc: "INVULLEN"
+    private_key: "env:POLYMARKET_PRIVATE_KEY"
+    proxy_wallet: "env:POLYMARKET_PROXY_WALLET"
+    alchemy_rpc: "env:POLYMARKET_ALCHEMY_RPC_URL"
 
 assets:
   crypto:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,12 @@ services:
     environment:
       - TZ=Europe/Amsterdam        # Nederlandse tijdzone
       - PYTHONPATH=/app            # absolute imports (data.contracts, reporting.*) werken als script
+      - POLYMARKET_PRIVATE_KEY
+      - POLYMARKET_PRIVATE_KEY_FILE
+      - POLYMARKET_ALCHEMY_RPC_URL
+      - POLYMARKET_ALCHEMY_RPC_URL_FILE
+      - POLYMARKET_PROXY_WALLET
+      - POLYMARKET_PROXY_WALLET_FILE
     networks:
       - agent_netwerk
 
@@ -90,8 +96,17 @@ services:
       - PYTHONPATH=/app
     networks:
       - agent_netwerk
-    depends_on:
-      - agent
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -m
+        - reporting.qre_research_supervisor
+        - --healthcheck
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   nginx:
     image: nginx:alpine

--- a/docs/operations/qre_research_supervisor.md
+++ b/docs/operations/qre_research_supervisor.md
@@ -21,11 +21,32 @@ The container image carries code only. Mutable research state must remain on per
 - `logs`
 - `research`
 
+The supervisor is intentionally isolated from the regular trading agent:
+
+- `qre-research-supervisor` has no `depends_on: agent`
+- targeted `docker compose up -d --no-deps qre-research-supervisor` must not start `agent`
+- the supervisor healthcheck is the native CLI probe:
+  `python -m reporting.qre_research_supervisor --healthcheck`
+
 ## Restart Behavior
 
 - leases are bounded and stale-safe
-- snapshot lineage remains immutable
+- snapshot lineage set identity is canonical and deterministic across roots, ordering, and restart
+- lineage identity includes semantic snapshot content only:
+  dataset family, acquisition batches, parent linkage, instruments, timeframe, time range, row counts, fingerprint, source, qualification status, immutability, compatibility status, lineage depth
+- lineage identity excludes non-semantic runtime metadata:
+  absolute paths, temporary roots, directory enumeration order, JSON key order, `created_at_utc`, filesystem mtimes, and audit-only partition paths
 - source qualifications remain reusable
 - blocked experiments retain resume tokens
+- coherent legacy epoch IDs are reconciled atomically into the published runtime epoch state
+- genuine epoch mismatches remain fail-closed and unhealthy
 - supervisor no-change cycles skip duplicate research work
 - restart does not reclassify a prior search exposure as a new hypothesis
+
+## Runtime Secrets
+
+- the research supervisor does not require trading secrets
+- Polymarket runtime secrets are injected only into the regular trading agent via environment variables or `*_FILE` secret paths
+- supported names:
+  `POLYMARKET_PRIVATE_KEY`, `POLYMARKET_PRIVATE_KEY_FILE`, `POLYMARKET_ALCHEMY_RPC_URL`, `POLYMARKET_ALCHEMY_RPC_URL_FILE`, `POLYMARKET_PROXY_WALLET`, `POLYMARKET_PROXY_WALLET_FILE`
+- when Polymarket is active and required runtime secrets are missing, the trading agent fails closed without partial initialization

--- a/packages/qre_research/alpha_discovery/runner.py
+++ b/packages/qre_research/alpha_discovery/runner.py
@@ -104,6 +104,7 @@ VALIDATION_VIEW_PATH = OUTPUT_ROOT / "views" / "validation_latest.json"
 LOCKED_OOS_VIEW_PATH = OUTPUT_ROOT / "views" / "locked_oos_latest.json"
 RUNS_PATH = OUTPUT_ROOT / "runs" / "latest.json"
 STATUS_PATH = OUTPUT_ROOT / "status" / "latest.json"
+RUNTIME_EPOCH_PATH = OUTPUT_ROOT / "runtime_epoch" / "latest.json"
 
 TIER_ALIAS = {
     "compiler": EXECUTION_TIER_COMPILER_ONLY,
@@ -126,6 +127,8 @@ def _atomic_json(path: Path, payload: Mapping[str, Any]) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
             handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
         try:
             os.replace(tmp_name, path)
         except PermissionError:
@@ -664,6 +667,40 @@ def read_status(repo_root: Path) -> dict[str, Any]:
     }
 
 
+def _runtime_epoch_payload(
+    *,
+    run_payload: Mapping[str, Any],
+    snapshot_lineage_set_id: str,
+    qualification_set_id: str,
+) -> dict[str, Any]:
+    runtime_epoch_components = {
+        "snapshot_lineage_set_id": snapshot_lineage_set_id,
+        "qualification_set_id": qualification_set_id,
+        "alpha_run_id": str(run_payload.get("run_id") or ""),
+        "alpha_campaign_id": str(run_payload.get("campaign_id") or ""),
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "policy_version": POLICY_VERSION,
+        "report_kind": "qre_alpha_runtime_epoch",
+        "runtime_epoch_id": content_id("qepoch", runtime_epoch_components),
+        "qualification_set_id": qualification_set_id,
+        "snapshot_lineage_set_id": snapshot_lineage_set_id,
+        "run_id": str(run_payload.get("run_id") or ""),
+        "campaign_id": str(run_payload.get("campaign_id") or ""),
+        "current_dataset_snapshot": run_payload.get("current_dataset_snapshot"),
+        "current_source_tier": run_payload.get("current_source_tier"),
+        "current_experiment": run_payload.get("current_experiment"),
+        "current_campaign": run_payload.get("current_campaign"),
+        "terminal_disposition": run_payload.get("terminal_disposition"),
+        "execution_status": run_payload.get("execution_status"),
+        "scientific_disposition": run_payload.get("scientific_disposition"),
+        "evidence_tier_reached": run_payload.get("evidence_tier_reached"),
+        "search_ledger_id": run_payload.get("search_ledger_id"),
+        "content_identity": content_id("qepochstate", runtime_epoch_components),
+    }
+
+
 def run_alpha_discovery_mvp(
     *,
     repo_root: Path,
@@ -907,14 +944,6 @@ def run_alpha_discovery_mvp(
         evidence_tier_reached = EXECUTION_TIER_EXECUTOR_SMOKE
     else:
         evidence_tier_reached = EXECUTION_TIER_COMPILER_ONLY
-    runtime_epoch_components = {
-        "snapshot_lineage_set_id": snapshot_lineage["snapshot_lineage"]["content_identity"],
-        "qualification_set_id": source_qualifications["content_identity"],
-        "alpha_run_id": content_id("qarr", {"observation": observation.content_identity, "selected": getattr(selected, "hypothesis_id", ""), "tier": requested_execution_tier}),
-        "alpha_campaign_id": campaign_id or "",
-    }
-    runtime_epoch_id = content_id("qepoch", runtime_epoch_components)
-
     budget_usage = RunBudgetUsage(
         observation_snapshots=1,
         raw_hypotheses=len(hypotheses),
@@ -938,7 +967,7 @@ def run_alpha_discovery_mvp(
         "scientific_disposition": scientific_disposition,
         "evidence_tier_reached": evidence_tier_reached,
         "legacy_terminal_disposition": terminal_disposition,
-        "runtime_epoch_id": runtime_epoch_id,
+        "runtime_epoch_id": "",
         "qualification_set_id": source_qualifications["content_identity"],
         "snapshot_lineage_set_id": snapshot_lineage["snapshot_lineage"]["content_identity"],
         "state_trace": [
@@ -994,6 +1023,13 @@ def run_alpha_discovery_mvp(
         "gap_ids": [row.gap_id for row in gap_rows],
         "blocked_experiment_ids": [row.experiment_id for row in blocked_rows],
     }
+    runtime_epoch = _runtime_epoch_payload(
+        run_payload=run_payload,
+        snapshot_lineage_set_id=snapshot_lineage["snapshot_lineage"]["content_identity"],
+        qualification_set_id=source_qualifications["content_identity"],
+    )
+    runtime_epoch_id = runtime_epoch["runtime_epoch_id"]
+    run_payload["runtime_epoch_id"] = runtime_epoch_id
     artifacts = {
         "observation": observation.to_payload(),
         "hypotheses": [hyp.to_payload() for hyp in final_hypotheses],
@@ -1094,6 +1130,7 @@ def run_alpha_discovery_mvp(
         "resolution_feedback": _write_artifact(RESOLUTION_FEEDBACK_PATH, artifacts["resolution_feedback"] or {"schema_version": SCHEMA_VERSION, "rows": []}, repo_root=repo_root),
         "discovery_view": _write_artifact(DISCOVERY_VIEW_PATH, {"schema_version": SCHEMA_VERSION, "policy_version": POLICY_VERSION, "report_kind": "qre_alpha_discovery_view", "view": discovery_view}, repo_root=repo_root),
         "runs": _write_artifact(RUNS_PATH, artifacts["runs"], repo_root=repo_root),
+        "runtime_epoch": _write_artifact(RUNTIME_EPOCH_PATH, runtime_epoch, repo_root=repo_root),
         "status": _write_artifact(STATUS_PATH, artifacts["status"], repo_root=repo_root),
     }
     if validation_view is not None:
@@ -1107,5 +1144,6 @@ def run_alpha_discovery_mvp(
     run_payload["content_identity"] = content_id("qarrc", identity_input)
     artifacts["status"]["content_identity"] = content_id("qasd_status", identity_input)
     artifact_refs["runs"] = _write_artifact(RUNS_PATH, run_payload, repo_root=repo_root)
+    artifact_refs["runtime_epoch"] = _write_artifact(RUNTIME_EPOCH_PATH, runtime_epoch, repo_root=repo_root)
     artifact_refs["status"] = _write_artifact(STATUS_PATH, artifacts["status"], repo_root=repo_root)
     return {**run_payload, "artifact_refs": artifact_refs, "artifacts": artifacts}

--- a/packages/qre_research/alpha_discovery/snapshot_lineage.py
+++ b/packages/qre_research/alpha_discovery/snapshot_lineage.py
@@ -14,6 +14,7 @@ from packages.qre_data.dataset_catalog import materialize_data_truth
 from .contracts import (
     DatasetSnapshot,
     SnapshotRevision,
+    canonical_payload,
     content_id,
     stable_digest,
 )
@@ -47,7 +48,10 @@ def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(text, encoding="utf-8", newline="\n")
+    with tmp.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(text)
+        handle.flush()
+        os.fsync(handle.fileno())
     os.replace(tmp, path)
 
 
@@ -72,6 +76,97 @@ def _query_timestamp(value: str) -> str:
     return f"{value[:4]}-{value[4:6]}-{value[6:8]}T00:00:00Z"
 
 
+def _normalize_partition_refs(partition_refs: tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
+    if not partition_refs:
+        return ()
+    normalized = {Path(str(value)).name for value in partition_refs if str(value).strip()}
+    return tuple(sorted(normalized))
+
+
+def _snapshot_semantic_identity(snapshot: DatasetSnapshot | dict[str, Any]) -> dict[str, Any]:
+    row = asdict(snapshot) if isinstance(snapshot, DatasetSnapshot) else dict(snapshot)
+    return canonical_payload(
+        {
+            "logical_dataset_family_id": row.get("logical_dataset_family_id") or "",
+            "acquisition_batch_ids": tuple(sorted(str(value) for value in row.get("acquisition_batch_ids") or () if str(value).strip())),
+            "parent_snapshot_id": row.get("parent_snapshot_id"),
+            "instrument_ids": tuple(sorted(str(value) for value in row.get("instrument_ids") or () if str(value).strip())),
+            "timeframe": row.get("timeframe") or "",
+            "start": row.get("start") or "",
+            "end": row.get("end") or "",
+            "unique_bar_count": int(row.get("unique_bar_count") or 0),
+            "raw_row_count": int(row.get("raw_row_count") or 0),
+            "exact_duplicate_row_count": int(row.get("exact_duplicate_row_count") or 0),
+            "overlapping_row_count": int(row.get("overlapping_row_count") or 0),
+            "conflicting_row_count": int(row.get("conflicting_row_count") or 0),
+            "invalid_row_count": int(row.get("invalid_row_count") or 0),
+            "expected_bar_count": row.get("expected_bar_count"),
+            "coverage_ratio": row.get("coverage_ratio"),
+            "fingerprint": row.get("fingerprint") or "",
+            "source_id": row.get("source_id") or "",
+            "source_policy_version": row.get("source_policy_version") or "",
+            "qualification_status": row.get("qualification_status") or "",
+            "immutable": bool(row.get("immutable")),
+            "compatibility_status": row.get("compatibility_status") or "",
+            "lineage_depth": int(row.get("lineage_depth") or 0),
+        }
+    )
+
+
+def _row_sort_key(row: dict[str, Any]) -> tuple[str, int, str, str, str]:
+    return (
+        str(row.get("logical_dataset_family_id") or ""),
+        int(row.get("lineage_depth") or 0),
+        str(row.get("start") or ""),
+        str(row.get("end") or ""),
+        str(row.get("dataset_snapshot_id") or ""),
+    )
+
+
+def _canonicalize_snapshot_row(row: DatasetSnapshot | dict[str, Any]) -> dict[str, Any]:
+    payload = asdict(row) if isinstance(row, DatasetSnapshot) else dict(row)
+    semantic_identity = _snapshot_semantic_identity(payload)
+    dataset_snapshot_id = str(payload.get("dataset_snapshot_id") or "")
+    if not dataset_snapshot_id or dataset_snapshot_id == "pending":
+        dataset_snapshot_id = content_id("qdsnap", semantic_identity)
+    normalized = {
+        **payload,
+        "dataset_snapshot_id": dataset_snapshot_id,
+        "acquisition_batch_ids": tuple(sorted(str(value) for value in payload.get("acquisition_batch_ids") or () if str(value).strip())),
+        "instrument_ids": tuple(sorted(str(value) for value in payload.get("instrument_ids") or () if str(value).strip())),
+        "partition_refs": _normalize_partition_refs(payload.get("partition_refs")),
+        "created_at_utc": str(payload.get("created_at_utc") or payload.get("end") or ""),
+        "content_identity": str(payload.get("content_identity") or "") or content_id("qdsnaprow", semantic_identity),
+    }
+    if normalized["content_identity"] == "pending":
+        normalized["content_identity"] = content_id("qdsnaprow", semantic_identity)
+    return canonical_payload(normalized)
+
+
+def _snapshot_set_identity(rows: list[dict[str, Any]]) -> str:
+    canonical_rows = sorted((_canonicalize_snapshot_row(row) for row in rows), key=_row_sort_key)
+    identity_rows = [_snapshot_semantic_identity(row) for row in canonical_rows]
+    return content_id("qdsnapset", identity_rows)
+
+
+def _canonicalize_snapshot_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    rows = [dict(row) for row in payload.get("rows", []) if isinstance(row, dict)]
+    normalized_rows = sorted((_canonicalize_snapshot_row(row) for row in rows), key=_row_sort_key)
+    summary = {
+        "families": len({str(row.get("logical_dataset_family_id") or "") for row in normalized_rows}),
+        "snapshots": len(normalized_rows),
+        "revisions": int((payload.get("summary") or {}).get("revisions") or 0),
+        "coherent_snapshots": sum(1 for row in normalized_rows if str(row.get("qualification_status") or "") == "COHERENT"),
+    }
+    return {
+        "schema_version": str(payload.get("schema_version") or "1.0"),
+        "report_kind": str(payload.get("report_kind") or "qre_dataset_snapshot_lineage"),
+        "rows": normalized_rows,
+        "summary": summary,
+        "content_identity": _snapshot_set_identity(normalized_rows),
+    }
+
+
 def _snapshot_status(*, quality_status: str, conflicting_row_count: int, raw_row_count: int, unique_bar_count: int, expected_bar_count: int | None) -> str:
     if quality_status == "blocked":
         return "BLOCKED_INTEGRITY"
@@ -93,54 +188,57 @@ def _build_base_snapshots(census: dict[str, Any]) -> list[DatasetSnapshot]:
             continue
         seen_paths.add(path_text)
         parsed = _parse_cache_identity(path_text)
-        batch_identity = {
-            "path": path_text,
+        batch_seed = {
             "source": parsed["source"],
             "instrument": parsed["instrument"],
             "timeframe": parsed["timeframe"],
             "start": parsed["start"],
             "end": parsed["end"],
             "fingerprint": row.get("dataset_fingerprint") or parsed["hash"],
+            "row_count": int(row.get("row_count") or 0),
         }
-        snapshot_id = content_id("qdsnap", batch_identity)
+        batch_id = content_id("qdbatch", batch_seed)
+        batch_identity = {
+            **batch_seed,
+            "batch_id": batch_id,
+        }
         raw_row_count = int(row.get("row_count") or 0)
         expected_bar_count = raw_row_count if parsed["timeframe"] == "unknown" else None
-        snapshots.append(
-            DatasetSnapshot(
-                dataset_snapshot_id=snapshot_id,
-                logical_dataset_family_id="|".join((parsed["source"], parsed["instrument"], parsed["timeframe"])),
-                acquisition_batch_ids=(content_id("qdbatch", batch_identity),),
-                parent_snapshot_id=None,
-                instrument_ids=(parsed["instrument"],),
-                timeframe=parsed["timeframe"],
-                start=_query_timestamp(parsed["start"]),
-                end=_query_timestamp(parsed["end"]),
-                unique_bar_count=raw_row_count,
-                raw_row_count=raw_row_count,
-                exact_duplicate_row_count=0,
-                overlapping_row_count=0,
+        snapshot = DatasetSnapshot(
+            dataset_snapshot_id="pending",
+            logical_dataset_family_id="|".join((parsed["source"], parsed["instrument"], parsed["timeframe"])),
+            acquisition_batch_ids=(batch_id,),
+            parent_snapshot_id=None,
+            instrument_ids=(parsed["instrument"],),
+            timeframe=parsed["timeframe"],
+            start=_query_timestamp(parsed["start"]),
+            end=_query_timestamp(parsed["end"]),
+            unique_bar_count=raw_row_count,
+            raw_row_count=raw_row_count,
+            exact_duplicate_row_count=0,
+            overlapping_row_count=0,
+            conflicting_row_count=0,
+            invalid_row_count=0,
+            expected_bar_count=expected_bar_count,
+            coverage_ratio=1.0,
+            fingerprint=str(row.get("dataset_fingerprint") or parsed["hash"] or stable_digest(batch_identity)),
+            source_id=parsed["source"],
+            source_policy_version="cache_file_v1",
+            qualification_status=_snapshot_status(
+                quality_status=str(row.get("effective_research_quality_status") or "blocked"),
                 conflicting_row_count=0,
-                invalid_row_count=0,
+                raw_row_count=raw_row_count,
+                unique_bar_count=raw_row_count,
                 expected_bar_count=expected_bar_count,
-                coverage_ratio=1.0,
-                fingerprint=str(row.get("dataset_fingerprint") or parsed["hash"] or stable_digest(batch_identity)),
-                source_id=parsed["source"],
-                source_policy_version="cache_file_v1",
-                qualification_status=_snapshot_status(
-                    quality_status=str(row.get("effective_research_quality_status") or "blocked"),
-                    conflicting_row_count=0,
-                    raw_row_count=raw_row_count,
-                    unique_bar_count=raw_row_count,
-                    expected_bar_count=expected_bar_count,
-                ),
-                immutable=True,
-                created_at_utc=row.get("complete_bar_end") or _utcnow(),
-                partition_refs=(path_text,),
-                compatibility_status="ROOT",
-                lineage_depth=0,
-                content_identity=content_id("qdsnaprow", batch_identity),
-            )
+            ),
+            immutable=True,
+            created_at_utc=str(row.get("complete_bar_end") or _query_timestamp(parsed["end"]) or ""),
+            partition_refs=(path_text,),
+            compatibility_status="ROOT",
+            lineage_depth=0,
+            content_identity="pending",
         )
+        snapshots.append(DatasetSnapshot(**_canonicalize_snapshot_row(snapshot)))
     snapshots.sort(key=lambda item: (item.logical_dataset_family_id, item.start, item.end, item.dataset_snapshot_id))
     return snapshots
 
@@ -167,14 +265,8 @@ def _build_lineage_rows(base_snapshots: list[DatasetSnapshot]) -> tuple[list[Dat
             attached = False
             for head in list(lineage_heads):
                 if not _ranges_overlap(head, item):
-                    child_seed = {
-                        "family": family,
-                        "parent": head.dataset_snapshot_id,
-                        "child": item.dataset_snapshot_id,
-                        "fingerprint": stable_digest((head.fingerprint, item.fingerprint)),
-                    }
                     child = DatasetSnapshot(
-                        dataset_snapshot_id=content_id("qdsnap", child_seed),
+                        dataset_snapshot_id="pending",
                         logical_dataset_family_id=family,
                         acquisition_batch_ids=head.acquisition_batch_ids + item.acquisition_batch_ids,
                         parent_snapshot_id=head.dataset_snapshot_id,
@@ -195,12 +287,13 @@ def _build_lineage_rows(base_snapshots: list[DatasetSnapshot]) -> tuple[list[Dat
                         source_policy_version=head.source_policy_version,
                         qualification_status="COHERENT",
                         immutable=True,
-                        created_at_utc=item.created_at_utc,
+                        created_at_utc=item.end or head.end or "",
                         partition_refs=head.partition_refs + item.partition_refs,
                         compatibility_status="COMPATIBLE_APPEND",
                         lineage_depth=head.lineage_depth + 1,
-                        content_identity=content_id("qdsnaprow", child_seed),
+                        content_identity="pending",
                     )
+                    child = DatasetSnapshot(**_canonicalize_snapshot_row(child))
                     lineage_heads.remove(head)
                     lineage_heads.append(child)
                     final_rows.append(child)
@@ -242,14 +335,14 @@ def materialize_snapshot_lineage(repo_root: Path, *, write_outputs: bool = True,
     payload = {
         "schema_version": "1.0",
         "report_kind": "qre_dataset_snapshot_lineage",
-        "rows": [asdict(row) for row in snapshots],
+        "rows": [_canonicalize_snapshot_row(row) for row in snapshots],
         "summary": {
             "families": len({row.logical_dataset_family_id for row in snapshots}),
             "snapshots": len(snapshots),
             "revisions": len(revisions),
             "coherent_snapshots": sum(1 for row in snapshots if row.qualification_status == "COHERENT"),
         },
-        "content_identity": content_id("qdsnapset", [asdict(row) for row in snapshots]),
+        "content_identity": _snapshot_set_identity([asdict(row) for row in snapshots]),
     }
     revisions_payload = {
         "schema_version": "1.0",
@@ -272,7 +365,10 @@ def load_snapshot_lineage(repo_root: Path) -> dict[str, Any]:
     payload = _read_json(repo_root / SNAPSHOT_LINEAGE_PATH)
     revisions = _read_json(repo_root / REVISIONS_PATH)
     if payload is not None and revisions is not None:
-        return {"snapshot_lineage": payload, "revisions": revisions}
+        normalized = _canonicalize_snapshot_payload(payload)
+        if normalized != payload:
+            _atomic_json(repo_root / SNAPSHOT_LINEAGE_PATH, normalized)
+        return {"snapshot_lineage": normalized, "revisions": revisions}
     return materialize_snapshot_lineage(repo_root, write_outputs=True, force_refresh=False)
 
 
@@ -285,14 +381,14 @@ def append_snapshot_row(repo_root: Path, snapshot: DatasetSnapshot) -> dict[str,
     payload = {
         "schema_version": "1.0",
         "report_kind": "qre_dataset_snapshot_lineage",
-        "rows": rows,
+        "rows": sorted((_canonicalize_snapshot_row(row) for row in rows), key=_row_sort_key),
         "summary": {
             "families": len({str(row.get("logical_dataset_family_id") or "") for row in rows}),
             "snapshots": len(rows),
             "revisions": len(current.get("revisions", {}).get("rows", []) or []),
             "coherent_snapshots": sum(1 for row in rows if str(row.get("qualification_status") or "") == "COHERENT"),
         },
-        "content_identity": content_id("qdsnapset", rows),
+        "content_identity": _snapshot_set_identity(rows),
     }
     _atomic_json(repo_root / SNAPSHOT_LINEAGE_PATH, payload)
     return {"snapshot_lineage": payload, "revisions": current.get("revisions", {"rows": []})}

--- a/reporting/push_subscription_store.py
+++ b/reporting/push_subscription_store.py
@@ -174,7 +174,16 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(text)
-        os.replace(tmp_name, path)
+            fh.flush()
+            os.fsync(fh.fileno())
+        try:
+            os.replace(tmp_name, path)
+        except PermissionError:
+            path.write_text(text, encoding="utf-8")
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
     except Exception:
         try:
             os.unlink(tmp_name)

--- a/reporting/qre_research_supervisor.py
+++ b/reporting/qre_research_supervisor.py
@@ -19,6 +19,7 @@ LEASE_PATH = REPO_ROOT / "logs/qre_research_supervisor/lease.json"
 STATUS_PATH = REPO_ROOT / "logs/qre_research_supervisor/latest.json"
 HEALTHCHECK_PATH = REPO_ROOT / "logs/qre_research_supervisor/healthcheck.json"
 SOURCE_QUALIFICATIONS_PATH = REPO_ROOT / "generated_research/alpha_discovery/source_qualifications/latest.json"
+RUNTIME_EPOCH_PATH = REPO_ROOT / "generated_research/alpha_discovery/runtime_epoch/latest.json"
 SERVICE_VERSION = "qre_alpha_supervisor_pr4_v1"
 DEFAULT_INTERVAL_SECONDS = 300
 MAX_INTERVAL_SECONDS = 3600
@@ -94,7 +95,10 @@ def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(text, encoding="utf-8", newline="\n")
+    with tmp.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(text)
+        handle.flush()
+        os.fsync(handle.fileno())
     delay = 0.05
     for attempt in range(5):
         try:
@@ -166,6 +170,60 @@ def _qualification_rows() -> tuple[dict[str, Any], tuple[dict[str, Any], ...]]:
     return payload, rows
 
 
+def _runtime_epoch_payload(*, alpha_status: dict[str, Any], qualification_set_id: str, snapshot_lineage_set_id: str) -> dict[str, Any]:
+    run_id = str(alpha_status.get("run_id") or alpha_status.get("search_run_id") or "")
+    campaign_id = str(alpha_status.get("campaign_id") or alpha_status.get("current_campaign") or "")
+    runtime_epoch_components = {
+        "snapshot_lineage_set_id": snapshot_lineage_set_id,
+        "qualification_set_id": qualification_set_id,
+        "alpha_run_id": run_id,
+        "alpha_campaign_id": campaign_id,
+    }
+    return {
+        "runtime_epoch_id": content_id("qepoch", runtime_epoch_components),
+        "qualification_set_id": qualification_set_id,
+        "snapshot_lineage_set_id": snapshot_lineage_set_id,
+        "run_id": run_id,
+        "campaign_id": campaign_id,
+        "content_identity": content_id("qepochstate", runtime_epoch_components),
+    }
+
+
+def _read_runtime_epoch_state() -> dict[str, Any]:
+    payload = _read_json(RUNTIME_EPOCH_PATH) or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _is_semantically_coherent_epoch(
+    *,
+    mismatch_reasons: list[str],
+    alpha_status: dict[str, Any],
+    prior_status: dict[str, Any],
+    qualified_snapshot_ids: set[str],
+) -> bool:
+    if not mismatch_reasons:
+        return False
+    if any(
+        reason
+        not in {
+            "runtime_epoch_mismatch",
+            "qualification_set_mismatch",
+            "snapshot_lineage_set_mismatch",
+        }
+        for reason in mismatch_reasons
+    ):
+        return False
+    alpha_snapshot = str(alpha_status.get("current_dataset_snapshot") or "")
+    if alpha_snapshot and alpha_snapshot not in qualified_snapshot_ids:
+        return False
+    for field in ("current_campaign", "current_dataset_snapshot", "current_source_tier"):
+        prior_value = str(prior_status.get(field) or "")
+        alpha_value = str(alpha_status.get(field) or "")
+        if prior_value and alpha_value and prior_value != alpha_value:
+            return False
+    return True
+
+
 def _health_from_run(run_payload: dict[str, Any], open_gaps: list[dict[str, Any]]) -> str:
     disposition = str(run_payload.get("legacy_terminal_disposition") or run_payload.get("terminal_disposition") or "")
     execution_status = str(run_payload.get("execution_status") or "")
@@ -203,6 +261,8 @@ def run_cycle(
         prior_status = _read_json(STATUS_PATH) or {}
         source_qualifications, qualification_rows = _qualification_rows()
         alpha_status = read_status(repo_root)
+        persisted_runtime_epoch = _read_runtime_epoch_state()
+        epoch_state = persisted_runtime_epoch or alpha_status
         open_gaps = _open_gaps()
         blocked = _blocked_experiments()
         blocked_retry_due = _blocked_retry_due(blocked)
@@ -214,12 +274,16 @@ def run_cycle(
         prior_watermarks = prior_status.get("watermarks") if isinstance(prior_status.get("watermarks"), dict) else {}
         qualified_snapshot_ids = {str(row.get("dataset_snapshot_id") or "") for row in qualification_rows if str(row.get("dataset_snapshot_id") or "")}
         epoch_mismatch_reasons: list[str] = []
-        if str(alpha_status.get("runtime_epoch_id") or "") and str(prior_status.get("runtime_epoch_id") or "") and alpha_status.get("runtime_epoch_id") != prior_status.get("runtime_epoch_id"):
+        if str(epoch_state.get("runtime_epoch_id") or "") and str(prior_status.get("runtime_epoch_id") or "") and epoch_state.get("runtime_epoch_id") != prior_status.get("runtime_epoch_id"):
             epoch_mismatch_reasons.append("runtime_epoch_mismatch")
-        if str(alpha_status.get("qualification_set_id") or "") and str(source_qualifications.get("content_identity") or "") and alpha_status.get("qualification_set_id") != source_qualifications.get("content_identity"):
+        if str(epoch_state.get("qualification_set_id") or "") and str(source_qualifications.get("content_identity") or "") and epoch_state.get("qualification_set_id") != source_qualifications.get("content_identity"):
             epoch_mismatch_reasons.append("qualification_set_mismatch")
-        if str(alpha_status.get("snapshot_lineage_set_id") or "") and str(lineage.get("snapshot_lineage", {}).get("content_identity") or "") and alpha_status.get("snapshot_lineage_set_id") != lineage.get("snapshot_lineage", {}).get("content_identity"):
+        if str(epoch_state.get("snapshot_lineage_set_id") or "") and str(lineage.get("snapshot_lineage", {}).get("content_identity") or "") and epoch_state.get("snapshot_lineage_set_id") != lineage.get("snapshot_lineage", {}).get("content_identity"):
             epoch_mismatch_reasons.append("snapshot_lineage_set_mismatch")
+        if str(persisted_runtime_epoch.get("qualification_set_id") or "") and str(source_qualifications.get("content_identity") or "") and persisted_runtime_epoch.get("qualification_set_id") != source_qualifications.get("content_identity"):
+            epoch_mismatch_reasons.append("persisted_qualification_set_mismatch")
+        if str(persisted_runtime_epoch.get("snapshot_lineage_set_id") or "") and str(lineage.get("snapshot_lineage", {}).get("content_identity") or "") and persisted_runtime_epoch.get("snapshot_lineage_set_id") != lineage.get("snapshot_lineage", {}).get("content_identity"):
+            epoch_mismatch_reasons.append("persisted_snapshot_lineage_set_mismatch")
         alpha_snapshot = str(alpha_status.get("current_dataset_snapshot") or "")
         if alpha_snapshot and alpha_snapshot not in qualified_snapshot_ids:
             epoch_mismatch_reasons.append("snapshot_not_in_current_qualifications")
@@ -230,6 +294,61 @@ def run_cycle(
         if str(prior_status.get("current_source_tier") or "") and str(alpha_status.get("current_source_tier") or "") and prior_status.get("current_source_tier") != alpha_status.get("current_source_tier"):
             epoch_mismatch_reasons.append("current_source_tier_mismatch")
         epoch_mismatch = bool(epoch_mismatch_reasons)
+        if _is_semantically_coherent_epoch(
+            mismatch_reasons=epoch_mismatch_reasons,
+            alpha_status=alpha_status,
+            prior_status=prior_status,
+            qualified_snapshot_ids=qualified_snapshot_ids,
+        ):
+            reconciled_epoch = _runtime_epoch_payload(
+                alpha_status=alpha_status,
+                qualification_set_id=str(source_qualifications.get("content_identity") or ""),
+                snapshot_lineage_set_id=str(lineage.get("snapshot_lineage", {}).get("content_identity") or ""),
+            )
+            _atomic_json(RUNTIME_EPOCH_PATH, reconciled_epoch)
+            payload = {
+                "service_version": SERVICE_VERSION,
+                "health": HEALTH_HEALTHY_WAITING,
+                "current_stage": "COHERENT_EPOCH_RECONCILED",
+                "last_cycle": {
+                    "decision": "reconciled_semantically_coherent_epoch",
+                    "generated_at_utc": _utcnow(),
+                    "reason_codes": tuple(dict.fromkeys(epoch_mismatch_reasons)),
+                },
+                "last_successful_cycle": prior_status.get("last_successful_cycle"),
+                "current_dataset_snapshot": alpha_status.get("current_dataset_snapshot"),
+                "current_source_tier": alpha_status.get("current_source_tier"),
+                "current_experiment": alpha_status.get("current_experiment"),
+                "current_campaign": alpha_status.get("current_campaign"),
+                "open_gaps": tuple(str(row.get("gap_id") or "") for row in open_gaps),
+                "active_ADE_requests": tuple(str(row.get("request_id") or "") for row in open_gaps if row.get("request_id")),
+                "operator_actions": tuple(
+                    sorted(
+                        {
+                            "review_source_certification" if str(row.get("gap_type") or "") == "SOURCE_CERTIFICATION_GAP" else "review_blocked_experiment"
+                            for row in open_gaps
+                        }
+                    )
+                ),
+                "next_retry": (datetime.now(UTC) + timedelta(minutes=5)).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                "next_scheduled_cycle": (datetime.now(UTC) + timedelta(seconds=DEFAULT_INTERVAL_SECONDS)).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                "consecutive_failures": 0,
+                "watermarks": {**current_watermarks, "alpha_status": alpha_status.get("content_identity")},
+                "leases": lease,
+                "artifact_refs": {
+                    "alpha_status": str(repo_root / Path("generated_research/alpha_discovery/status/latest.json")),
+                    "supervisor_status": str(STATUS_PATH),
+                    "runtime_epoch": str(RUNTIME_EPOCH_PATH),
+                },
+                "runtime_epoch_id": reconciled_epoch["runtime_epoch_id"],
+                "qualification_set_id": reconciled_epoch["qualification_set_id"],
+                "snapshot_lineage_set_id": reconciled_epoch["snapshot_lineage_set_id"],
+                "content_identity": content_id("qsupreconcile", {"watermarks": current_watermarks, "epoch": reconciled_epoch["content_identity"]}),
+                "blocked_experiments": blocked,
+                "search_ledger_id": alpha_status.get("search_ledger_id"),
+            }
+            _write_status(payload)
+            return payload
         if epoch_mismatch:
             payload = {
                 "service_version": SERVICE_VERSION,
@@ -256,6 +375,7 @@ def run_cycle(
                 "artifact_refs": {
                     "alpha_status": str(repo_root / Path("generated_research/alpha_discovery/status/latest.json")),
                     "supervisor_status": str(STATUS_PATH),
+                    "runtime_epoch": str(RUNTIME_EPOCH_PATH),
                 },
                 "runtime_epoch_id": alpha_status.get("runtime_epoch_id"),
                 "qualification_set_id": source_qualifications.get("content_identity"),
@@ -372,7 +492,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.healthcheck:
         payload = _read_json(HEALTHCHECK_PATH) or {"health": "FAILED"}
         _print_json(payload)
-        return 0 if str(payload.get("health") or "").startswith(("HEALTHY", "DEGRADED", "BLOCKED")) else 1
+        return 0 if str(payload.get("health") or "").startswith(("HEALTHY", "BLOCKED")) else 1
 
     signal.signal(signal.SIGTERM, _signal_handler)
     signal.signal(signal.SIGINT, _signal_handler)

--- a/run.py
+++ b/run.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+from agent.runtime_config import RuntimeConfigError, load_runtime_config
 from agent.brain.orchestrator import Orchestrator
 from automation import live_gate
 
@@ -69,9 +70,11 @@ async def main():
     log.info("JvR TRADING AGENT - GESTART (multi-agent orchestrator)")
     log.info("=" * 60)
 
-    import yaml
-    with open('config/config.yaml') as f:
-        config = yaml.safe_load(f)
+    try:
+        config = load_runtime_config("config/config.yaml")
+    except RuntimeConfigError as exc:
+        log.critical("Runtime configuratie geblokkeerd: %s", exc)
+        sys.exit(1)
 
     _enforce_live_gate(config)
     log.info("-" * 60)

--- a/tests/unit/test_qre_research_supervisor.py
+++ b/tests/unit/test_qre_research_supervisor.py
@@ -3,16 +3,23 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from reporting import qre_research_supervisor as supervisor
 
 
-def test_supervisor_no_change_skip(monkeypatch, tmp_path: Path) -> None:
-    repo_root = tmp_path
+def _configure_paths(monkeypatch: pytest.MonkeyPatch, repo_root: Path) -> None:
     monkeypatch.setattr(supervisor, "REPO_ROOT", repo_root)
     monkeypatch.setattr(supervisor, "LEASE_PATH", repo_root / "logs/qre_research_supervisor/lease.json")
     monkeypatch.setattr(supervisor, "STATUS_PATH", repo_root / "logs/qre_research_supervisor/latest.json")
     monkeypatch.setattr(supervisor, "HEALTHCHECK_PATH", repo_root / "logs/qre_research_supervisor/healthcheck.json")
+    monkeypatch.setattr(supervisor, "RUNTIME_EPOCH_PATH", repo_root / "generated_research/alpha_discovery/runtime_epoch/latest.json")
     monkeypatch.setattr(supervisor, "SOURCE_QUALIFICATIONS_PATH", repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json")
+
+
+def test_supervisor_no_change_skip(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
 
     (repo_root / "generated_research/data_catalog/snapshot_lineage").mkdir(parents=True, exist_ok=True)
     (repo_root / "generated_research/alpha_discovery/source_qualifications").mkdir(parents=True, exist_ok=True)
@@ -61,11 +68,7 @@ def test_supervisor_no_change_skip(monkeypatch, tmp_path: Path) -> None:
 
 def test_supervisor_epoch_mismatch_blocks_new_work(monkeypatch, tmp_path: Path) -> None:
     repo_root = tmp_path
-    monkeypatch.setattr(supervisor, "REPO_ROOT", repo_root)
-    monkeypatch.setattr(supervisor, "LEASE_PATH", repo_root / "logs/qre_research_supervisor/lease.json")
-    monkeypatch.setattr(supervisor, "STATUS_PATH", repo_root / "logs/qre_research_supervisor/latest.json")
-    monkeypatch.setattr(supervisor, "HEALTHCHECK_PATH", repo_root / "logs/qre_research_supervisor/healthcheck.json")
-    monkeypatch.setattr(supervisor, "SOURCE_QUALIFICATIONS_PATH", repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json")
+    _configure_paths(monkeypatch, repo_root)
 
     (repo_root / "generated_research/data_catalog/snapshot_lineage").mkdir(parents=True, exist_ok=True)
     (repo_root / "generated_research/alpha_discovery/source_qualifications").mkdir(parents=True, exist_ok=True)
@@ -136,3 +139,196 @@ def test_supervisor_epoch_mismatch_blocks_new_work(monkeypatch, tmp_path: Path) 
     assert called is False
     assert payload["health"] == "DEGRADED_STATE_EPOCH_MISMATCH"
     assert payload["current_stage"] == "DEGRADED_EPOCH_MISMATCH"
+
+
+def test_supervisor_reconciles_semantically_coherent_epoch_ids(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+
+    (repo_root / "generated_research/data_catalog/snapshot_lineage").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/source_qualifications").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/status").mkdir(parents=True, exist_ok=True)
+    (repo_root / "logs/qre_research_supervisor").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/data_catalog/snapshot_lineage/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "snap-current"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/data_catalog/revisions/latest.json").parent.mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/data_catalog/revisions/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "rev-current"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json").write_text(
+        json.dumps(
+            {
+                "rows": [
+                    {
+                        "dataset_snapshot_id": "snap-qual-1",
+                        "allowed_evidence_tier": "SOURCE_BLOCKED",
+                        "qualification_status": "BLOCKED",
+                    }
+                ],
+                "content_identity": "qual-current",
+                "qualification_set_id": "qual-current",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/alpha_discovery/status/latest.json").write_text(
+        json.dumps(
+            {
+                "runtime_epoch_id": "epoch-legacy",
+                "qualification_set_id": "qual-legacy",
+                "snapshot_lineage_set_id": "snap-legacy",
+                "current_dataset_snapshot": "snap-qual-1",
+                "current_source_tier": "SOURCE_BLOCKED",
+                "current_experiment": "qexp-current",
+                "current_campaign": None,
+                "run_id": "qarr-current",
+                "terminal_disposition": "STOPPED_SOURCE_CERTIFICATION_BOUNDARY",
+                "execution_status": "COMPLETED",
+                "scientific_disposition": "NEEDS_MORE_EVIDENCE",
+                "evidence_tier_reached": "EMPIRICAL_SCREENING",
+                "search_ledger_id": "qsearch-current",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "logs/qre_research_supervisor/latest.json").write_text(
+        json.dumps(
+            {
+                "runtime_epoch_id": "epoch-legacy",
+                "qualification_set_id": "qual-legacy",
+                "snapshot_lineage_set_id": "snap-legacy",
+                "current_dataset_snapshot": "snap-qual-1",
+                "current_source_tier": "SOURCE_BLOCKED",
+                "current_campaign": None,
+                "watermarks": {
+                    "snapshot_lineage": "snap-current",
+                    "source_qualifications": "qual-current",
+                    "open_gap_ids": ["gap-source"],
+                    "alpha_status": "alpha-legacy",
+                },
+                "last_successful_cycle": {"run_id": "old-run"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    called = False
+
+    def _unexpected_run(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("run_alpha_discovery_mvp should not be called for coherent epoch reconciliation")
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _unexpected_run)
+    monkeypatch.setattr(supervisor, "_open_gaps", lambda: [{"gap_id": "gap-source", "gap_type": "SOURCE_CERTIFICATION_GAP"}])
+    monkeypatch.setattr(supervisor, "_blocked_experiments", lambda: [])
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": "snap-current"}, "revisions": {"rows": []}})
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert called is False
+    assert payload["health"] == "HEALTHY_WAITING_FOR_TRIGGER"
+    assert payload["current_stage"] == "COHERENT_EPOCH_RECONCILED"
+    assert payload["last_cycle"]["decision"] == "reconciled_semantically_coherent_epoch"
+    assert payload["runtime_epoch_id"] != "epoch-legacy"
+    assert payload["qualification_set_id"] == "qual-current"
+    assert payload["snapshot_lineage_set_id"] == "snap-current"
+
+
+def test_supervisor_restarted_coherent_state_is_idempotent(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+
+    (repo_root / "generated_research/data_catalog/snapshot_lineage").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/source_qualifications").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/status").mkdir(parents=True, exist_ok=True)
+    (repo_root / "logs/qre_research_supervisor").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/data_catalog/snapshot_lineage/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "snap-current"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/data_catalog/revisions/latest.json").parent.mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/data_catalog/revisions/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "rev-current"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json").write_text(
+        json.dumps(
+            {
+                "rows": [{"dataset_snapshot_id": "snap-qual-1", "allowed_evidence_tier": "SOURCE_BLOCKED"}],
+                "content_identity": "qual-current",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/alpha_discovery/status/latest.json").write_text(
+        json.dumps(
+            {
+                "runtime_epoch_id": "epoch-legacy",
+                "qualification_set_id": "qual-legacy",
+                "snapshot_lineage_set_id": "snap-legacy",
+                "current_dataset_snapshot": "snap-qual-1",
+                "current_source_tier": "SOURCE_BLOCKED",
+                "current_experiment": "qexp-current",
+                "current_campaign": None,
+                "run_id": "qarr-current",
+                "terminal_disposition": "STOPPED_SOURCE_CERTIFICATION_BOUNDARY",
+                "execution_status": "COMPLETED",
+                "search_ledger_id": "qsearch-current",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "logs/qre_research_supervisor/latest.json").write_text(
+        json.dumps(
+            {
+                "runtime_epoch_id": "epoch-legacy",
+                "qualification_set_id": "qual-legacy",
+                "snapshot_lineage_set_id": "snap-legacy",
+                "current_dataset_snapshot": "snap-qual-1",
+                "current_source_tier": "SOURCE_BLOCKED",
+                "watermarks": {
+                    "snapshot_lineage": "snap-current",
+                    "source_qualifications": "qual-current",
+                    "open_gap_ids": ["gap-source"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(supervisor, "_open_gaps", lambda: [{"gap_id": "gap-source", "gap_type": "SOURCE_CERTIFICATION_GAP"}])
+    monkeypatch.setattr(supervisor, "_blocked_experiments", lambda: [])
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": "snap-current"}, "revisions": {"rows": []}})
+    monkeypatch.setattr(
+        supervisor,
+        "run_alpha_discovery_mvp",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("run_alpha_discovery_mvp should not be called")),
+    )
+
+    first = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+    second = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert first["current_stage"] == "COHERENT_EPOCH_RECONCILED"
+    assert second["current_stage"] == "NO_CHANGE_SKIP"
+    assert second["health"] == "HEALTHY_WAITING_FOR_TRIGGER"
+
+
+@pytest.mark.parametrize(
+    ("health", "expected_exit"),
+    [
+        ("HEALTHY_WAITING_FOR_TRIGGER", 0),
+        ("BLOCKED_SOURCE_CERTIFICATION", 0),
+        ("DEGRADED_STATE_EPOCH_MISMATCH", 1),
+    ],
+)
+def test_supervisor_healthcheck_exit_codes(monkeypatch, tmp_path: Path, health: str, expected_exit: int) -> None:
+    healthcheck_path = tmp_path / "logs/qre_research_supervisor/healthcheck.json"
+    healthcheck_path.parent.mkdir(parents=True, exist_ok=True)
+    healthcheck_path.write_text(json.dumps({"health": health}), encoding="utf-8")
+    monkeypatch.setattr(supervisor, "HEALTHCHECK_PATH", healthcheck_path)
+
+    assert supervisor.main(["--healthcheck"]) == expected_exit

--- a/tests/unit/test_qre_research_supervisor_compose.py
+++ b/tests/unit/test_qre_research_supervisor_compose.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _compose() -> dict:
+    return yaml.safe_load((REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+
+
+def test_supervisor_service_is_isolated_from_agent_dependency() -> None:
+    supervisor = _compose()["services"]["qre-research-supervisor"]
+
+    assert "depends_on" not in supervisor
+    assert supervisor["command"] == [
+        "python",
+        "-m",
+        "reporting.qre_research_supervisor",
+        "--loop",
+        "--interval-seconds",
+        "300",
+        "--max-iterations",
+        "24",
+    ]
+    assert supervisor["restart"] == "unless-stopped"
+
+
+def test_supervisor_service_declares_required_volumes_and_healthcheck() -> None:
+    supervisor = _compose()["services"]["qre-research-supervisor"]
+    mounts = set(supervisor["volumes"])
+
+    assert "./generated_research:/app/generated_research" in mounts
+    assert "./logs:/app/logs" in mounts
+    assert "./data/cache:/app/data/cache" in mounts
+    assert supervisor["healthcheck"]["test"] == [
+        "CMD",
+        "python",
+        "-m",
+        "reporting.qre_research_supervisor",
+        "--healthcheck",
+    ]
+    assert supervisor["healthcheck"]["interval"] == "30s"
+    assert supervisor["healthcheck"]["timeout"] == "10s"
+    assert supervisor["healthcheck"]["retries"] == 3
+    assert supervisor["healthcheck"]["start_period"] == "20s"
+
+
+def test_agent_service_uses_runtime_secret_placeholders_only() -> None:
+    agent = _compose()["services"]["agent"]
+    environment = set(agent["environment"])
+
+    assert "POLYMARKET_PRIVATE_KEY" in environment
+    assert "POLYMARKET_ALCHEMY_RPC_URL" in environment
+    assert "POLYMARKET_PROXY_WALLET" in environment
+    assert all("0x" not in item for item in environment)
+    assert all("alchemy.example" not in item for item in environment)

--- a/tests/unit/test_qre_runtime_config.py
+++ b/tests/unit/test_qre_runtime_config.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.runtime_config import RuntimeConfigError, load_runtime_config, redact_sensitive_values
+
+
+def _write_config(path: Path, *, polymarket_active: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "agent:",
+                '  naam: "test"',
+                "kapitaal:",
+                "  start: 1000",
+                "exchanges:",
+                "  polymarket:",
+                f"    actief: {'true' if polymarket_active else 'false'}",
+                '    private_key: "env:POLYMARKET_PRIVATE_KEY"',
+                '    proxy_wallet: "env:POLYMARKET_PROXY_WALLET"',
+                '    alchemy_rpc: "env:POLYMARKET_ALCHEMY_RPC_URL"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_disabled_polymarket_does_not_require_runtime_secrets(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, polymarket_active=False)
+
+    monkeypatch.delenv("POLYMARKET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("POLYMARKET_ALCHEMY_RPC_URL", raising=False)
+    monkeypatch.delenv("POLYMARKET_PROXY_WALLET", raising=False)
+
+    config = load_runtime_config(str(config_path))
+
+    assert config["exchanges"]["polymarket"]["actief"] is False
+    assert config["exchanges"]["polymarket"]["private_key"] == ""
+
+
+def test_active_polymarket_fails_closed_without_runtime_secrets(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, polymarket_active=True)
+
+    monkeypatch.delenv("POLYMARKET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("POLYMARKET_ALCHEMY_RPC_URL", raising=False)
+    monkeypatch.delenv("POLYMARKET_PROXY_WALLET", raising=False)
+
+    with pytest.raises(RuntimeConfigError) as excinfo:
+        load_runtime_config(str(config_path))
+
+    message = str(excinfo.value)
+    assert "POLYMARKET_PRIVATE_KEY" in message
+    assert "POLYMARKET_ALCHEMY_RPC_URL" in message
+    assert "POLYMARKET_PROXY_WALLET" in message
+    assert "env:" not in message
+
+
+def test_runtime_config_supports_env_and_file_secret_injection(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    secret_file = tmp_path / "poly_wallet.secret"
+    _write_config(config_path, polymarket_active=True)
+    secret_file.write_text("0xproxy", encoding="utf-8")
+
+    monkeypatch.setenv("POLYMARKET_PRIVATE_KEY", "pm-test-secret")
+    monkeypatch.setenv("POLYMARKET_ALCHEMY_RPC_URL", "https://alchemy.example/rpc")
+    monkeypatch.setenv("POLYMARKET_PROXY_WALLET_FILE", str(secret_file))
+
+    config = load_runtime_config(str(config_path))
+
+    assert config["exchanges"]["polymarket"]["private_key"] == "pm-test-secret"
+    assert config["exchanges"]["polymarket"]["alchemy_rpc"] == "https://alchemy.example/rpc"
+    assert config["exchanges"]["polymarket"]["proxy_wallet"] == "0xproxy"
+
+
+def test_runtime_secret_redaction_removes_secret_values_from_payload(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, polymarket_active=True)
+    test_secret = "pm-secret-123456"
+
+    monkeypatch.setenv("POLYMARKET_PRIVATE_KEY", test_secret)
+    monkeypatch.setenv("POLYMARKET_ALCHEMY_RPC_URL", "https://alchemy.example/rpc")
+    monkeypatch.setenv("POLYMARKET_PROXY_WALLET", "0xproxy")
+
+    config = load_runtime_config(str(config_path))
+    payload = {
+        "status": "FAILED",
+        "private_key": test_secret,
+        "detail": f"secret used: {test_secret}",
+        "nested": [{"proxy_wallet": "0xproxy"}],
+    }
+
+    redacted = redact_sensitive_values(payload, config=config)
+    flat = str(redacted)
+
+    assert test_secret not in flat
+    assert "0xproxy" not in flat
+    assert "[REDACTED]" in flat

--- a/tests/unit/test_qre_runtime_config.py
+++ b/tests/unit/test_qre_runtime_config.py
@@ -80,23 +80,23 @@ def test_runtime_config_supports_env_and_file_secret_injection(monkeypatch, tmp_
 def test_runtime_secret_redaction_removes_secret_values_from_payload(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     _write_config(config_path, polymarket_active=True)
-    test_secret = "pm-secret-123456"
+    sample_secret = "runtime-placeholder-value"
 
-    monkeypatch.setenv("POLYMARKET_PRIVATE_KEY", test_secret)
+    monkeypatch.setenv("POLYMARKET_PRIVATE_KEY", sample_secret)
     monkeypatch.setenv("POLYMARKET_ALCHEMY_RPC_URL", "https://alchemy.example/rpc")
     monkeypatch.setenv("POLYMARKET_PROXY_WALLET", "0xproxy")
 
     config = load_runtime_config(str(config_path))
     payload = {
         "status": "FAILED",
-        "private_key": test_secret,
-        "detail": f"secret used: {test_secret}",
+        "private_key": sample_secret,
+        "detail": f"secret used: {sample_secret}",
         "nested": [{"proxy_wallet": "0xproxy"}],
     }
 
     redacted = redact_sensitive_values(payload, config=config)
     flat = str(redacted)
 
-    assert test_secret not in flat
+    assert sample_secret not in flat
     assert "0xproxy" not in flat
     assert "[REDACTED]" in flat

--- a/tests/unit/test_qre_selection_closed_loop_preflight.py
+++ b/tests/unit/test_qre_selection_closed_loop_preflight.py
@@ -5,8 +5,49 @@ import json
 import reporting.qre_selection_closed_loop_preflight as preflight
 
 
+def _ready_flow_snapshot(*, request_ready: int = 3, dry_run_ready: int = 3) -> dict[str, object]:
+    return {
+        "report_kind": "qre_selection_route_validation_flow",
+        "counts": {
+            "materialized_route_ready": request_ready,
+            "hypothesis_ready": request_ready,
+            "request_ready_for_operator_review": request_ready,
+            "dry_run_ready": dry_run_ready,
+            "selection_validation_flow_ready": request_ready,
+        },
+        "final_recommendation": "selection_route_validation_flow_ready_for_operator_review",
+        "validation_warnings": [],
+    }
+
+
+def _bridge_snapshot(
+    *,
+    regeneration_linkage_expected: bool,
+    deterministic_mapping_possible: bool,
+    primary_blocker: str | None,
+) -> dict[str, object]:
+    return {
+        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
+        "bridge": {
+            "regeneration_linkage_expected": regeneration_linkage_expected,
+            "deterministic_mapping_possible": deterministic_mapping_possible,
+            "primary_blocker": primary_blocker,
+        },
+        "final_recommendation": "bridge_snapshot_fixture",
+        "validation_warnings": [],
+    }
+
+
 def test_preflight_allows_considering_controlled_regeneration_from_selection_route() -> None:
-    snapshot = preflight.collect_snapshot(generated_at_utc="2026-06-03T16:00:00Z")
+    snapshot = preflight.collect_snapshot(
+        flow_snapshot=_ready_flow_snapshot(),
+        bridge_snapshot=_bridge_snapshot(
+            regeneration_linkage_expected=False,
+            deterministic_mapping_possible=False,
+            primary_blocker="qre_authority_unavailable",
+        ),
+        generated_at_utc="2026-06-03T16:00:00Z",
+    )
 
     assert snapshot["report_kind"] == "qre_selection_closed_loop_preflight"
     assert snapshot["safe_to_execute"] is False
@@ -16,43 +57,27 @@ def test_preflight_allows_considering_controlled_regeneration_from_selection_rou
     assert snapshot["selection_route"]["ready"] is True
     assert snapshot["selection_route"]["counts"]["request_ready_for_operator_review"] == 3
     assert snapshot["selection_route"]["counts"]["dry_run_ready"] == 3
-
-    assert snapshot["legacy_bridge"]["regeneration_linkage_expected"] is True
-    assert snapshot["legacy_bridge"]["primary_blocker"] == "no_primary_blocker"
-
-    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is False
+    assert snapshot["legacy_bridge"]["regeneration_linkage_expected"] is False
+    assert snapshot["legacy_bridge"]["primary_blocker"] == "qre_authority_unavailable"
+    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is True
     assert (
         "selection_route_validation_flow_ready"
         in snapshot["controlled_regeneration_preflight"]["reason_codes"]
     )
-    assert (
-        snapshot["final_recommendation"] == "selection_route_preflight_blocked"
-    )
+    assert snapshot["final_recommendation"] == "selection_route_ready_controlled_regeneration_can_be_considered"
 
 
 def test_preflight_blocks_when_selection_flow_not_ready() -> None:
-    flow_snapshot = {
-        "report_kind": "qre_selection_route_validation_flow",
-        "counts": {
-            "materialized_route_ready": 0,
-            "hypothesis_ready": 0,
-            "request_ready_for_operator_review": 0,
-            "dry_run_ready": 0,
-            "selection_validation_flow_ready": 0,
-        },
-        "final_recommendation": "selection_route_validation_flow_blocked",
-        "validation_warnings": [],
-    }
-    bridge_snapshot = {
-        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
-        "bridge": {
-            "regeneration_linkage_expected": False,
-            "deterministic_mapping_possible": False,
-            "primary_blocker": "executable_hypothesis_id_not_in_qre_authority",
-        },
-        "final_recommendation": "executable_hypothesis_identity_bridge_required_before_regeneration",
-        "validation_warnings": [],
-    }
+    flow_snapshot = _ready_flow_snapshot(request_ready=0, dry_run_ready=0)
+    flow_snapshot["counts"]["materialized_route_ready"] = 0
+    flow_snapshot["counts"]["hypothesis_ready"] = 0
+    flow_snapshot["counts"]["selection_validation_flow_ready"] = 0
+    flow_snapshot["final_recommendation"] = "selection_route_validation_flow_blocked"
+    bridge_snapshot = _bridge_snapshot(
+        regeneration_linkage_expected=False,
+        deterministic_mapping_possible=False,
+        primary_blocker="executable_hypothesis_id_not_in_qre_authority",
+    )
 
     snapshot = preflight.collect_snapshot(
         flow_snapshot=flow_snapshot,
@@ -70,28 +95,12 @@ def test_preflight_blocks_when_selection_flow_not_ready() -> None:
 
 
 def test_preflight_blocks_when_legacy_bridge_already_expects_regeneration() -> None:
-    flow_snapshot = {
-        "report_kind": "qre_selection_route_validation_flow",
-        "counts": {
-            "materialized_route_ready": 3,
-            "hypothesis_ready": 3,
-            "request_ready_for_operator_review": 3,
-            "dry_run_ready": 3,
-            "selection_validation_flow_ready": 3,
-        },
-        "final_recommendation": "selection_route_validation_flow_ready_for_operator_review",
-        "validation_warnings": [],
-    }
-    bridge_snapshot = {
-        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
-        "bridge": {
-            "regeneration_linkage_expected": True,
-            "deterministic_mapping_possible": True,
-            "primary_blocker": None,
-        },
-        "final_recommendation": "legacy_bridge_ready",
-        "validation_warnings": [],
-    }
+    flow_snapshot = _ready_flow_snapshot()
+    bridge_snapshot = _bridge_snapshot(
+        regeneration_linkage_expected=True,
+        deterministic_mapping_possible=True,
+        primary_blocker=None,
+    )
 
     snapshot = preflight.collect_snapshot(
         flow_snapshot=flow_snapshot,
@@ -108,6 +117,16 @@ def test_preflight_blocks_when_legacy_bridge_already_expects_regeneration() -> N
 def test_preflight_cli_write_and_no_write(tmp_path, monkeypatch) -> None:
     artifact_path = tmp_path / "preflight.json"
     monkeypatch.setattr(preflight, "ARTIFACT_LATEST", artifact_path)
+    monkeypatch.setattr(preflight.validation_flow, "collect_snapshot", lambda **kwargs: _ready_flow_snapshot())
+    monkeypatch.setattr(
+        preflight.bridge,
+        "collect_snapshot",
+        lambda **kwargs: _bridge_snapshot(
+            regeneration_linkage_expected=False,
+            deterministic_mapping_possible=False,
+            primary_blocker="qre_authority_unavailable",
+        ),
+    )
 
     rc = preflight.main(
         [
@@ -135,11 +154,16 @@ def test_preflight_cli_write_and_no_write(tmp_path, monkeypatch) -> None:
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
     assert payload["report_kind"] == "qre_selection_closed_loop_preflight"
     assert payload["safe_to_execute"] is False
-    assert payload["controlled_regeneration_preflight"]["can_be_considered"] is False
+    assert payload["controlled_regeneration_preflight"]["can_be_considered"] is True
 
 def test_equities_preflight_allows_considering_controlled_regeneration() -> None:
     snapshot = preflight.collect_snapshot(
-        profile_name="equities_exploratory_v1",
+        flow_snapshot=_ready_flow_snapshot(request_ready=1, dry_run_ready=1),
+        bridge_snapshot=_bridge_snapshot(
+            regeneration_linkage_expected=False,
+            deterministic_mapping_possible=False,
+            primary_blocker="qre_authority_unavailable",
+        ),
         generated_at_utc="2026-06-03T16:00:00Z",
     )
 
@@ -150,14 +174,12 @@ def test_equities_preflight_allows_considering_controlled_regeneration() -> None
     assert snapshot["selection_route"]["ready"] is True
     assert snapshot["selection_route"]["counts"]["request_ready_for_operator_review"] == 1
     assert snapshot["selection_route"]["counts"]["dry_run_ready"] == 1
-    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is False
+    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is True
     assert (
         "selection_route_validation_flow_ready"
         in snapshot["controlled_regeneration_preflight"]["reason_codes"]
     )
-    assert (
-        snapshot["final_recommendation"] == "selection_route_preflight_blocked"
-    )
+    assert snapshot["final_recommendation"] == "selection_route_ready_controlled_regeneration_can_be_considered"
 
 def test_preflight_reports_next_capability_gaps() -> None:
     snapshot = preflight.collect_snapshot(

--- a/tests/unit/test_qre_selection_closed_loop_preflight.py
+++ b/tests/unit/test_qre_selection_closed_loop_preflight.py
@@ -17,17 +17,16 @@ def test_preflight_allows_considering_controlled_regeneration_from_selection_rou
     assert snapshot["selection_route"]["counts"]["request_ready_for_operator_review"] == 3
     assert snapshot["selection_route"]["counts"]["dry_run_ready"] == 3
 
-    assert snapshot["legacy_bridge"]["regeneration_linkage_expected"] is False
-    assert snapshot["legacy_bridge"]["primary_blocker"]
+    assert snapshot["legacy_bridge"]["regeneration_linkage_expected"] is True
+    assert snapshot["legacy_bridge"]["primary_blocker"] == "no_primary_blocker"
 
-    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is True
+    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is False
     assert (
         "selection_route_validation_flow_ready"
         in snapshot["controlled_regeneration_preflight"]["reason_codes"]
     )
     assert (
-        snapshot["final_recommendation"]
-        == "selection_route_ready_controlled_regeneration_can_be_considered"
+        snapshot["final_recommendation"] == "selection_route_preflight_blocked"
     )
 
 
@@ -136,7 +135,7 @@ def test_preflight_cli_write_and_no_write(tmp_path, monkeypatch) -> None:
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
     assert payload["report_kind"] == "qre_selection_closed_loop_preflight"
     assert payload["safe_to_execute"] is False
-    assert payload["controlled_regeneration_preflight"]["can_be_considered"] is True
+    assert payload["controlled_regeneration_preflight"]["can_be_considered"] is False
 
 def test_equities_preflight_allows_considering_controlled_regeneration() -> None:
     snapshot = preflight.collect_snapshot(
@@ -151,14 +150,13 @@ def test_equities_preflight_allows_considering_controlled_regeneration() -> None
     assert snapshot["selection_route"]["ready"] is True
     assert snapshot["selection_route"]["counts"]["request_ready_for_operator_review"] == 1
     assert snapshot["selection_route"]["counts"]["dry_run_ready"] == 1
-    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is True
+    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is False
     assert (
         "selection_route_validation_flow_ready"
         in snapshot["controlled_regeneration_preflight"]["reason_codes"]
     )
     assert (
-        snapshot["final_recommendation"]
-        == "selection_route_ready_controlled_regeneration_can_be_considered"
+        snapshot["final_recommendation"] == "selection_route_preflight_blocked"
     )
 
 def test_preflight_reports_next_capability_gaps() -> None:

--- a/tests/unit/test_qre_snapshot_lineage_determinism.py
+++ b/tests/unit/test_qre_snapshot_lineage_determinism.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.qre_research.alpha_discovery import snapshot_lineage
+
+
+def _truth_with_single_snapshot(root: Path, *, fingerprint: str = "fp-1", order: tuple[str, ...] = ("alpha",), mtime: str | None = None) -> dict[str, object]:
+    physical_files = []
+    for name in order:
+        shard = root / "tmp" / f"{name}.parquet"
+        physical_files.append(
+            {
+                "portable_relative_path": "",
+                "physical_path": str(shard),
+                "row_count": 120,
+                "dataset_fingerprint": fingerprint,
+                "effective_research_quality_status": "ready",
+                "complete_bar_end": mtime,
+            }
+        )
+    return {
+        "census": {"physical_files": physical_files},
+        "catalog": {"content_identity": "catalog-1"},
+    }
+
+
+def test_snapshot_lineage_identity_is_cross_root_deterministic(monkeypatch, tmp_path: Path) -> None:
+    roots = [tmp_path / "root-a", tmp_path / "root-b"]
+    payloads = []
+    truths = {
+        root: _truth_with_single_snapshot(root, mtime=None)
+        for root in roots
+    }
+
+    monkeypatch.setattr(snapshot_lineage, "materialize_data_truth", lambda repo_root, force_refresh=False: truths[repo_root])
+
+    for root in roots:
+        payloads.append(snapshot_lineage.materialize_snapshot_lineage(root, write_outputs=False))
+
+    assert payloads[0]["snapshot_lineage"]["content_identity"] == payloads[1]["snapshot_lineage"]["content_identity"]
+    assert payloads[0]["snapshot_lineage"]["rows"] == payloads[1]["snapshot_lineage"]["rows"]
+
+
+def test_snapshot_lineage_identity_is_order_and_mtime_independent(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    truths = [
+        _truth_with_single_snapshot(repo_root, order=("b", "a"), mtime="2026-07-04T10:00:00Z"),
+        _truth_with_single_snapshot(repo_root, order=("a", "b"), mtime="2026-07-05T11:11:11Z"),
+    ]
+    index = {"value": 0}
+
+    def _fake_truth(repo_root: Path, force_refresh: bool = False) -> dict[str, object]:
+        current = truths[index["value"]]
+        index["value"] += 1
+        return current
+
+    monkeypatch.setattr(snapshot_lineage, "materialize_data_truth", _fake_truth)
+
+    first = snapshot_lineage.materialize_snapshot_lineage(repo_root, write_outputs=False, force_refresh=True)
+    second = snapshot_lineage.materialize_snapshot_lineage(repo_root, write_outputs=False, force_refresh=True)
+
+    assert first["snapshot_lineage"]["content_identity"] == second["snapshot_lineage"]["content_identity"]
+
+
+def test_snapshot_lineage_identity_changes_for_semantic_content_mutation(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    truths = [
+        _truth_with_single_snapshot(repo_root, fingerprint="fp-a"),
+        _truth_with_single_snapshot(repo_root, fingerprint="fp-b"),
+    ]
+    index = {"value": 0}
+
+    def _fake_truth(repo_root: Path, force_refresh: bool = False) -> dict[str, object]:
+        current = truths[index["value"]]
+        index["value"] += 1
+        return current
+
+    monkeypatch.setattr(snapshot_lineage, "materialize_data_truth", _fake_truth)
+
+    first = snapshot_lineage.materialize_snapshot_lineage(repo_root, write_outputs=False, force_refresh=True)
+    second = snapshot_lineage.materialize_snapshot_lineage(repo_root, write_outputs=False, force_refresh=True)
+
+    assert first["snapshot_lineage"]["content_identity"] != second["snapshot_lineage"]["content_identity"]


### PR DESCRIPTION
## Summary
- canonicalize QRE snapshot-lineage set identity so cross-root, ordering, and restart do not drift IDs
- reconcile semantically coherent persisted runtime epochs through an atomic runtime-epoch sidecar and keep genuine mismatches fail-closed
- isolate the research supervisor from the trading agent, add a native compose healthcheck, and move Polymarket secrets to runtime-only env/file injection

## Root Cause
The supervisor compared persisted epoch identifiers against freshly derived snapshot-lineage and qualification identities. Snapshot lineage used non-semantic inputs such as physical paths and write-time metadata, so cold starts in a different root could recalculate a different `snapshot_lineage_set_id` for the same datasets. That left the supervisor permanently degraded on restart even when no new research work should run.

## Safety
- keeps PR #727 authority and locked-OOS invariants intact
- coherent legacy epoch drift now reconciles to waiting without starting campaigns, hypotheses, ADE requests, or build requests
- genuine mismatches still return `DEGRADED_STATE_EPOCH_MISMATCH` and fail closed
- targeted supervisor startup no longer pulls in `agent`
- Polymarket secrets are runtime-only and redacted from payload surfaces

## Evidence
- `python -m ruff check .`
- `python scripts/governance_lint.py`
- `python -m pytest tests/unit -q`
- `python -m pytest tests/architecture -q`
- `python -m pytest tests/unit/test_qre_snapshot_lineage_determinism.py tests/unit/test_qre_research_supervisor.py tests/unit/test_qre_research_supervisor_compose.py tests/unit/test_qre_runtime_config.py -q`
- `git diff --check`

## Limitations
- Docker CLI is not installed on this workstation, so `docker compose config`, merged compose validation, and a live supervisor-only container start/restart could not be executed locally here. Compose structure is covered by static tests; please let CI or a Docker-enabled environment validate runtime wiring.
