### PR TITLE
fix: prevent repeated blocked qre supervisor discovery

### DIFF
--- a/reporting/qre_research_supervisor.py
+++ b/reporting/qre_research_supervisor.py
@@ -20,6 +20,8 @@ STATUS_PATH = REPO_ROOT / "logs/qre_research_supervisor/latest.json"
 HEALTHCHECK_PATH = REPO_ROOT / "logs/qre_research_supervisor/healthcheck.json"
 SOURCE_QUALIFICATIONS_PATH = REPO_ROOT / "generated_research/alpha_discovery/source_qualifications/latest.json"
 RUNTIME_EPOCH_PATH = REPO_ROOT / "generated_research/alpha_discovery/runtime_epoch/latest.json"
+SOURCE_RESOLUTION_PATH = REPO_ROOT / "generated_research/alpha_discovery/source_resolution/latest.json"
+OBSERVATIONS_PATH = REPO_ROOT / "generated_research/alpha_discovery/observations/latest.json"
 SERVICE_VERSION = "qre_alpha_supervisor_pr4_v1"
 DEFAULT_INTERVAL_SECONDS = 300
 MAX_INTERVAL_SECONDS = 3600
@@ -49,6 +51,10 @@ def _snapshot_lineage_module() -> Any:
 
 def content_id(prefix: str, payload: Any) -> str:
     return _contracts().content_id(prefix, payload)
+
+
+def canonical_payload(value: Any) -> Any:
+    return _contracts().canonical_payload(value)
 
 
 def load_snapshot_lineage(repo_root: Path) -> dict[str, Any]:
@@ -164,6 +170,161 @@ def _blocked_retry_due(blocked: list[dict[str, Any]]) -> bool:
     return False
 
 
