### PR TITLE
fix: reconstruct legacy ledger status identity

### DIFF
--- a/reporting/qre_research_supervisor.py
+++ b/reporting/qre_research_supervisor.py
@@ -22,6 +22,8 @@ SOURCE_QUALIFICATIONS_PATH = REPO_ROOT / "generated_research/alpha_discovery/sou
 RUNTIME_EPOCH_PATH = REPO_ROOT / "generated_research/alpha_discovery/runtime_epoch/latest.json"
 SOURCE_RESOLUTION_PATH = REPO_ROOT / "generated_research/alpha_discovery/source_resolution/latest.json"
 OBSERVATIONS_PATH = REPO_ROOT / "generated_research/alpha_discovery/observations/latest.json"
+RUNS_PATH = Path("generated_research/alpha_discovery/runs/latest.json")
+SEARCH_LEDGER_PATH = Path("generated_research/alpha_discovery/search_ledger/latest.json")
 SERVICE_VERSION = "qre_alpha_supervisor_pr4_v1"
 DEFAULT_INTERVAL_SECONDS = 300
 MAX_INTERVAL_SECONDS = 3600
@@ -357,6 +359,68 @@ def _read_runtime_epoch_state() -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _read_current_run_state(repo_root: Path) -> dict[str, Any]:
+    payload = _read_json(repo_root / RUNS_PATH) or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _ledger_artifact_identity(repo_root: Path) -> tuple[str, bool]:
+    path = repo_root / SEARCH_LEDGER_PATH
+    payload = _read_json(path)
+    if not isinstance(payload, dict):
+        return "", path.is_file()
+    candidates: list[str] = []
+    for key in ("search_ledger_id", "search_run_id", "ledger_id"):
+        value = str(payload.get(key) or "")
+        if value:
+            candidates.append(value)
+    ledger = payload.get("ledger")
+    if isinstance(ledger, dict):
+        for key in ("search_ledger_id", "search_run_id", "ledger_id"):
+            value = str(ledger.get(key) or "")
+            if value:
+                candidates.append(value)
+    rows = payload.get("rows")
+    if isinstance(rows, list):
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            for key in ("search_ledger_id", "search_run_id", "ledger_id"):
+                value = str(row.get(key) or "")
+                if value:
+                    candidates.append(value)
+    unique = tuple(dict.fromkeys(candidates))
+    return (unique[0], True) if len(unique) == 1 else ("", True)
+
+
+def _reconstruct_legacy_search_ledger_id(
+    *,
+    repo_root: Path,
+    alpha_status: dict[str, Any],
+    persisted_runtime_epoch: dict[str, Any],
+) -> tuple[str | None, tuple[str, ...]]:
+    runtime_ledger_id = str(persisted_runtime_epoch.get("search_ledger_id") or "")
+    run_ledger_id = str(_read_current_run_state(repo_root).get("search_ledger_id") or "")
+    artifact_ledger_id, artifact_present = _ledger_artifact_identity(repo_root)
+    status_ledger_id = str(alpha_status.get("search_ledger_id") or "")
+    source_ids = {
+        "runtime_epoch": runtime_ledger_id,
+        "run": run_ledger_id,
+        "search_ledger": artifact_ledger_id,
+        "status": status_ledger_id,
+    }
+    nonempty_ids = {value for value in source_ids.values() if value}
+    if len(nonempty_ids) > 1:
+        return None, ("legacy_search_ledger_identity_mismatch",)
+    if runtime_ledger_id and artifact_present and not artifact_ledger_id:
+        return None, ("legacy_search_ledger_identity_mismatch",)
+    if run_ledger_id and artifact_present and not artifact_ledger_id:
+        return None, ("legacy_search_ledger_identity_mismatch",)
+    if nonempty_ids:
+        return sorted(nonempty_ids)[0], ()
+    return None, ()
+
+
 def _artifact_rows(repo_root: Path, relative: str) -> tuple[dict[str, Any], ...]:
     payload = _read_json(repo_root / Path(relative)) or {}
     return tuple(dict(row) for row in payload.get("rows") or [] if isinstance(row, dict))