+def _watermarks(*, snapshot_lineage_set_id: str, qualification_set_id: str, open_gaps: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "snapshot_lineage": snapshot_lineage_set_id,
+        "source_qualifications": qualification_set_id,
+        "open_gap_ids": sorted(str(row.get("gap_id") or "") for row in open_gaps),
+    }
+
+
+def _operator_actions(open_gaps: list[dict[str, Any]]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                "configure_provider_credentials" if str(row.get("gap_type") or "") == "CREDENTIAL_GAP" else
+                "resolve_license_boundary" if str(row.get("gap_type") or "") == "LICENSE_GAP" else
+                "review_source_certification" if str(row.get("gap_type") or "") == "SOURCE_CERTIFICATION_GAP" else
+                "review_blocked_experiment"
+                for row in open_gaps
+            }
+        )
+    )
+
+
+def _semantic_gap_rows(open_gaps: list[dict[str, Any]]) -> tuple[dict[str, Any], ...]:
+    rows = [
+        canonical_payload(
+            {
+                "gap_id": str(row.get("gap_id") or ""),
+                "experiment_id": str(row.get("experiment_id") or ""),
+                "gap_type": str(row.get("gap_type") or ""),
+                "status": str(row.get("status") or ""),
+                "request_id": str(row.get("request_id") or ""),
+                "deduplication_key": str(row.get("deduplication_key") or ""),
+                "content_identity": str(row.get("content_identity") or ""),
+            }
+        )
+        for row in open_gaps
+    ]
+    return tuple(sorted(rows, key=lambda row: (str(row.get("gap_id") or ""), str(row.get("experiment_id") or ""), str(row.get("gap_type") or ""))))
+
+
+def _semantic_blocked_rows(blocked: list[dict[str, Any]]) -> tuple[dict[str, Any], ...]:
+    rows = [
+        canonical_payload(
+            {
+                "experiment_id": str(row.get("experiment_id") or ""),
+                "hypothesis_id": str(row.get("hypothesis_id") or ""),
+                "strategy_spec_id": str(row.get("strategy_spec_id") or ""),
+                "preregistration_id": str(row.get("preregistration_id") or ""),
+                "blocked_stage": str(row.get("blocked_stage") or ""),
+                "gap_ids": tuple(sorted(str(value) for value in row.get("gap_ids") or () if str(value))),
+                "required_data_snapshot": str(row.get("required_data_snapshot") or ""),
+                "required_source_tier": str(row.get("required_source_tier") or ""),
+                "required_primitive": str(row.get("required_primitive") or ""),
+                "required_executor": str(row.get("required_executor") or ""),
+                "current_status": str(row.get("current_status") or ""),
+                "resume_token": str(row.get("resume_token") or ""),
+                "content_identity": str(row.get("content_identity") or ""),
+            }
+        )
+        for row in blocked
+    ]
+    return tuple(sorted(rows, key=lambda row: (str(row.get("experiment_id") or ""), str(row.get("resume_token") or ""))))
+
+
+def _source_resolution_state(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(repo_root / Path("generated_research/alpha_discovery/source_resolution/latest.json")) or {}
+    rows = payload.get("rows") or []
+    if not rows or not isinstance(rows[0], dict):
+        return {}
+    row = dict(rows[0])
+    return canonical_payload(
+        {
+            "resolution_id": str(row.get("resolution_id") or ""),
+            "selected_source": str(row.get("selected_source") or ""),
+            "selected_snapshot": str(row.get("selected_snapshot") or ""),
+            "current_source_tier": str(row.get("current_source_tier") or ""),
+            "target_source_tier": str(row.get("target_source_tier") or ""),
+            "qualification_actions": tuple(sorted(str(value) for value in row.get("qualification_actions") or () if str(value))),
+            "candidate_sources": tuple(sorted(str(value) for value in row.get("candidate_sources") or () if str(value))),
+            "credential_requirements": tuple(sorted(str(value) for value in row.get("credential_requirements") or () if str(value))),
+            "license_requirements": tuple(sorted(str(value) for value in row.get("license_requirements") or () if str(value))),
+            "cross_source_requirements": tuple(sorted(str(value) for value in row.get("cross_source_requirements") or () if str(value))),
+            "unresolved_blockers": tuple(sorted(str(value) for value in row.get("unresolved_blockers") or () if str(value))),
+            "operator_action_required": bool(row.get("operator_action_required")),
+            "automatic_actions_allowed": bool(row.get("automatic_actions_allowed")),
+            "content_identity": str(row.get("content_identity") or payload.get("content_identity") or ""),
+        }
+    )
+
+
+def _observation_inventory_state(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(repo_root / Path("generated_research/alpha_discovery/observations/latest.json")) or {}
+    if not payload:
+        return {}
+    return canonical_payload(
+        {
+            "primitive_inventory": payload.get("primitive_inventory") or {},
+            "executor_inventory": payload.get("executor_inventory") or {},
+            "data_coverage": payload.get("data_coverage") or {},
+            "source_quality": payload.get("source_quality") or {},
+            "identity_readiness": str(payload.get("identity_readiness") or ""),
+        }
+    )
+
+
+def _semantic_cycle_inputs(
+    *,
+    snapshot_lineage_set_id: str,
+    qualification_set_id: str,
+    open_gaps: list[dict[str, Any]],
+    blocked: list[dict[str, Any]],
+    source_resolution_state: dict[str, Any],
+    observation_state: dict[str, Any],
+    alpha_status: dict[str, Any],
+) -> dict[str, Any]:
+    return canonical_payload(
+        {
+            "snapshot_lineage_set_id": snapshot_lineage_set_id,
+            "qualification_set_id": qualification_set_id,
+            "open_gaps": _semantic_gap_rows(open_gaps),
+            "blocked_experiments": _semantic_blocked_rows(blocked),
+            "source_resolution": source_resolution_state,
+            "observation_state": observation_state,
+            "authority_state": {
+                "requested_execution_tier": str(alpha_status.get("requested_execution_tier") or ""),
+                "admitted_execution_tier": str(alpha_status.get("admitted_execution_tier") or ""),
+                "current_source_tier": str(alpha_status.get("current_source_tier") or ""),
+                "terminal_disposition": str(alpha_status.get("terminal_disposition") or alpha_status.get("legacy_terminal_disposition") or ""),
+                "scientific_disposition": str(alpha_status.get("scientific_disposition") or ""),
+                "evidence_tier_reached": str(alpha_status.get("evidence_tier_reached") or ""),
+                "execution_status": str(alpha_status.get("execution_status") or ""),
+            },
+        }
+    )
+
+
+def _semantic_cycle_identity(**kwargs: Any) -> str:
+    return content_id("qsupsem", _semantic_cycle_inputs(**kwargs))
+
+
+def _validate_status_publication(payload: dict[str, Any]) -> None:
+    watermarks = payload.get("watermarks") if isinstance(payload.get("watermarks"), dict) else {}
+    qualification_set_id = str(payload.get("qualification_set_id") or "")
+    snapshot_lineage_set_id = str(payload.get("snapshot_lineage_set_id") or "")
+    if qualification_set_id and str(watermarks.get("source_qualifications") or "") not in {"", qualification_set_id}:
+        raise ValueError("supervisor_status_publication_requires_matching_source_qualification_watermark")
+    if snapshot_lineage_set_id and str(watermarks.get("snapshot_lineage") or "") not in {"", snapshot_lineage_set_id}:
+        raise ValueError("supervisor_status_publication_requires_matching_snapshot_lineage_watermark")
+
+
+def _publish_status(payload: dict[str, Any]) -> None:
+    _validate_status_publication(payload)
+    _write_status(payload)
+
+
 def _qualification_rows() -> tuple[dict[str, Any], tuple[dict[str, Any], ...]]:
     payload = _read_json(SOURCE_QUALIFICATIONS_PATH) or {}
     rows = tuple(dict(row) for row in payload.get("rows") or [] if isinstance(row, dict))
@@ -266,12 +427,26 @@ def run_cycle(
         open_gaps = _open_gaps()
         blocked = _blocked_experiments()
         blocked_retry_due = _blocked_retry_due(blocked)
-        current_watermarks = {
-            "snapshot_lineage": lineage.get("snapshot_lineage", {}).get("content_identity"),
-            "source_qualifications": source_qualifications.get("content_identity"),
-            "open_gap_ids": sorted(str(row.get("gap_id") or "") for row in open_gaps),
-        }
+        snapshot_lineage_set_id = str(lineage.get("snapshot_lineage", {}).get("content_identity") or "")
+        qualification_set_id = str(source_qualifications.get("content_identity") or "")
+        current_watermarks = _watermarks(
+            snapshot_lineage_set_id=snapshot_lineage_set_id,
+            qualification_set_id=qualification_set_id,
+            open_gaps=open_gaps,
+        )
+        source_resolution_state = _source_resolution_state(repo_root)
+        observation_state = _observation_inventory_state(repo_root)
+        semantic_input_identity = _semantic_cycle_identity(
+            snapshot_lineage_set_id=snapshot_lineage_set_id,
+            qualification_set_id=qualification_set_id,
+            open_gaps=open_gaps,
+            blocked=blocked,
+            source_resolution_state=source_resolution_state,
+            observation_state=observation_state,
+            alpha_status=alpha_status,
+        )
         prior_watermarks = prior_status.get("watermarks") if isinstance(prior_status.get("watermarks"), dict) else {}
+        prior_semantic_input_identity = str(prior_status.get("semantic_input_identity") or "")
         qualified_snapshot_ids = {str(row.get("dataset_snapshot_id") or "") for row in qualification_rows if str(row.get("dataset_snapshot_id") or "")}
         epoch_mismatch_reasons: list[str] = []
         if str(epoch_state.get("runtime_epoch_id") or "") and str(prior_status.get("runtime_epoch_id") or "") and epoch_state.get("runtime_epoch_id") != prior_status.get("runtime_epoch_id"):
@@ -322,14 +497,7 @@ def run_cycle(
                 "current_campaign": alpha_status.get("current_campaign"),
                 "open_gaps": tuple(str(row.get("gap_id") or "") for row in open_gaps),
                 "active_ADE_requests": tuple(str(row.get("request_id") or "") for row in open_gaps if row.get("request_id")),
-                "operator_actions": tuple(
-                    sorted(
-                        {
-                            "review_source_certification" if str(row.get("gap_type") or "") == "SOURCE_CERTIFICATION_GAP" else "review_blocked_experiment"
-                            for row in open_gaps
-                        }
-                    )
-                ),
+                "operator_actions": _operator_actions(open_gaps),
                 "next_retry": (datetime.now(UTC) + timedelta(minutes=5)).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
                 "next_scheduled_cycle": (datetime.now(UTC) + timedelta(seconds=DEFAULT_INTERVAL_SECONDS)).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
                 "consecutive_failures": 0,
@@ -344,10 +512,11 @@ def run_cycle(
                 "qualification_set_id": reconciled_epoch["qualification_set_id"],
                 "snapshot_lineage_set_id": reconciled_epoch["snapshot_lineage_set_id"],
                 "content_identity": content_id("qsupreconcile", {"watermarks": current_watermarks, "epoch": reconciled_epoch["content_identity"]}),
+                "semantic_input_identity": semantic_input_identity,
                 "blocked_experiments": blocked,
                 "search_ledger_id": alpha_status.get("search_ledger_id"),
             }
-            _write_status(payload)
+            _publish_status(payload)
             return payload
         if epoch_mismatch:
             payload = {
@@ -381,33 +550,66 @@ def run_cycle(
                 "qualification_set_id": source_qualifications.get("content_identity"),
                 "snapshot_lineage_set_id": lineage.get("snapshot_lineage", {}).get("content_identity"),
                 "content_identity": content_id("qsupdegraded", {"reason_codes": tuple(dict.fromkeys(epoch_mismatch_reasons)), "watermarks": current_watermarks}),
+                "semantic_input_identity": semantic_input_identity,
                 "blocked_experiments": blocked,
                 "search_ledger_id": alpha_status.get("search_ledger_id"),
             }
-            _write_status(payload)
+            _publish_status(payload)
             return payload
         comparable_prior = {key: prior_watermarks.get(key) for key in current_watermarks}
-        if comparable_prior == current_watermarks and not blocked_retry_due:
+        if prior_semantic_input_identity == semantic_input_identity or (
+            comparable_prior == current_watermarks and not blocked_retry_due
+        ):
+            health = _health_from_run(alpha_status, open_gaps)
             payload = {
                 "service_version": SERVICE_VERSION,
-                "health": HEALTH_HEALTHY_WAITING,
+                "health": health,
                 "current_stage": "NO_CHANGE_SKIP",
-                "last_cycle": {"decision": "no_material_change", "generated_at_utc": _utcnow()},
+                "last_cycle": {
+                    "decision": "no_material_change",
+                    "generated_at_utc": _utcnow(),
+                    "reason_codes": ("semantic_inputs_unchanged",) if prior_semantic_input_identity == semantic_input_identity else ("watermarks_unchanged",),
+                },
                 "last_successful_cycle": prior_status.get("last_successful_cycle"),
+                "current_dataset_snapshot": alpha_status.get("current_dataset_snapshot"),
+                "current_source_tier": alpha_status.get("current_source_tier"),
+                "current_experiment": alpha_status.get("current_experiment"),
+                "current_campaign": alpha_status.get("current_campaign"),
+                "open_gaps": tuple(str(row.get("gap_id") or "") for row in open_gaps),
+                "active_ADE_requests": tuple(str(row.get("request_id") or "") for row in open_gaps if row.get("request_id")),
+                "operator_actions": _operator_actions(open_gaps),
+                "next_retry": prior_status.get("next_retry"),
+                "next_scheduled_cycle": (datetime.now(UTC) + timedelta(seconds=DEFAULT_INTERVAL_SECONDS)).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                "consecutive_failures": 0 if health.startswith("HEALTHY") else 1,
                 "watermarks": current_watermarks,
                 "leases": lease,
-                "content_identity": content_id("qsupnoop", current_watermarks),
+                "runtime_epoch_id": str(persisted_runtime_epoch.get("runtime_epoch_id") or alpha_status.get("runtime_epoch_id") or ""),
+                "qualification_set_id": qualification_set_id,
+                "snapshot_lineage_set_id": snapshot_lineage_set_id,
+                "search_ledger_id": alpha_status.get("search_ledger_id"),
+                "semantic_input_identity": semantic_input_identity,
+                "blocked_experiments": blocked,
+                "content_identity": content_id("qsupnoop", {"semantic_input_identity": semantic_input_identity, "health": health}),
             }
-            _write_status(payload)
+            _publish_status(payload)
             return payload
         run_payload = run_alpha_discovery_mvp(repo_root=repo_root, dry_run=dry_run, max_hypotheses=3, execution_tier="screening")
         open_gaps = _open_gaps()
         blocked = _blocked_experiments()
-        current_watermarks = {
-            "snapshot_lineage": lineage.get("snapshot_lineage", {}).get("content_identity"),
-            "source_qualifications": source_qualifications.get("content_identity"),
-            "open_gap_ids": sorted(str(row.get("gap_id") or "") for row in open_gaps),
-        }
+        current_watermarks = _watermarks(
+            snapshot_lineage_set_id=str(run_payload.get("snapshot_lineage_set_id") or snapshot_lineage_set_id),
+            qualification_set_id=str(run_payload.get("qualification_set_id") or qualification_set_id),
+            open_gaps=open_gaps,
+        )
+        semantic_input_identity = _semantic_cycle_identity(
+            snapshot_lineage_set_id=str(run_payload.get("snapshot_lineage_set_id") or snapshot_lineage_set_id),
+            qualification_set_id=str(run_payload.get("qualification_set_id") or qualification_set_id),
+            open_gaps=open_gaps,
+            blocked=blocked,
+            source_resolution_state=_source_resolution_state(repo_root),
+            observation_state=_observation_inventory_state(repo_root),
+            alpha_status=run_payload,
+        )
         health = _health_from_run(run_payload, open_gaps)
         status = {
             "service_version": SERVICE_VERSION,
@@ -427,21 +629,11 @@ def run_cycle(
             "current_campaign": run_payload.get("current_campaign"),
             "open_gaps": tuple(str(row.get("gap_id") or "") for row in open_gaps),
             "active_ADE_requests": tuple(str(row.get("request_id") or "") for row in open_gaps if row.get("request_id")),
-            "operator_actions": tuple(
-                sorted(
-                    {
-                        "configure_provider_credentials" if str(row.get("gap_type") or "") == "CREDENTIAL_GAP" else
-                        "resolve_license_boundary" if str(row.get("gap_type") or "") == "LICENSE_GAP" else
-                        "review_source_certification" if str(row.get("gap_type") or "") == "SOURCE_CERTIFICATION_GAP" else
-                        "review_blocked_experiment"
-                        for row in open_gaps
-                    }
-                )
-            ),
+            "operator_actions": _operator_actions(open_gaps),
             "next_retry": (datetime.now(UTC) + timedelta(minutes=5)).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
             "next_scheduled_cycle": (datetime.now(UTC) + timedelta(seconds=DEFAULT_INTERVAL_SECONDS)).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
             "consecutive_failures": 0 if health.startswith("HEALTHY") else 1,
-            "watermarks": {**current_watermarks, "alpha_status": alpha_status.get("content_identity")},
+            "watermarks": {**current_watermarks, "alpha_status": run_payload.get("content_identity")},
             "leases": lease,
             "artifact_refs": {
                 "alpha_status": str(repo_root / Path("generated_research/alpha_discovery/status/latest.json")),
@@ -451,6 +643,7 @@ def run_cycle(
             "qualification_set_id": run_payload.get("qualification_set_id"),
             "snapshot_lineage_set_id": run_payload.get("snapshot_lineage_set_id"),
             "health": health,
+            "semantic_input_identity": semantic_input_identity,
             "content_identity": content_id("qsup", {"run_id": run_payload.get("run_id"), "health": health, "blocked": len(blocked)}),
         }
         payload = {
@@ -458,7 +651,7 @@ def run_cycle(
             "blocked_experiments": blocked,
             "search_ledger_id": run_payload.get("search_ledger_id"),
         }
-        _write_status(payload)
+        _publish_status(payload)
         return payload
     finally:
         _release_lease(lease)

--- a/tests/unit/test_qre_research_supervisor.py
+++ b/tests/unit/test_qre_research_supervisor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
@@ -15,6 +17,10 @@ def _configure_paths(monkeypatch: pytest.MonkeyPatch, repo_root: Path) -> None:
     monkeypatch.setattr(supervisor, "HEALTHCHECK_PATH", repo_root / "logs/qre_research_supervisor/healthcheck.json")
     monkeypatch.setattr(supervisor, "RUNTIME_EPOCH_PATH", repo_root / "generated_research/alpha_discovery/runtime_epoch/latest.json")
     monkeypatch.setattr(supervisor, "SOURCE_QUALIFICATIONS_PATH", repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json")
+
+
+def _file_digest(path: Path) -> str:
+    return sha256(path.read_bytes()).hexdigest()
 
 
 def test_supervisor_no_change_skip(monkeypatch, tmp_path: Path) -> None:
@@ -314,7 +320,326 @@ def test_supervisor_restarted_coherent_state_is_idempotent(monkeypatch, tmp_path
 
     assert first["current_stage"] == "COHERENT_EPOCH_RECONCILED"
     assert second["current_stage"] == "NO_CHANGE_SKIP"
-    assert second["health"] == "HEALTHY_WAITING_FOR_TRIGGER"
+    assert second["health"] == "BLOCKED_SOURCE_CERTIFICATION"
+
+
+def test_supervisor_blocked_state_skips_repeated_discovery_cycles(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+
+    artifact_root = repo_root / "generated_research/alpha_discovery"
+    for relative in (
+        "source_qualifications",
+        "status",
+        "runtime_epoch",
+        "blocked_experiments",
+        "capability_gaps",
+        "search_ledger",
+        "hypotheses",
+        "experiments",
+    ):
+        (artifact_root / relative).mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/data_catalog/snapshot_lineage").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/data_catalog/revisions").mkdir(parents=True, exist_ok=True)
+    (repo_root / "logs/qre_research_supervisor").mkdir(parents=True, exist_ok=True)
+
+    hypothesis_id = "qah-baseline"
+    experiment_id = "qexp-baseline"
+    gap_id = "qgap-baseline"
+    search_ledger_id = "qsl-baseline"
+    runtime_epoch_id = "qepoch-baseline"
+    qualification_set_id = "qdsqset-baseline"
+    snapshot_lineage_set_id = "qdsnapset-baseline"
+    blocked_retry = "2026-07-04T12:00:00Z"
+
+    (repo_root / "generated_research/data_catalog/snapshot_lineage/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": snapshot_lineage_set_id}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/data_catalog/revisions/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "rev-current"}),
+        encoding="utf-8",
+    )
+    (artifact_root / "source_qualifications/latest.json").write_text(
+        json.dumps(
+            {
+                "rows": [
+                    {
+                        "dataset_snapshot_id": "snap-blocked",
+                        "allowed_evidence_tier": "SOURCE_BLOCKED",
+                        "qualification_status": "BLOCKED",
+                    }
+                ],
+                "content_identity": qualification_set_id,
+                "qualification_set_id": qualification_set_id,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_root / "status/latest.json").write_text(
+        json.dumps(
+            {
+                "runtime_epoch_id": "qepoch-legacy",
+                "qualification_set_id": "qdsqset-legacy",
+                "snapshot_lineage_set_id": "qdsnapset-legacy",
+                "current_dataset_snapshot": None,
+                "current_source_tier": "SOURCE_BLOCKED",
+                "current_experiment": experiment_id,
+                "current_campaign": None,
+                "run_id": "qarr-baseline",
+                "terminal_disposition": "STOPPED_SOURCE_CERTIFICATION_BOUNDARY",
+                "execution_status": "COMPLETED",
+                "scientific_disposition": "NEEDS_MORE_EVIDENCE",
+                "evidence_tier_reached": "EMPIRICAL_SCREENING",
+                "search_ledger_id": search_ledger_id,
+                "selected_hypothesis_id": hypothesis_id,
+                "requested_execution_tier": "EMPIRICAL_SCREENING",
+                "admitted_execution_tier": "COMPILER_ONLY",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_root / "runtime_epoch/latest.json").write_text(
+        json.dumps(
+            {
+                "runtime_epoch_id": runtime_epoch_id,
+                "qualification_set_id": qualification_set_id,
+                "snapshot_lineage_set_id": snapshot_lineage_set_id,
+                "content_identity": "qepochstate-legacy",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_root / "blocked_experiments/latest.json").write_text(
+        json.dumps(
+            {
+                "rows": [
+                    {
+                        "experiment_id": experiment_id,
+                        "hypothesis_id": hypothesis_id,
+                        "strategy_spec_id": "qspec-baseline",
+                        "preregistration_id": experiment_id,
+                        "blocked_stage": "EXECUTE",
+                        "gap_ids": [gap_id],
+                        "required_data_snapshot": None,
+                        "required_source_tier": "SOURCE_SCREENING_ELIGIBLE",
+                        "required_primitive": None,
+                        "required_executor": None,
+                        "current_status": "BLOCKED",
+                        "resume_token": "qresume-baseline",
+                        "last_attempt_at_utc": "2026-07-04T11:45:00Z",
+                        "next_retry_after_utc": blocked_retry,
+                        "content_identity": "qblocked-baseline",
+                    }
+                ],
+                "content_identity": "qblockedset-baseline",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_root / "capability_gaps/latest.json").write_text(
+        json.dumps(
+            {
+                "rows": [
+                    {
+                        "gap_id": gap_id,
+                        "experiment_id": experiment_id,
+                        "gap_type": "SOURCE_CERTIFICATION_GAP",
+                        "status": "WAITING_FOR_OPERATOR",
+                        "request_id": None,
+                    }
+                ],
+                "content_identity": "qgapset-baseline",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_root / "search_ledger/latest.json").write_text(
+        json.dumps({"ledger": {"search_run_id": search_ledger_id}, "content_identity": "qslc-baseline"}),
+        encoding="utf-8",
+    )
+    (artifact_root / "hypotheses/latest.json").write_text(
+        json.dumps({"rows": [{"hypothesis_id": hypothesis_id}], "content_identity": "qhyp-set"}),
+        encoding="utf-8",
+    )
+    (artifact_root / "experiments/latest.json").write_text(
+        json.dumps({"rows": [{"experiment_id": experiment_id}], "content_identity": "qexp-set"}),
+        encoding="utf-8",
+    )
+    (repo_root / "logs/qre_research_supervisor/latest.json").write_text(
+        json.dumps(
+            {
+                "runtime_epoch_id": "qepoch-legacy",
+                "qualification_set_id": "qdsqset-legacy",
+                "snapshot_lineage_set_id": "qdsnapset-legacy",
+                "current_dataset_snapshot": None,
+                "current_source_tier": "SOURCE_BLOCKED",
+                "current_experiment": experiment_id,
+                "current_campaign": None,
+                "watermarks": {
+                    "snapshot_lineage": snapshot_lineage_set_id,
+                    "source_qualifications": qualification_set_id,
+                    "open_gap_ids": [gap_id],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    open_gaps = [{"gap_id": gap_id, "experiment_id": experiment_id, "gap_type": "SOURCE_CERTIFICATION_GAP", "status": "WAITING_FOR_OPERATOR", "request_id": None}]
+    blocked_rows = [
+        {
+            "experiment_id": experiment_id,
+            "hypothesis_id": hypothesis_id,
+            "strategy_spec_id": "qspec-baseline",
+            "preregistration_id": experiment_id,
+            "blocked_stage": "EXECUTE",
+            "gap_ids": [gap_id],
+            "required_data_snapshot": None,
+            "required_source_tier": "SOURCE_SCREENING_ELIGIBLE",
+            "required_primitive": None,
+            "required_executor": None,
+            "current_status": "BLOCKED",
+            "resume_token": "qresume-baseline",
+            "last_attempt_at_utc": "2026-07-04T11:45:00Z",
+            "next_retry_after_utc": blocked_retry,
+            "content_identity": "qblocked-baseline",
+        }
+    ]
+
+    artifact_paths = {
+        "hypotheses": artifact_root / "hypotheses/latest.json",
+        "experiments": artifact_root / "experiments/latest.json",
+        "capability_gaps": artifact_root / "capability_gaps/latest.json",
+        "search_ledger": artifact_root / "search_ledger/latest.json",
+        "source_qualifications": artifact_root / "source_qualifications/latest.json",
+        "runtime_epoch": artifact_root / "runtime_epoch/latest.json",
+        "status": artifact_root / "status/latest.json",
+    }
+
+    run_calls = 0
+
+    def _unexpected_run(*args, **kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        raise AssertionError("run_alpha_discovery_mvp should not be called for unchanged blocked state")
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _unexpected_run)
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": snapshot_lineage_set_id}, "revisions": {"rows": []}})
+    monkeypatch.setattr(supervisor, "_open_gaps", lambda: list(open_gaps))
+    monkeypatch.setattr(supervisor, "_blocked_experiments", lambda: list(blocked_rows))
+    monkeypatch.setattr(
+        supervisor,
+        "_utcnow",
+        iter(
+            [
+                "2026-07-04T11:56:00Z",
+                "2026-07-04T11:56:01Z",
+                "2026-07-04T12:01:33Z",
+                "2026-07-04T12:01:34Z",
+                "2026-07-04T12:06:33Z",
+                "2026-07-04T12:06:34Z",
+            ]
+        ).__next__,
+    )
+
+    baseline = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+    post_baseline_digests = {name: _file_digest(path) for name, path in artifact_paths.items()}
+    post_baseline_mtimes = {name: os.stat(path).st_mtime_ns for name, path in artifact_paths.items()}
+
+    cycle_2 = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+    restart_cycle = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert baseline["current_stage"] == "COHERENT_EPOCH_RECONCILED"
+    assert cycle_2["current_stage"] == "NO_CHANGE_SKIP"
+    assert restart_cycle["current_stage"] == "NO_CHANGE_SKIP"
+    assert cycle_2["health"] == "BLOCKED_SOURCE_CERTIFICATION"
+    assert restart_cycle["health"] == "BLOCKED_SOURCE_CERTIFICATION"
+    assert cycle_2["last_cycle"]["decision"] == "no_material_change"
+    assert restart_cycle["last_cycle"]["decision"] == "no_material_change"
+    assert cycle_2["current_campaign"] is None
+    assert restart_cycle["current_campaign"] is None
+    assert cycle_2["current_dataset_snapshot"] is None
+    assert restart_cycle["current_dataset_snapshot"] is None
+    assert cycle_2["active_ADE_requests"] == ()
+    assert restart_cycle["active_ADE_requests"] == ()
+    assert cycle_2["current_experiment"] == experiment_id
+    assert restart_cycle["current_experiment"] == experiment_id
+    assert cycle_2["search_ledger_id"] == search_ledger_id
+    assert restart_cycle["search_ledger_id"] == search_ledger_id
+    assert cycle_2["qualification_set_id"] == qualification_set_id
+    assert restart_cycle["qualification_set_id"] == qualification_set_id
+    assert cycle_2["snapshot_lineage_set_id"] == snapshot_lineage_set_id
+    assert restart_cycle["snapshot_lineage_set_id"] == snapshot_lineage_set_id
+    assert cycle_2["runtime_epoch_id"] == baseline["runtime_epoch_id"]
+    assert restart_cycle["runtime_epoch_id"] == baseline["runtime_epoch_id"]
+    assert cycle_2["blocked_experiments"][0]["experiment_id"] == experiment_id
+    assert restart_cycle["blocked_experiments"][0]["experiment_id"] == experiment_id
+    assert run_calls == 0
+    for name, path in artifact_paths.items():
+        assert _file_digest(path) == post_baseline_digests[name], name
+        assert os.stat(path).st_mtime_ns == post_baseline_mtimes[name], name
+
+
+def test_supervisor_run_status_aligns_watermarks_with_run_ids(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+
+    (repo_root / "generated_research/data_catalog/snapshot_lineage").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/data_catalog/revisions").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/source_qualifications").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/status").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/runtime_epoch").mkdir(parents=True, exist_ok=True)
+    (repo_root / "logs/qre_research_supervisor").mkdir(parents=True, exist_ok=True)
+
+    (repo_root / "generated_research/data_catalog/snapshot_lineage/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "snap-before"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/data_catalog/revisions/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "rev-before"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "qual-before", "qualification_set_id": "qual-before"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/alpha_discovery/status/latest.json").write_text(
+        json.dumps({"content_identity": "alpha-before"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(supervisor, "_open_gaps", lambda: [{"gap_id": "gap-source", "gap_type": "SOURCE_CERTIFICATION_GAP"}])
+    monkeypatch.setattr(supervisor, "_blocked_experiments", lambda: [{"experiment_id": "qexp-run", "content_identity": "qblocked-run", "resume_token": "qresume-run"}])
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": "snap-before"}, "revisions": {"rows": []}})
+    monkeypatch.setattr(
+        supervisor,
+        "run_alpha_discovery_mvp",
+        lambda **kwargs: {
+            "run_id": "qarr-run",
+            "terminal_disposition": "STOPPED_SOURCE_CERTIFICATION_BOUNDARY",
+            "execution_status": "COMPLETED",
+            "current_dataset_snapshot": None,
+            "current_source_tier": "SOURCE_BLOCKED",
+            "current_experiment": "qexp-run",
+            "current_campaign": None,
+            "runtime_epoch_id": "qepoch-run",
+            "qualification_set_id": "qual-after",
+            "snapshot_lineage_set_id": "snap-after",
+            "search_ledger_id": "qsl-run",
+            "requested_execution_tier": "EMPIRICAL_SCREENING",
+            "admitted_execution_tier": "COMPILER_ONLY",
+            "scientific_disposition": "NEEDS_MORE_EVIDENCE",
+            "evidence_tier_reached": "EMPIRICAL_SCREENING",
+            "content_identity": "qarrc-run",
+        },
+    )
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert payload["qualification_set_id"] == "qual-after"
+    assert payload["watermarks"]["source_qualifications"] == "qual-after"
+    assert payload["snapshot_lineage_set_id"] == "snap-after"
+    assert payload["watermarks"]["snapshot_lineage"] == "snap-after"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Root cause
- After `COHERENT_EPOCH_RECONCILED`, the supervisor only skipped when watermarks matched and `blocked_retry_due` was false.
- A blocked experiment with an expired `next_retry_after_utc` therefore re-entered discovery even when the semantic blocked state was unchanged.
- The post-run supervisor status also reused pre-run qualification/snapshot watermarks while publishing post-run IDs, which allowed `qualification_set_id != watermarks.source_qualifications`.

## Fix
- Add a canonical supervisor semantic-input identity built from snapshot lineage, qualification set, open gaps, blocked experiments, source-resolution state, observation inventories, and authority state.
- Use that identity to short-circuit repeated blocked cycles to `NO_CHANGE_SKIP`, regardless of retry clock drift alone.
- Publish supervisor status only when qualification and snapshot watermarks match the same generation IDs being emitted.
- Preserve the blocked source-certification health on unchanged blocked cycles instead of downgrading them to generic healthy waiting.

## Proof
- Added a regression that reproduces: reconcile -> unchanged cycle -> restart unchanged cycle, with zero new discovery work and stable IDs/artifacts.
- Added a status-publication invariant test for qualification/snapshot watermark alignment.
- Local required gates are green: `ruff`, `governance_lint`, `pytest tests/unit -q`, `pytest tests/architecture -q`, `git diff --check`.