@@ -509,6 +573,11 @@ def run_cycle(
         source_qualifications, qualification_rows = _qualification_rows()
         alpha_status = read_status(repo_root)
         persisted_runtime_epoch = _read_runtime_epoch_state()
+        reconstructed_search_ledger_id, search_ledger_reasons = _reconstruct_legacy_search_ledger_id(
+            repo_root=repo_root,
+            alpha_status=alpha_status,
+            persisted_runtime_epoch=persisted_runtime_epoch,
+        )
         epoch_state = persisted_runtime_epoch or alpha_status
         open_gaps = _open_gaps()
         blocked = _blocked_experiments()
@@ -568,6 +637,10 @@ def run_cycle(
                 snapshot_lineage_set_id=snapshot_lineage_set_id,
                 qualification_set_id=qualification_set_id,
             )
+            if legacy_valid and search_ledger_reasons:
+                legacy_valid = False
+                legacy_health = HEALTH_DEGRADED_LEGACY_STATE_INCONSISTENT
+                legacy_reasons = search_ledger_reasons
             if legacy_valid:
                 runtime_epoch_id = str(persisted_runtime_epoch.get("runtime_epoch_id") or alpha_status.get("runtime_epoch_id") or prior_status.get("runtime_epoch_id") or "")
                 health = _health_from_run(alpha_status, open_gaps)
@@ -596,7 +669,7 @@ def run_cycle(
                     "runtime_epoch_id": runtime_epoch_id,
                     "qualification_set_id": qualification_set_id,
                     "snapshot_lineage_set_id": snapshot_lineage_set_id,
-                    "search_ledger_id": alpha_status.get("search_ledger_id"),
+                    "search_ledger_id": reconstructed_search_ledger_id,
                     "semantic_input_identity": semantic_input_identity,
                     "blocked_experiments": blocked,
                     "content_identity": content_id("qsuplegacy", {"semantic_input_identity": semantic_input_identity, "health": health}),
@@ -628,9 +701,41 @@ def run_cycle(
                 "runtime_epoch_id": str(persisted_runtime_epoch.get("runtime_epoch_id") or alpha_status.get("runtime_epoch_id") or prior_status.get("runtime_epoch_id") or ""),
                 "qualification_set_id": qualification_set_id,
                 "snapshot_lineage_set_id": snapshot_lineage_set_id,
-                "search_ledger_id": alpha_status.get("search_ledger_id"),
+                "search_ledger_id": None if search_ledger_reasons else reconstructed_search_ledger_id,
                 "blocked_experiments": blocked,
                 "content_identity": content_id("qsuplegacydegraded", {"reason_codes": legacy_reasons, "watermarks": current_watermarks}),
+            }
+            _publish_status(payload)
+            return payload
+        if blocked and search_ledger_reasons:
+            payload = {
+                "service_version": SERVICE_VERSION,
+                "health": HEALTH_DEGRADED_LEGACY_STATE_INCONSISTENT,
+                "current_stage": HEALTH_DEGRADED_LEGACY_STATE_INCONSISTENT,
+                "last_cycle": {
+                    "decision": "fail_closed_legacy_state_not_migrated",
+                    "generated_at_utc": _utcnow(),
+                    "reason_codes": search_ledger_reasons,
+                },
+                "last_successful_cycle": prior_status.get("last_successful_cycle"),
+                "current_dataset_snapshot": alpha_status.get("current_dataset_snapshot"),
+                "current_source_tier": alpha_status.get("current_source_tier"),
+                "current_experiment": alpha_status.get("current_experiment"),
+                "current_campaign": alpha_status.get("current_campaign"),
+                "open_gaps": tuple(str(row.get("gap_id") or "") for row in open_gaps),
+                "active_ADE_requests": tuple(str(row.get("request_id") or "") for row in open_gaps if row.get("request_id")),
+                "operator_actions": ("repair_legacy_supervisor_state",),
+                "next_retry": prior_status.get("next_retry"),
+                "next_scheduled_cycle": (datetime.now(UTC) + timedelta(seconds=DEFAULT_INTERVAL_SECONDS)).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                "consecutive_failures": int(prior_status.get("consecutive_failures") or 0) + 1,
+                "watermarks": current_watermarks,
+                "leases": lease,
+                "runtime_epoch_id": str(persisted_runtime_epoch.get("runtime_epoch_id") or alpha_status.get("runtime_epoch_id") or prior_status.get("runtime_epoch_id") or ""),
+                "qualification_set_id": qualification_set_id,
+                "snapshot_lineage_set_id": snapshot_lineage_set_id,
+                "search_ledger_id": None,
+                "blocked_experiments": blocked,
+                "content_identity": content_id("qsuplegacydegraded", {"reason_codes": search_ledger_reasons, "watermarks": current_watermarks}),
             }
             _publish_status(payload)
             return payload
@@ -751,7 +856,7 @@ def run_cycle(
                 "runtime_epoch_id": str(persisted_runtime_epoch.get("runtime_epoch_id") or alpha_status.get("runtime_epoch_id") or ""),
                 "qualification_set_id": qualification_set_id,
                 "snapshot_lineage_set_id": snapshot_lineage_set_id,
-                "search_ledger_id": alpha_status.get("search_ledger_id"),
+                "search_ledger_id": reconstructed_search_ledger_id,
                 "semantic_input_identity": semantic_input_identity,
                 "blocked_experiments": blocked,
                 "content_identity": content_id("qsupnoop", {"semantic_input_identity": semantic_input_identity, "health": health}),

--- a/tests/unit/test_qre_research_supervisor.py
+++ b/tests/unit/test_qre_research_supervisor.py
@@ -25,6 +25,11 @@ def _file_digest(path: Path) -> str:
     return sha256(path.read_bytes()).hexdigest()
 
 
+def _generated_artifact_digests(repo_root: Path) -> dict[str, str]:
+    root = repo_root / "generated_research"
+    return {path.relative_to(root).as_posix(): _file_digest(path) for path in root.rglob("*.json")}
+
+
 def _write_minimal_legacy_blocked_fixture(
     repo_root: Path,
     *,
@@ -824,6 +829,157 @@ def test_supervisor_reconstructs_legacy_ledger_when_status_projection_lost_it(mo
     assert payload["current_stage"] == "LEGACY_SEMANTIC_IDENTITY_MIGRATED"
     assert payload["last_cycle"]["decision"] == "semantic_identity_backfilled_no_change"
     assert payload["search_ledger_id"] == ids["ledger_id"]
+
+
+def test_supervisor_legacy_ledger_runtime_and_run_consistency_projects_id(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+    ids = _write_minimal_legacy_blocked_fixture(repo_root)
+
+    status_path = repo_root / "generated_research/alpha_discovery/status/latest.json"
+    alpha_status = json.loads(status_path.read_text(encoding="utf-8"))
+    alpha_status["search_ledger_id"] = None
+    status_path.write_text(json.dumps(alpha_status), encoding="utf-8")
+    artifact_digests = _generated_artifact_digests(repo_root)
+    run_calls = 0
+
+    def _unexpected_run(*args, **kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        raise AssertionError("run_alpha_discovery_mvp should not be called for consistent legacy ledger reconstruction")
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _unexpected_run)
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": ids["snapshot_lineage_set_id"]}, "revisions": {"rows": []}})
+    monkeypatch.setattr(supervisor, "_utcnow", iter(["2026-07-04T12:04:00Z", "2026-07-04T12:04:01Z"]).__next__)
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert run_calls == 0
+    assert payload["current_stage"] == "LEGACY_SEMANTIC_IDENTITY_MIGRATED"
+    assert payload["search_ledger_id"] == ids["ledger_id"]
+    assert _generated_artifact_digests(repo_root) == artifact_digests
+
+
+def test_supervisor_legacy_ledger_runtime_run_conflict_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+    ids = _write_minimal_legacy_blocked_fixture(repo_root)
+    (repo_root / "generated_research/alpha_discovery/runs/latest.json").write_text(
+        json.dumps({"run_id": "qarr-legacy", "search_ledger_id": "qsl-conflicting-run"}),
+        encoding="utf-8",
+    )
+    artifact_digests = _generated_artifact_digests(repo_root)
+    run_calls = 0
+
+    def _unexpected_run(*args, **kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        raise AssertionError("run_alpha_discovery_mvp should not be called for conflicting legacy ledger identities")
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _unexpected_run)
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": ids["snapshot_lineage_set_id"]}, "revisions": {"rows": []}})
+    monkeypatch.setattr(supervisor, "_utcnow", iter(["2026-07-04T12:05:00Z", "2026-07-04T12:05:01Z"]).__next__)
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert run_calls == 0
+    assert payload["health"] == "DEGRADED_LEGACY_STATE_INCONSISTENT"
+    assert payload["last_cycle"]["reason_codes"] == ("legacy_search_ledger_identity_mismatch",)
+    assert payload["operator_actions"] == ("repair_legacy_supervisor_state",)
+    assert payload["search_ledger_id"] is None
+    assert _generated_artifact_digests(repo_root) == artifact_digests
+
+
+def test_supervisor_legacy_ledger_runtime_id_survives_missing_ledger_artifact(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+    ids = _write_minimal_legacy_blocked_fixture(repo_root)
+    (repo_root / "generated_research/alpha_discovery/search_ledger/latest.json").unlink()
+    artifact_digests = _generated_artifact_digests(repo_root)
+    run_calls = 0
+
+    def _unexpected_run(*args, **kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        raise AssertionError("run_alpha_discovery_mvp should not be called when optional ledger artifact is absent")
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _unexpected_run)
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": ids["snapshot_lineage_set_id"]}, "revisions": {"rows": []}})
+    monkeypatch.setattr(supervisor, "_utcnow", iter(["2026-07-04T12:06:00Z", "2026-07-04T12:06:01Z"]).__next__)
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert run_calls == 0
+    assert payload["current_stage"] == "LEGACY_SEMANTIC_IDENTITY_MIGRATED"
+    assert payload["search_ledger_id"] == ids["ledger_id"]
+    assert _generated_artifact_digests(repo_root) == artifact_digests
+
+
+def test_supervisor_legacy_ledger_artifact_mismatch_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+    ids = _write_minimal_legacy_blocked_fixture(repo_root)
+    (repo_root / "generated_research/alpha_discovery/search_ledger/latest.json").write_text(
+        json.dumps({"ledger": {"search_run_id": "qsl-conflicting-artifact"}, "content_identity": "qslc-conflicting"}),
+        encoding="utf-8",
+    )
+    artifact_digests = _generated_artifact_digests(repo_root)
+    run_calls = 0
+
+    def _unexpected_run(*args, **kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        raise AssertionError("run_alpha_discovery_mvp should not be called for conflicting ledger artifact")
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _unexpected_run)
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": ids["snapshot_lineage_set_id"]}, "revisions": {"rows": []}})
+    monkeypatch.setattr(supervisor, "_utcnow", iter(["2026-07-04T12:07:00Z", "2026-07-04T12:07:01Z"]).__next__)
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert run_calls == 0
+    assert payload["health"] == "DEGRADED_LEGACY_STATE_INCONSISTENT"
+    assert payload["last_cycle"]["reason_codes"] == ("legacy_search_ledger_identity_mismatch",)
+    assert payload["operator_actions"] == ("repair_legacy_supervisor_state",)
+    assert payload["search_ledger_id"] is None
+    assert _generated_artifact_digests(repo_root) == artifact_digests
+
+
+def test_supervisor_legacy_ledgerless_state_remains_ledgerless(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+    ids = _write_minimal_legacy_blocked_fixture(repo_root)
+    for relative in (
+        "generated_research/alpha_discovery/status/latest.json",
+        "generated_research/alpha_discovery/runtime_epoch/latest.json",
+        "generated_research/alpha_discovery/runs/latest.json",
+    ):
+        path = repo_root / relative
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["search_ledger_id"] = None
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    (repo_root / "generated_research/alpha_discovery/search_ledger/latest.json").write_text(
+        json.dumps({"ledger": None, "content_identity": "qslc-ledgerless"}),
+        encoding="utf-8",
+    )
+    artifact_digests = _generated_artifact_digests(repo_root)
+    run_calls = 0
+
+    def _unexpected_run(*args, **kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        raise AssertionError("run_alpha_discovery_mvp should not be called for legitimate ledgerless legacy state")
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _unexpected_run)
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": ids["snapshot_lineage_set_id"]}, "revisions": {"rows": []}})
+    monkeypatch.setattr(supervisor, "_utcnow", iter(["2026-07-04T12:08:00Z", "2026-07-04T12:08:01Z"]).__next__)
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert run_calls == 0
+    assert payload["current_stage"] == "LEGACY_SEMANTIC_IDENTITY_MIGRATED"
+    assert payload["search_ledger_id"] is None
+    assert _generated_artifact_digests(repo_root) == artifact_digests
 
 
 def test_supervisor_incomplete_legacy_state_fails_closed_without_discovery(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/test_qre_research_supervisor.py
+++ b/tests/unit/test_qre_research_supervisor.py
@@ -36,6 +36,7 @@ def _write_minimal_legacy_blocked_fixture(
         "source_qualifications",
         "status",
         "runtime_epoch",
+        "runs",
         "blocked_experiments",
         "capability_gaps",
         "search_ledger",
@@ -99,8 +100,13 @@ def _write_minimal_legacy_blocked_fixture(
                 "runtime_epoch_id": ids["runtime_epoch_id"],
                 "qualification_set_id": ids["qualification_set_id"],
                 "snapshot_lineage_set_id": ids["snapshot_lineage_set_id"],
+                "search_ledger_id": ids["ledger_id"],
             }
         ),
+        encoding="utf-8",
+    )
+    (artifact_root / "runs/latest.json").write_text(
+        json.dumps({"run_id": "qarr-legacy", "search_ledger_id": ids["ledger_id"]}),
         encoding="utf-8",
     )
     (artifact_root / "blocked_experiments/latest.json").write_text(
@@ -476,6 +482,7 @@ def test_supervisor_blocked_state_skips_repeated_discovery_cycles(monkeypatch, t
         "source_resolution",
         "status",
         "runtime_epoch",
+        "runs",
         "blocked_experiments",
         "capability_gaps",
         "search_ledger",
@@ -561,9 +568,14 @@ def test_supervisor_blocked_state_skips_repeated_discovery_cycles(monkeypatch, t
                 "runtime_epoch_id": runtime_epoch_id,
                 "qualification_set_id": qualification_set_id,
                 "snapshot_lineage_set_id": snapshot_lineage_set_id,
+                "search_ledger_id": search_ledger_id,
                 "content_identity": "qepochstate-legacy",
             }
         ),
+        encoding="utf-8",
+    )
+    (artifact_root / "runs/latest.json").write_text(
+        json.dumps({"run_id": "qarr-baseline", "search_ledger_id": search_ledger_id}),
         encoding="utf-8",
     )
     (artifact_root / "blocked_experiments/latest.json").write_text(
@@ -705,6 +717,7 @@ def test_supervisor_blocked_state_skips_repeated_discovery_cycles(monkeypatch, t
         "source_qualifications": artifact_root / "source_qualifications/latest.json",
         "source_resolution": artifact_root / "source_resolution/latest.json",
         "runtime_epoch": artifact_root / "runtime_epoch/latest.json",
+        "runs": artifact_root / "runs/latest.json",
         "status": artifact_root / "status/latest.json",
         "discovery_view": artifact_root / "views/discovery_latest.json",
         "validation_view": artifact_root / "views/validation_latest.json",
@@ -746,6 +759,7 @@ def test_supervisor_blocked_state_skips_repeated_discovery_cycles(monkeypatch, t
 
     assert baseline["current_stage"] == "LEGACY_SEMANTIC_IDENTITY_MIGRATED"
     assert baseline["last_cycle"]["decision"] == "semantic_identity_backfilled_no_change"
+    assert baseline["search_ledger_id"] == search_ledger_id
     assert cycle_2["current_stage"] == "NO_CHANGE_SKIP"
     assert restart_cycle["current_stage"] == "NO_CHANGE_SKIP"
     assert cycle_2["health"] == "BLOCKED_SOURCE_CERTIFICATION"
@@ -777,6 +791,39 @@ def test_supervisor_blocked_state_skips_repeated_discovery_cycles(monkeypatch, t
     for name, path in artifact_paths.items():
         assert _file_digest(path) == pre_baseline_digests[name], name
         assert os.stat(path).st_mtime_ns == pre_baseline_mtimes[name], name
+
+
+def test_supervisor_reconstructs_legacy_ledger_when_status_projection_lost_it(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+    ids = _write_minimal_legacy_blocked_fixture(repo_root)
+
+    status_path = repo_root / "generated_research/alpha_discovery/status/latest.json"
+    alpha_status = json.loads(status_path.read_text(encoding="utf-8"))
+    alpha_status["search_ledger_id"] = None
+    status_path.write_text(json.dumps(alpha_status), encoding="utf-8")
+
+    run_calls = 0
+
+    def _unexpected_run(*args, **kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        raise AssertionError("run_alpha_discovery_mvp should not be called for coherent legacy status repair")
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _unexpected_run)
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": ids["snapshot_lineage_set_id"]}, "revisions": {"rows": []}})
+    monkeypatch.setattr(
+        supervisor,
+        "_utcnow",
+        iter(["2026-07-04T12:03:00Z", "2026-07-04T12:03:01Z"]).__next__,
+    )
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert run_calls == 0
+    assert payload["current_stage"] == "LEGACY_SEMANTIC_IDENTITY_MIGRATED"
+    assert payload["last_cycle"]["decision"] == "semantic_identity_backfilled_no_change"
+    assert payload["search_ledger_id"] == ids["ledger_id"]
 
 
 def test_supervisor_incomplete_legacy_state_fails_closed_without_discovery(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reconstruct legacy search_ledger_id from persisted runtime epoch, current run, and search-ledger artifact
- fail closed on legacy ledger identity conflicts before publishing blocked-safe status
- add regression coverage for lost supervisor projection, conflict cases, missing optional artifact, and legitimate ledgerless state

## Local checks
- python -m ruff check .: passed
- python scripts/governance_lint.py: passed
- python -m pytest tests/unit/test_qre_research_supervisor.py -q: 17 passed
- python -m pytest tests/architecture -q: 164 passed
- git diff --check: passed
- python -m pytest tests/unit -q: timed out locally twice, after 604.1s and 1204.0s, without summary