### PR TITLE
feat: add qre source certification readiness

### DIFF
--- a/docs/governance/qre_source_certification_policy.md
+++ b/docs/governance/qre_source_certification_policy.md
@@ -1,0 +1,64 @@
+# QRE Source Certification Policy
+
+Policy version: `qre_alpha_source_qualification_pr4_v1`.
+
+QRE source certification is evidence-based. A snapshot can become
+`SOURCE_SCREENING_ELIGIBLE` only when its source manifest permits automated
+research screening and its measured snapshot metrics satisfy the screening
+policy. The policy does not grant trading, candidate, paper, shadow, live, or
+Step 5 authority.
+
+## Required Source Manifest
+
+Each snapshot must resolve to a source manifest by `source_id`, `provider_id`,
+or an approved alias. Missing manifests block qualification with
+`missing_source_manifest`.
+
+The manifest must show:
+
+- `license_policy_status=PASS` or equivalent screening-approved status;
+- `allowed_use` includes `research_screening` or `automated_research_screening`;
+- `source_status` is `quality_gated`, `screening_ready`, or `certified`.
+
+Otherwise the snapshot is blocked with
+`source_license_not_screening_eligible`.
+
+## Expected Bars And Calendars
+
+Expected bars must be measured from the data catalog integrity layer. Crypto
+24/7 hourly/daily data can use a deterministic continuous calendar. Daily
+weekday-only markets can use deterministic weekday counts. Intraday session
+markets require an explicit or reliable session calendar; otherwise
+`expected_bar_count` and `coverage_ratio` remain null and the snapshot is
+blocked with `missing_expected_bar_count` and `missing_calendar`.
+
+Coverage is never set to `1.0` when expected bars are unknown.
+
+## Screening Thresholds
+
+Screening eligibility requires:
+
+- `coverage_ratio >= 0.90`;
+- `unique_bar_count >= 48`;
+- duplicate bar ratio `<= 0.05`;
+- no conflicting duplicate bars;
+- no invalid OHLCV/timestamp rows;
+- stable fingerprint and immutable/reproducible snapshot identity;
+- required query, period, source, instrument, timeframe, and lineage fields.
+
+Validation eligibility remains separate and is not granted by this policy.
+
+## Operator Actions
+
+Common blocked reason codes are:
+
+- `missing_source_manifest`;
+- `source_license_not_screening_eligible`;
+- `missing_expected_bar_count`;
+- `missing_calendar`;
+- `insufficient_coverage`;
+- `duplicate_bar_ratio_too_high`;
+- `conflicting_rows_present`;
+- `insufficient_unique_history`;
+- `invalid_ohlcv_or_timestamp`;
+- `impossible_bar_density`.

--- a/packages/qre_research/alpha_discovery/snapshot_lineage.py
+++ b/packages/qre_research/alpha_discovery/snapshot_lineage.py
@@ -179,8 +179,80 @@ def _snapshot_status(*, quality_status: str, conflicting_row_count: int, raw_row
     return "COHERENT"
 
 
+def _dataset_snapshot_from_logical(row: dict[str, Any]) -> DatasetSnapshot:
+    integrity = dict(row.get("integrity_summary") or {})
+    quality = dict(row.get("quality_summary") or {})
+    instrument_ids = tuple(str(value) for value in row.get("instrument_ids") or () if str(value))
+    dataset_id = str(row.get("dataset_id") or "|".join((str(row.get("source_id") or ""), ",".join(instrument_ids), str(row.get("timeframe") or ""))))
+    unique_bar_count = int(integrity.get("unique_bar_count") or row.get("row_count") or 0)
+    raw_row_count = int(integrity.get("raw_row_count") or row.get("raw_row_count") or unique_bar_count)
+    expected_bar_count = integrity.get("expected_bar_count")
+    if expected_bar_count is not None:
+        expected_bar_count = int(expected_bar_count)
+    coverage_ratio = integrity.get("coverage_ratio")
+    if coverage_ratio is not None:
+        coverage_ratio = round(float(coverage_ratio), 6)
+    conflicting_row_count = int(integrity.get("conflicting_row_count") or 0)
+    invalid_row_count = int(integrity.get("invalid_row_count") or 0)
+    exact_duplicate_row_count = int(integrity.get("exact_duplicate_row_count") or 0)
+    overlapping_row_count = int(integrity.get("overlapping_row_count") or 0)
+    row_integrity_status = str(quality.get("row_integrity_status") or "blocked").lower()
+    qualification_status = _snapshot_status(
+        quality_status="ready" if row_integrity_status == "ready" else "blocked",
+        conflicting_row_count=conflicting_row_count,
+        raw_row_count=raw_row_count,
+        unique_bar_count=unique_bar_count,
+        expected_bar_count=expected_bar_count,
+    )
+    semantic = {
+        "dataset_id": dataset_id,
+        "fingerprint": row.get("dataset_fingerprint"),
+        "source_id": row.get("source_id"),
+        "instrument_ids": instrument_ids,
+        "timeframe": row.get("timeframe"),
+        "start": row.get("start"),
+        "end": row.get("end"),
+        "unique_bar_count": unique_bar_count,
+        "expected_bar_count": expected_bar_count,
+    }
+    snapshot = DatasetSnapshot(
+        dataset_snapshot_id=str(row.get("dataset_snapshot_id") or "") or content_id("qdsnap", semantic),
+        logical_dataset_family_id=dataset_id,
+        acquisition_batch_ids=tuple(sorted(str(value) for value in row.get("acquisition_batch_ids") or row.get("partition_refs") or () if str(value))),
+        parent_snapshot_id=None,
+        instrument_ids=instrument_ids,
+        timeframe=str(row.get("timeframe") or ""),
+        start=str(row.get("start") or ""),
+        end=str(row.get("end") or ""),
+        unique_bar_count=unique_bar_count,
+        raw_row_count=raw_row_count,
+        exact_duplicate_row_count=exact_duplicate_row_count,
+        overlapping_row_count=overlapping_row_count,
+        conflicting_row_count=conflicting_row_count,
+        invalid_row_count=invalid_row_count,
+        expected_bar_count=expected_bar_count,
+        coverage_ratio=coverage_ratio,
+        fingerprint=str(row.get("dataset_fingerprint") or stable_digest(semantic)),
+        source_id=str(row.get("source_id") or ""),
+        source_policy_version=str(row.get("source_policy_version") or row.get("source_manifest_id") or "data_catalog_logical_v1"),
+        qualification_status=qualification_status,
+        immutable=True,
+        created_at_utc=str((row.get("provenance") or {}).get("generated_at_utc") or row.get("complete_bar_end") or row.get("end") or ""),
+        partition_refs=tuple(sorted(str(value) for value in row.get("partition_refs") or () if str(value))),
+        compatibility_status="ROOT",
+        lineage_depth=0,
+        content_identity="pending",
+    )
+    return DatasetSnapshot(**_canonicalize_snapshot_row(snapshot))
+
+
 def _build_base_snapshots(census: dict[str, Any]) -> list[DatasetSnapshot]:
     snapshots: list[DatasetSnapshot] = []
+    logical_rows = [dict(row) for row in census.get("logical_datasets") or [] if isinstance(row, dict)]
+    if logical_rows:
+        snapshots = [_dataset_snapshot_from_logical(row) for row in logical_rows]
+        snapshots.sort(key=lambda item: (item.logical_dataset_family_id, item.start, item.end, item.dataset_snapshot_id))
+        return snapshots
     seen_paths: set[str] = set()
     for row in census.get("physical_files", []):
         path_text = str(row.get("portable_relative_path") or row.get("physical_path") or "")

--- a/packages/qre_research/alpha_discovery/source_qualification.py
+++ b/packages/qre_research/alpha_discovery/source_qualification.py
@@ -19,6 +19,9 @@ SOURCE_SMOKE_ONLY = SOURCE_TIER_SMOKE_ONLY
 SOURCE_SCREENING_ELIGIBLE = SOURCE_TIER_SCREENING_ELIGIBLE
 SOURCE_VALIDATION_ELIGIBLE = SOURCE_TIER_VALIDATION_ELIGIBLE
 SOURCE_BLOCKED = SOURCE_TIER_BLOCKED
+MIN_SCREENING_COVERAGE_RATIO = 0.90
+MIN_SCREENING_UNIQUE_BARS = 48
+MAX_DUPLICATE_BAR_RATIO = 0.05
 
 SCREENING_REQUIRED_FIELDS = (
     "dataset_snapshot_id",
@@ -60,6 +63,23 @@ def _registry_rows() -> dict[str, dict[str, Any]]:
             if key:
                 resolved[str(key).lower()] = dict(row)
     return resolved
+
+
+def _source_manifest_for(source_id: str) -> dict[str, Any] | None:
+    return _registry_rows().get(str(source_id or "").lower())
+
+
+def _manifest_allows_screening(manifest: dict[str, Any] | None) -> bool:
+    if manifest is None:
+        return False
+    allowed_use = {str(value).lower() for value in manifest.get("allowed_use") or ()}
+    license_status = str(manifest.get("license_policy_status") or manifest.get("license_terms_status") or "").upper()
+    source_status = str(manifest.get("source_status") or "").lower()
+    if license_status not in {"PASS", "REVIEWED_SCREENING_OK"}:
+        return False
+    if "research_screening" not in allowed_use and "automated_research_screening" not in allowed_use:
+        return False
+    return source_status in {"quality_gated", "screening_ready", "certified"}
 
 
 def reconcile_source_policy(*, repo_root: Path, dataset_catalog: dict[str, Any]) -> dict[str, Any]:
@@ -115,25 +135,30 @@ def _screening_reasons(snapshot: dict[str, Any]) -> list[str]:
     reasons: list[str] = []
     if str(snapshot.get("qualification_status") or "") != "COHERENT":
         reasons.append("snapshot_not_coherent")
-    if int(snapshot.get("conflicting_row_count") or 0) > 0:
-        reasons.append("within_snapshot_conflict")
+    raw_row_count = int(snapshot.get("raw_row_count") or 0)
+    exact_duplicate_count = int(snapshot.get("exact_duplicate_row_count") or 0)
+    conflicting_count = int(snapshot.get("conflicting_row_count") or 0)
+    if conflicting_count > 0:
+        reasons.append("conflicting_rows_present")
     if int(snapshot.get("invalid_row_count") or 0) > 0:
-        reasons.append("invalid_rows")
+        reasons.append("invalid_ohlcv_or_timestamp")
     for field in SCREENING_REQUIRED_FIELDS:
         value = snapshot.get(field)
         if value is None or value == "" or value == () or value == []:
             reasons.append(f"qualification_metric_missing:{field}")
     if snapshot.get("expected_bar_count") is None:
-        reasons.append("qualification_metric_missing:expected_bar_count")
+        reasons.append("missing_expected_bar_count")
     if snapshot.get("coverage_ratio") is None:
-        reasons.append("qualification_metric_missing:coverage_ratio")
-    if int(snapshot.get("unique_bar_count") or 0) < 90:
+        reasons.append("missing_calendar")
+    if int(snapshot.get("unique_bar_count") or 0) < MIN_SCREENING_UNIQUE_BARS:
         reasons.append("insufficient_unique_history")
+    if raw_row_count and exact_duplicate_count / raw_row_count > MAX_DUPLICATE_BAR_RATIO:
+        reasons.append("duplicate_bar_ratio_too_high")
     coverage_ratio = snapshot.get("coverage_ratio")
     if coverage_ratio is not None and not (0.0 <= float(coverage_ratio) <= 1.0):
         reasons.append("invalid_coverage_ratio")
-    elif coverage_ratio is not None and float(coverage_ratio) < 0.9:
-        reasons.append("excess_missing_bars")
+    elif coverage_ratio is not None and float(coverage_ratio) < MIN_SCREENING_COVERAGE_RATIO:
+        reasons.append("insufficient_coverage")
     if int(snapshot.get("expected_bar_count") or 0) and int(snapshot.get("unique_bar_count") or 0) > int(snapshot.get("expected_bar_count") or 0):
         reasons.append("impossible_bar_density")
     if not snapshot.get("fingerprint"):
@@ -183,53 +208,64 @@ def qualify_datasets(*, repo_root: Path | None = None, dataset_catalog: dict[str
                     "qualification_status": "COHERENT" if str((dataset.get("quality_summary") or {}).get("effective_research_quality_status") or "").lower() == "ready" else "BLOCKED",
                 }
             )
+    def _set_if_missing(row: dict[str, Any], key: str, value: Any) -> None:
+        if row.get(key) is None or row.get(key) == "" or row.get(key) == () or row.get(key) == []:
+            row[key] = value
+
     for snapshot in snapshots:
         dataset_key = str(snapshot.get("dataset_snapshot_id") or snapshot.get("dataset_id") or "")
         dataset = catalog_rows.get(dataset_key) or {}
         integrity = dict(dataset.get("integrity_summary") or {})
         quality = dict(dataset.get("quality_summary") or {})
         identity = dict(dataset.get("identity_summary") or {})
-        snapshot.setdefault("logical_dataset_family_id", dataset.get("dataset_id"))
-        snapshot.setdefault("acquisition_batch_ids", tuple(dataset.get("acquisition_batch_ids") or ()))
-        snapshot.setdefault("expected_bar_count", integrity.get("expected_bar_count"))
-        snapshot.setdefault("coverage_ratio", integrity.get("coverage_ratio"))
-        snapshot.setdefault("missing_bar_count", max(int(snapshot.get("expected_bar_count") or 0) - int(snapshot.get("unique_bar_count") or 0), 0) if snapshot.get("expected_bar_count") is not None else None)
-        snapshot.setdefault("conflicting_row_count", integrity.get("conflicting_row_count", snapshot.get("conflicting_row_count", 0)))
-        snapshot.setdefault("invalid_row_count", integrity.get("invalid_row_count", snapshot.get("invalid_row_count", 0)))
-        snapshot.setdefault("invalid_bar_count", snapshot.get("invalid_row_count"))
-        snapshot.setdefault("adjustment_policy", dataset.get("adjustment_policy") or quality.get("adjustment_policy") or "explicit")
-        snapshot.setdefault("timezone_policy", dataset.get("timezone_policy") or "UTC_NORMALIZED")
-        snapshot.setdefault("session_policy", dataset.get("session_policy") or "canonical_session_calendar")
-        snapshot.setdefault("history_start", snapshot.get("start") or dataset.get("start"))
-        snapshot.setdefault("history_end", snapshot.get("end") or dataset.get("end"))
-        snapshot.setdefault("history_span", dataset.get("history_span") or quality.get("history_span") or "derived")
-        snapshot.setdefault("minimum_required_history", dataset.get("minimum_required_history") or quality.get("minimum_required_history") or "derived")
-        snapshot.setdefault("minimum_required_rows", dataset.get("minimum_required_rows") or quality.get("minimum_required_rows") or 90)
-        snapshot.setdefault("activity_estimate", dataset.get("activity_estimate") or integrity.get("activity_estimate") or int(snapshot.get("unique_bar_count") or 0) // 40)
-        snapshot.setdefault("validation_capacity", dataset.get("validation_capacity") or integrity.get("validation_capacity") or 0)
-        snapshot.setdefault("source_policy_version", dataset.get("source_policy_version") or policy_reconciliation.get("policy_version") or SOURCE_POLICY_VERSION)
-        snapshot.setdefault("qualification_policy_version", dataset.get("qualification_policy_version") or SOURCE_POLICY_VERSION)
-        snapshot.setdefault("instrument_identity", tuple(snapshot.get("instrument_ids") or identity.get("instrument_ids") or ()))
-        snapshot.setdefault("required_expected_bar_count", snapshot.get("expected_bar_count"))
+        _set_if_missing(snapshot, "logical_dataset_family_id", dataset.get("dataset_id"))
+        _set_if_missing(snapshot, "acquisition_batch_ids", tuple(dataset.get("acquisition_batch_ids") or (dataset.get("partition_refs") or (dataset_key,))))
+        _set_if_missing(snapshot, "expected_bar_count", integrity.get("expected_bar_count"))
+        _set_if_missing(snapshot, "coverage_ratio", integrity.get("coverage_ratio"))
+        _set_if_missing(snapshot, "missing_bar_count", max(int(snapshot.get("expected_bar_count") or 0) - int(snapshot.get("unique_bar_count") or 0), 0) if snapshot.get("expected_bar_count") is not None else None)
+        _set_if_missing(snapshot, "conflicting_row_count", integrity.get("conflicting_row_count", snapshot.get("conflicting_row_count", 0)))
+        _set_if_missing(snapshot, "invalid_row_count", integrity.get("invalid_row_count", snapshot.get("invalid_row_count", 0)))
+        _set_if_missing(snapshot, "exact_duplicate_row_count", integrity.get("exact_duplicate_row_count", snapshot.get("exact_duplicate_row_count", 0)))
+        _set_if_missing(snapshot, "invalid_bar_count", snapshot.get("invalid_row_count"))
+        _set_if_missing(snapshot, "adjustment_policy", dataset.get("adjustment_policy") or quality.get("adjustment_policy") or "explicit")
+        _set_if_missing(snapshot, "timezone_policy", dataset.get("timezone_policy") or "UTC_NORMALIZED")
+        _set_if_missing(snapshot, "session_policy", dataset.get("session_policy") or "canonical_session_calendar")
+        _set_if_missing(snapshot, "history_start", snapshot.get("start") or dataset.get("start"))
+        _set_if_missing(snapshot, "history_end", snapshot.get("end") or dataset.get("end"))
+        _set_if_missing(snapshot, "history_span", dataset.get("history_span") or quality.get("history_span") or "derived")
+        _set_if_missing(snapshot, "minimum_required_history", dataset.get("minimum_required_history") or quality.get("minimum_required_history") or "derived")
+        _set_if_missing(snapshot, "minimum_required_rows", dataset.get("minimum_required_rows") or quality.get("minimum_required_rows") or MIN_SCREENING_UNIQUE_BARS)
+        _set_if_missing(snapshot, "activity_estimate", dataset.get("activity_estimate") or integrity.get("activity_estimate") or int(snapshot.get("unique_bar_count") or 0))
+        _set_if_missing(snapshot, "validation_capacity", dataset.get("validation_capacity") or integrity.get("validation_capacity") or 0)
+        _set_if_missing(snapshot, "source_policy_version", dataset.get("source_policy_version") or policy_reconciliation.get("policy_version") or SOURCE_POLICY_VERSION)
+        _set_if_missing(snapshot, "qualification_policy_version", dataset.get("qualification_policy_version") or SOURCE_POLICY_VERSION)
+        _set_if_missing(snapshot, "instrument_identity", tuple(snapshot.get("instrument_ids") or identity.get("instrument_ids") or ()))
+        _set_if_missing(snapshot, "required_expected_bar_count", snapshot.get("expected_bar_count"))
+    snapshots = sorted(
+        snapshots,
+        key=lambda row: (
+            str(row.get("source_id") or ""),
+            str(row.get("dataset_snapshot_id") or row.get("dataset_id") or ""),
+            str(row.get("timeframe") or ""),
+        ),
+    )
     for snapshot in snapshots:
         source_id = str(snapshot.get("source_id") or "")
+        manifest = _source_manifest_for(source_id)
         allowed_tier = SOURCE_TIER_BLOCKED
         reason_codes = list(dict.fromkeys(_screening_reasons(snapshot)))
-        adjustment_policy = "AUTO_ADJUST_TRUE" if "yfinance" in source_id else "UNKNOWN"
+        if manifest is None:
+            reason_codes.insert(0, "missing_source_manifest")
+        elif not _manifest_allows_screening(manifest):
+            reason_codes.insert(0, "source_license_not_screening_eligible")
+        adjustment_policy = "AUTO_ADJUST_TRUE" if "yfinance" in source_id else "EXPLICIT_SOURCE_POLICY"
         cross_source_status = "NOT_AVAILABLE"
-        if "yfinance" in source_id:
-            if current_status == "manual_research_only":
-                if snapshot_scoped_authority and not reason_codes:
-                    allowed_tier = SOURCE_TIER_SCREENING_ELIGIBLE
-                else:
-                    allowed_tier = SOURCE_TIER_BLOCKED
-                    reason_codes.insert(0, "global_policy_ceiling_manual_research_only")
-                    if snapshot_scoped_authority:
-                        reason_codes.append("snapshot_scoped_screening_not_met")
-            else:
-                allowed_tier = SOURCE_TIER_SCREENING_ELIGIBLE if not reason_codes else SOURCE_TIER_BLOCKED
-        elif not reason_codes:
-            allowed_tier = SOURCE_TIER_VALIDATION_ELIGIBLE
+        if not reason_codes:
+            allowed_tier = SOURCE_TIER_SCREENING_ELIGIBLE
+        elif "yfinance" in source_id and current_status == "manual_research_only":
+            reason_codes.insert(0, "global_policy_ceiling_manual_research_only")
+            if snapshot_scoped_authority:
+                reason_codes.append("snapshot_scoped_screening_not_met")
         rows.append(
             {
                 "qualification_id": content_id("qdsq", {"snapshot_id": snapshot.get("dataset_snapshot_id"), "tier": allowed_tier}),
@@ -257,9 +293,9 @@ def qualify_datasets(*, repo_root: Path | None = None, dataset_catalog: dict[str
                 "missing_bar_count": max(int(snapshot.get("expected_bar_count") or 0) - int(snapshot.get("unique_bar_count") or 0), 0) if snapshot.get("expected_bar_count") is not None else None,
                 "duplicate_bar_count": snapshot.get("exact_duplicate_row_count", 0),
                 "conflicting_bar_count": snapshot.get("conflicting_row_count", 0),
-                "OHLC_validity": "VALID" if "within_snapshot_conflict" not in reason_codes and "invalid_rows" not in reason_codes else "BLOCKED",
+                "OHLC_validity": "VALID" if "conflicting_rows_present" not in reason_codes and "invalid_ohlcv_or_timestamp" not in reason_codes else "BLOCKED",
                 "volume_validity": "VALID",
-                "timestamp_validity": "VALID" if "invalid_rows" not in reason_codes else "BLOCKED",
+                "timestamp_validity": "VALID" if "invalid_ohlcv_or_timestamp" not in reason_codes else "BLOCKED",
                 "session_validity": "VALID" if str(snapshot.get("timeframe") or "").endswith(("d", "h")) else "UNKNOWN",
                 "identity_validity": "ready" if tuple(snapshot.get("instrument_ids") or ()) else "ambiguous",
                 "corporate_action_validity": "UNKNOWN",

--- a/packages/qre_research/alpha_discovery/source_qualification.py
+++ b/packages/qre_research/alpha_discovery/source_qualification.py
@@ -66,7 +66,18 @@ def _registry_rows() -> dict[str, dict[str, Any]]:
 
 
 def _source_manifest_for(source_id: str) -> dict[str, Any] | None:
-    return _registry_rows().get(str(source_id or "").lower())
+    key = str(source_id or "").lower()
+    aliases = (
+        key,
+        "yahoo_finance_yfinance_manifest" if key == "yfinance" else key,
+        "yahoo_finance_yfinance" if key == "yfinance" else key,
+    )
+    rows = _registry_rows()
+    for alias in aliases:
+        manifest = rows.get(alias)
+        if manifest is not None:
+            return manifest
+    return None
 
 
 def _manifest_allows_screening(manifest: dict[str, Any] | None) -> bool:
@@ -143,6 +154,8 @@ def _screening_reasons(snapshot: dict[str, Any]) -> list[str]:
     if int(snapshot.get("invalid_row_count") or 0) > 0:
         reasons.append("invalid_ohlcv_or_timestamp")
     for field in SCREENING_REQUIRED_FIELDS:
+        if field in {"expected_bar_count", "coverage_ratio", "missing_bar_count"}:
+            continue
         value = snapshot.get(field)
         if value is None or value == "" or value == () or value == []:
             reasons.append(f"qualification_metric_missing:{field}")

--- a/packages/qre_research/alpha_discovery/source_resolution.py
+++ b/packages/qre_research/alpha_discovery/source_resolution.py
@@ -114,14 +114,8 @@ def resolve_source(
                 blockers.append("screening_authority_missing")
         else:
             current_tier = str(selected_snapshot.get("allowed_source_tier") or SOURCE_TIER_SMOKE_ONLY)
-            if (
-                current_tier == SOURCE_TIER_SMOKE_ONLY
-                and str(selected_snapshot.get("source_id") or "").startswith("yfinance")
-                and str(selected_snapshot.get("qualification_status") or "") == "COHERENT"
-                and int(selected_snapshot.get("conflicting_row_count") or 0) == 0
-                and int(selected_snapshot.get("unique_bar_count") or 0) >= 25
-            ):
-                current_tier = SOURCE_TIER_SCREENING_ELIGIBLE
+            if target_source_tier == SOURCE_TIER_SCREENING_ELIGIBLE:
+                blockers.append("source_qualification_missing")
         qualification_actions.append("use_existing_coherent_snapshot")
     elif candidates and not qualification_rows:
         qualification_actions.append("attempt_clean_snapshot_acquisition")

--- a/reporting/qre_research_supervisor.py
+++ b/reporting/qre_research_supervisor.py
@@ -623,6 +623,14 @@ def run_cycle(
             epoch_mismatch_reasons.append("current_snapshot_mismatch")
         if str(prior_status.get("current_source_tier") or "") and str(alpha_status.get("current_source_tier") or "") and prior_status.get("current_source_tier") != alpha_status.get("current_source_tier"):
             epoch_mismatch_reasons.append("current_source_tier_mismatch")
+        source_improvement_trigger = bool(
+            prior_semantic_input_identity
+            and str(prior_watermarks.get("source_qualifications") or "")
+            and str(prior_watermarks.get("source_qualifications") or "") != qualification_set_id
+            and any(str(row.get("allowed_evidence_tier") or "") in {"SOURCE_SCREENING_ELIGIBLE", "SOURCE_VALIDATION_ELIGIBLE"} for row in qualification_rows)
+        )
+        if source_improvement_trigger:
+            epoch_mismatch_reasons = [reason for reason in epoch_mismatch_reasons if reason != "qualification_set_mismatch"]
         epoch_mismatch = bool(epoch_mismatch_reasons)
         if prior_status and not prior_semantic_input_identity and blocked:
             legacy_valid, legacy_health, legacy_reasons = _legacy_blocked_state_validation(

--- a/tests/unit/test_qre_alpha_snapshot_resolution.py
+++ b/tests/unit/test_qre_alpha_snapshot_resolution.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from packages.qre_research.alpha_discovery import source_qualification
 from packages.qre_research.alpha_discovery.contracts import (
     SOURCE_TIER_SCREENING_ELIGIBLE,
     DataRequirement,
     DatasetSnapshot,
 )
 from packages.qre_research.alpha_discovery.snapshot_lineage import append_snapshot_row
-from packages.qre_research.alpha_discovery.source_qualification import (
-    qualify_datasets,
-    reconcile_source_policy,
-)
+from packages.qre_research.alpha_discovery.source_qualification import qualify_datasets
 from packages.qre_research.alpha_discovery.source_resolution import resolve_source
 
 
@@ -65,11 +63,41 @@ def _requirement() -> DataRequirement:
     )
 
 
-def test_snapshot_append_enables_screening_resolution(tmp_path: Path) -> None:
+def _certified_registry(monkeypatch) -> None:
+    monkeypatch.setattr(
+        source_qualification,
+        "build_source_manifest_registry",
+        lambda: {
+            "rows": [
+                {
+                    "source_id": "certified_crypto_vendor",
+                    "provider_id": "certified_crypto_vendor",
+                    "source_status": "quality_gated",
+                    "license_policy_status": "PASS",
+                    "allowed_use": ["research_screening"],
+                    "calendar_model": "CRYPTO_24_7",
+                }
+            ]
+        },
+    )
+
+
+def _write_qualifications(repo_root: Path, catalog: dict) -> None:
+    policy = {"content_identity": "policy-fixture", "policy_version": "policy-fixture"}
+    qualification_payload = qualify_datasets(repo_root=repo_root, dataset_catalog=catalog, policy_reconciliation=policy)
+    (repo_root / "generated_research/alpha_discovery/source_qualifications").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json").write_text(
+        json.dumps(qualification_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_snapshot_append_enables_screening_resolution(monkeypatch, tmp_path: Path) -> None:
+    _certified_registry(monkeypatch)
     repo_root = tmp_path
     snapshot = DatasetSnapshot(
         dataset_snapshot_id="snap-1",
-        logical_dataset_family_id="yfinance|ETH-EUR|1d",
+        logical_dataset_family_id="certified_crypto_vendor|ETH-EUR|1d",
         acquisition_batch_ids=("batch-1",),
         parent_snapshot_id=None,
         instrument_ids=("ETH-EUR",),
@@ -85,17 +113,38 @@ def test_snapshot_append_enables_screening_resolution(tmp_path: Path) -> None:
         expected_bar_count=None,
         coverage_ratio=1.0,
         fingerprint="fp-1",
-        source_id="yfinance",
+        source_id="certified_crypto_vendor",
         source_policy_version="policy-v1",
         qualification_status="COHERENT",
         immutable=True,
         created_at_utc="2026-07-03T00:00:00Z",
-        partition_refs=("data/cache/market/yfinance__ETH-EUR__1d__20260101__20260701__abcd.parquet",),
+        partition_refs=("data/cache/market/certified_crypto_vendor__ETH-EUR__1d__20260101__20260701__abcd.parquet",),
         compatibility_status="ROOT",
         lineage_depth=0,
         content_identity="content-1",
     )
     append_snapshot_row(repo_root, snapshot)
+    _write_qualifications(
+        repo_root,
+        {
+            "datasets": [
+                {
+                    "dataset_id": "certified_crypto_vendor|ETH-EUR|1d",
+                    "dataset_snapshot_id": "snap-1",
+                    "dataset_fingerprint": "fp-1",
+                    "source_id": "certified_crypto_vendor",
+                    "instrument_ids": ["ETH-EUR"],
+                    "timeframe": "1d",
+                    "start": "2026-01-01T00:00:00Z",
+                    "end": "2026-07-01T00:00:00Z",
+                    "quality_summary": {"effective_research_quality_status": "ready"},
+                    "identity_summary": {"instrument_identity_status": "ready"},
+                    "integrity_summary": {"raw_row_count": 180, "unique_bar_count": 180, "expected_bar_count": 180, "coverage_ratio": 1.0, "exact_duplicate_row_count": 0, "conflicting_row_count": 0, "invalid_row_count": 0},
+                    "history_span": "180d",
+                }
+            ]
+        },
+    )
     resolution = resolve_source(repo_root=repo_root, requirement=_requirement(), target_source_tier=SOURCE_TIER_SCREENING_ELIGIBLE)
     assert resolution.selected_snapshot == "snap-1"
     assert resolution.current_source_tier == SOURCE_TIER_SCREENING_ELIGIBLE
@@ -137,11 +186,12 @@ def test_append_snapshot_persists_latest_artifact(tmp_path: Path) -> None:
     assert payload["rows"][0]["dataset_snapshot_id"] == "snap-2"
 
 
-def test_source_resolution_ignores_stale_unqualified_lineage_updates(tmp_path: Path) -> None:
+def test_source_resolution_ignores_stale_unqualified_lineage_updates(monkeypatch, tmp_path: Path) -> None:
+    _certified_registry(monkeypatch)
     repo_root = tmp_path
     snapshot_v1 = DatasetSnapshot(
         dataset_snapshot_id="snap-v1",
-        logical_dataset_family_id="yfinance|ETH-EUR|1d",
+        logical_dataset_family_id="certified_crypto_vendor|ETH-EUR|1d",
         acquisition_batch_ids=("batch-1",),
         parent_snapshot_id=None,
         instrument_ids=("ETH-EUR",),
@@ -157,12 +207,12 @@ def test_source_resolution_ignores_stale_unqualified_lineage_updates(tmp_path: P
         expected_bar_count=120,
         coverage_ratio=1.0,
         fingerprint="fp-v1",
-        source_id="yfinance",
+        source_id="certified_crypto_vendor",
         source_policy_version="policy-v1",
         qualification_status="COHERENT",
         immutable=True,
         created_at_utc="2026-07-03T00:00:00Z",
-        partition_refs=("data/cache/market/yfinance__ETH-EUR__1d__20260101__20260401__v1.parquet",),
+        partition_refs=("data/cache/market/certified_crypto_vendor__ETH-EUR__1d__20260101__20260401__v1.parquet",),
         compatibility_status="ROOT",
         lineage_depth=0,
         content_identity="content-v1",
@@ -171,10 +221,10 @@ def test_source_resolution_ignores_stale_unqualified_lineage_updates(tmp_path: P
     catalog = {
         "datasets": [
             {
-                "dataset_id": "yfinance|ETH-EUR|1d",
+                "dataset_id": "certified_crypto_vendor|ETH-EUR|1d",
                 "dataset_snapshot_id": "snap-v1",
                 "dataset_fingerprint": "fp-v1",
-                "source_id": "yfinance",
+                "source_id": "certified_crypto_vendor",
                 "instrument_ids": ["ETH-EUR"],
                 "timeframe": "1d",
                 "start": "2026-01-01T00:00:00Z",
@@ -201,19 +251,13 @@ def test_source_resolution_ignores_stale_unqualified_lineage_updates(tmp_path: P
             }
         ]
     }
-    policy = reconcile_source_policy(repo_root=repo_root, dataset_catalog=catalog)
-    qualification_payload = qualify_datasets(repo_root=repo_root, dataset_catalog=catalog, policy_reconciliation=policy)
-    (repo_root / "generated_research/alpha_discovery/source_qualifications").mkdir(parents=True, exist_ok=True)
-    (repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json").write_text(
-        json.dumps(qualification_payload, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    _write_qualifications(repo_root, catalog)
     resolution_v1 = resolve_source(repo_root=repo_root, requirement=_requirement(), target_source_tier=SOURCE_TIER_SCREENING_ELIGIBLE)
     assert resolution_v1.selected_snapshot == "snap-v1"
 
     snapshot_v2 = DatasetSnapshot(
         dataset_snapshot_id="snap-v2",
-        logical_dataset_family_id="yfinance|ETH-EUR|1d",
+        logical_dataset_family_id="certified_crypto_vendor|ETH-EUR|1d",
         acquisition_batch_ids=("batch-2",),
         parent_snapshot_id="snap-v1",
         instrument_ids=("ETH-EUR",),
@@ -229,12 +273,12 @@ def test_source_resolution_ignores_stale_unqualified_lineage_updates(tmp_path: P
         expected_bar_count=120,
         coverage_ratio=1.0,
         fingerprint="fp-v2",
-        source_id="yfinance",
+        source_id="certified_crypto_vendor",
         source_policy_version="policy-v1",
         qualification_status="COHERENT",
         immutable=True,
         created_at_utc="2026-07-03T00:00:00Z",
-        partition_refs=("data/cache/market/yfinance__ETH-EUR__1d__20260402__20260701__v2.parquet",),
+        partition_refs=("data/cache/market/certified_crypto_vendor__ETH-EUR__1d__20260402__20260701__v2.parquet",),
         compatibility_status="COMPATIBLE_APPEND",
         lineage_depth=1,
         content_identity="content-v2",

--- a/tests/unit/test_qre_alpha_source_qualification.py
+++ b/tests/unit/test_qre_alpha_source_qualification.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from packages.qre_research.alpha_discovery.contracts import DatasetSnapshot
+from packages.qre_research.alpha_discovery import source_qualification
 from packages.qre_research.alpha_discovery.snapshot_lineage import append_snapshot_row
 from packages.qre_research.alpha_discovery.source_qualification import (
     SOURCE_BLOCKED,
@@ -80,37 +84,54 @@ def test_missing_screening_metrics_fail_closed(tmp_path) -> None:
     assert row["allowed_evidence_tier"] == SOURCE_BLOCKED
     assert row["qualification_status"] == "BLOCKED"
     assert row["coverage_ratio"] is None
-    assert "qualification_metric_missing:expected_bar_count" in row["reason_codes"]
-    assert "qualification_metric_missing:coverage_ratio" in row["reason_codes"]
+    assert "missing_expected_bar_count" in row["reason_codes"]
+    assert "missing_calendar" in row["reason_codes"]
     assert "insufficient_unique_history" in row["reason_codes"]
 
 
-def test_complete_snapshot_can_be_screening_eligible(tmp_path) -> None:
+def test_crypto_24_7_complete_snapshot_can_be_screening_eligible(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        source_qualification,
+        "build_source_manifest_registry",
+        lambda: {
+            "rows": [
+                {
+                    "source_id": "certified_crypto_vendor",
+                    "provider_id": "certified_crypto_vendor",
+                    "source_name": "Certified Crypto Vendor",
+                    "source_status": "quality_gated",
+                    "license_policy_status": "PASS",
+                    "allowed_use": ["research_screening"],
+                    "calendar_model": "CRYPTO_24_7",
+                }
+            ]
+        },
+    )
     repo_root = tmp_path
     snapshot = DatasetSnapshot(
         dataset_snapshot_id="snap-screening",
-        logical_dataset_family_id="yfinance|AAPL|1d",
+        logical_dataset_family_id="certified_crypto_vendor|BTC-USD|1h",
         acquisition_batch_ids=("batch-1",),
         parent_snapshot_id=None,
-        instrument_ids=("AAPL",),
-        timeframe="1d",
+        instrument_ids=("BTC-USD",),
+        timeframe="1h",
         start="2026-01-01T00:00:00Z",
-        end="2026-04-01T00:00:00Z",
-        unique_bar_count=120,
-        raw_row_count=120,
+        end="2026-01-02T23:00:00Z",
+        unique_bar_count=48,
+        raw_row_count=48,
         exact_duplicate_row_count=0,
         overlapping_row_count=0,
         conflicting_row_count=0,
         invalid_row_count=0,
-        expected_bar_count=120,
+        expected_bar_count=48,
         coverage_ratio=1.0,
         fingerprint="sha256:screening",
-        source_id="yfinance",
+        source_id="certified_crypto_vendor",
         source_policy_version="policy-v1",
         qualification_status="COHERENT",
         immutable=True,
         created_at_utc="2026-07-03T00:00:00Z",
-        partition_refs=("data/cache/market/yfinance__AAPL__1d__20260101__20260401__abcd.parquet",),
+        partition_refs=("data/cache/market/certified_crypto_vendor__BTC-USD__1h__20260101__20260102__abcd.parquet",),
         compatibility_status="ROOT",
         lineage_depth=0,
         content_identity="content-screening",
@@ -119,14 +140,14 @@ def test_complete_snapshot_can_be_screening_eligible(tmp_path) -> None:
     catalog = {
         "datasets": [
             {
-                "dataset_id": "yfinance|AAPL|1d",
+                "dataset_id": "certified_crypto_vendor|BTC-USD|1h",
                 "dataset_snapshot_id": "snap-screening",
                 "dataset_fingerprint": "sha256:screening",
-                "source_id": "yfinance",
-                "instrument_ids": ["AAPL"],
-                "timeframe": "1d",
+                "source_id": "certified_crypto_vendor",
+                "instrument_ids": ["BTC-USD"],
+                "timeframe": "1h",
                 "start": "2026-01-01T00:00:00Z",
-                "end": "2026-04-01T00:00:00Z",
+                "end": "2026-01-02T23:00:00Z",
                 "quality_summary": {
                     "effective_research_quality_status": "ready",
                     "minimum_required_history": "90d",
@@ -134,21 +155,21 @@ def test_complete_snapshot_can_be_screening_eligible(tmp_path) -> None:
                 },
                 "identity_summary": {"instrument_identity_status": "ready"},
                 "integrity_summary": {
-                    "raw_row_count": 120,
-                    "unique_bar_count": 120,
-                    "expected_bar_count": 120,
+                    "raw_row_count": 48,
+                    "unique_bar_count": 48,
+                    "expected_bar_count": 48,
                     "coverage_ratio": 1.0,
                     "exact_duplicate_row_count": 0,
                     "conflicting_row_count": 0,
                     "invalid_row_count": 0,
-                    "activity_estimate": 4,
+                    "activity_estimate": 48,
                 },
                 "adjustment_policy": "explicit",
                 "timezone_policy": "UTC_NORMALIZED",
                 "session_policy": "canonical_session_calendar",
-                "history_span": "90d",
+                "history_span": "48h",
                 "validation_capacity": 1,
-                "activity_estimate": 4,
+                "activity_estimate": 48,
                 "source_policy_version": "policy-v1",
                 "qualification_policy_version": "policy-v1",
             }
@@ -162,6 +183,157 @@ def test_complete_snapshot_can_be_screening_eligible(tmp_path) -> None:
     assert row["qualification_status"] == "COHERENT"
     assert row["coverage_ratio"] == 1.0
     assert not row["reason_codes"]
+
+
+def test_license_policy_failure_blocks_screening(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        source_qualification,
+        "build_source_manifest_registry",
+        lambda: {
+            "rows": [
+                {
+                    "source_id": "restricted_vendor",
+                    "provider_id": "restricted_vendor",
+                    "source_name": "Restricted Vendor",
+                    "source_status": "quality_gated",
+                    "license_policy_status": "FAIL",
+                    "allowed_use": ["metadata_context"],
+                    "calendar_model": "CRYPTO_24_7",
+                }
+            ]
+        },
+    )
+    catalog = {
+        "datasets": [
+            {
+                "dataset_id": "restricted_vendor|BTC-USD|1h",
+                "dataset_snapshot_id": "snap-restricted",
+                "dataset_fingerprint": "sha256:test",
+                "source_id": "restricted_vendor",
+                "instrument_ids": ["BTC-USD"],
+                "timeframe": "1h",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-05T03:00:00Z",
+                "quality_summary": {"effective_research_quality_status": "ready"},
+                "identity_summary": {"instrument_identity_status": "ready"},
+                "integrity_summary": {
+                    "raw_row_count": 100,
+                    "unique_bar_count": 100,
+                    "expected_bar_count": 100,
+                    "coverage_ratio": 1.0,
+                    "exact_duplicate_row_count": 0,
+                    "conflicting_row_count": 0,
+                    "invalid_row_count": 0,
+                },
+            }
+        ]
+    }
+    policy = {"content_identity": "policy-fixture", "policy_version": "policy-fixture"}
+    row = qualify_datasets(dataset_catalog=catalog, policy_reconciliation=policy)["rows"][0]
+
+    assert row["allowed_evidence_tier"] == SOURCE_BLOCKED
+    assert "source_license_not_screening_eligible" in row["reason_codes"]
+
+
+def test_duplicate_conflict_quality_failure_blocks_source(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        source_qualification,
+        "build_source_manifest_registry",
+        lambda: {
+            "rows": [
+                {
+                    "source_id": "certified_crypto_vendor",
+                    "provider_id": "certified_crypto_vendor",
+                    "source_status": "quality_gated",
+                    "license_policy_status": "PASS",
+                    "allowed_use": ["research_screening"],
+                    "calendar_model": "CRYPTO_24_7",
+                }
+            ]
+        },
+    )
+    catalog = {
+        "datasets": [
+            {
+                "dataset_id": "certified_crypto_vendor|BTC-USD|1h",
+                "dataset_snapshot_id": "snap-conflict",
+                "dataset_fingerprint": "sha256:test",
+                "source_id": "certified_crypto_vendor",
+                "instrument_ids": ["BTC-USD"],
+                "timeframe": "1h",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-10T23:00:00Z",
+                "quality_summary": {"effective_research_quality_status": "ready"},
+                "identity_summary": {"instrument_identity_status": "ready"},
+                "integrity_summary": {
+                    "raw_row_count": 260,
+                    "unique_bar_count": 240,
+                    "expected_bar_count": 240,
+                    "coverage_ratio": 1.0,
+                    "exact_duplicate_row_count": 20,
+                    "conflicting_row_count": 3,
+                    "invalid_row_count": 0,
+                },
+            }
+        ]
+    }
+    row = qualify_datasets(dataset_catalog=catalog, policy_reconciliation={"content_identity": "policy-fixture"})["rows"][0]
+
+    assert row["allowed_evidence_tier"] == SOURCE_BLOCKED
+    assert "conflicting_rows_present" in row["reason_codes"]
+    assert "duplicate_bar_ratio_too_high" in row["reason_codes"]
+
+
+def test_source_qualification_identity_is_cross_root_order_and_mtime_deterministic(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        source_qualification,
+        "build_source_manifest_registry",
+        lambda: {
+            "rows": [
+                {
+                    "source_id": "certified_crypto_vendor",
+                    "provider_id": "certified_crypto_vendor",
+                    "source_status": "quality_gated",
+                    "license_policy_status": "PASS",
+                    "allowed_use": ["research_screening"],
+                    "calendar_model": "CRYPTO_24_7",
+                }
+            ]
+        },
+    )
+    rows = [
+        {
+            "dataset_id": "certified_crypto_vendor|BTC-USD|1h",
+            "dataset_snapshot_id": "snap-a",
+            "dataset_fingerprint": "sha256:a",
+            "source_id": "certified_crypto_vendor",
+            "instrument_ids": ["BTC-USD"],
+            "timeframe": "1h",
+            "start": "2026-01-01T00:00:00Z",
+            "end": "2026-01-04T23:00:00Z",
+            "quality_summary": {"effective_research_quality_status": "ready"},
+            "identity_summary": {"instrument_identity_status": "ready"},
+            "integrity_summary": {"raw_row_count": 96, "unique_bar_count": 96, "expected_bar_count": 96, "coverage_ratio": 1.0, "exact_duplicate_row_count": 0, "conflicting_row_count": 0, "invalid_row_count": 0},
+        },
+        {
+            "dataset_id": "certified_crypto_vendor|ETH-USD|1h",
+            "dataset_snapshot_id": "snap-b",
+            "dataset_fingerprint": "sha256:b",
+            "source_id": "certified_crypto_vendor",
+            "instrument_ids": ["ETH-USD"],
+            "timeframe": "1h",
+            "start": "2026-01-01T00:00:00Z",
+            "end": "2026-01-04T23:00:00Z",
+            "quality_summary": {"effective_research_quality_status": "ready"},
+            "identity_summary": {"instrument_identity_status": "ready"},
+            "integrity_summary": {"raw_row_count": 96, "unique_bar_count": 96, "expected_bar_count": 96, "coverage_ratio": 1.0, "exact_duplicate_row_count": 0, "conflicting_row_count": 0, "invalid_row_count": 0},
+        },
+    ]
+    left = qualify_datasets(dataset_catalog={"datasets": rows}, policy_reconciliation={"content_identity": "policy-fixture"})
+    right = qualify_datasets(dataset_catalog={"datasets": list(reversed(rows))}, policy_reconciliation={"content_identity": "policy-fixture"})
+
+    assert left["content_identity"] == right["content_identity"]
+    assert left["rows"] == right["rows"]
 
 
 def test_qualification_summary_counts_blocked_replay_and_logical_datasets(tmp_path) -> None:

--- a/tests/unit/test_qre_alpha_source_qualification.py
+++ b/tests/unit/test_qre_alpha_source_qualification.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
-from packages.qre_research.alpha_discovery.contracts import DatasetSnapshot
 from packages.qre_research.alpha_discovery import source_qualification
+from packages.qre_research.alpha_discovery.contracts import DatasetSnapshot
 from packages.qre_research.alpha_discovery.snapshot_lineage import append_snapshot_row
 from packages.qre_research.alpha_discovery.source_qualification import (
     SOURCE_BLOCKED,

--- a/tests/unit/test_qre_research_supervisor.py
+++ b/tests/unit/test_qre_research_supervisor.py
@@ -1106,6 +1106,113 @@ def test_supervisor_run_status_aligns_watermarks_with_run_ids(monkeypatch, tmp_p
     assert payload["watermarks"]["snapshot_lineage"] == "snap-after"
 
 
+def test_supervisor_source_qualification_change_triggers_material_cycle(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _configure_paths(monkeypatch, repo_root)
+
+    (repo_root / "generated_research/data_catalog/snapshot_lineage").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/data_catalog/revisions").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/source_qualifications").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/status").mkdir(parents=True, exist_ok=True)
+    (repo_root / "generated_research/alpha_discovery/runtime_epoch").mkdir(parents=True, exist_ok=True)
+    (repo_root / "logs/qre_research_supervisor").mkdir(parents=True, exist_ok=True)
+
+    (repo_root / "generated_research/data_catalog/snapshot_lineage/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "snap-current"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/data_catalog/revisions/latest.json").write_text(
+        json.dumps({"rows": [], "content_identity": "rev-current"}),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/alpha_discovery/source_qualifications/latest.json").write_text(
+        json.dumps(
+            {
+                "rows": [
+                    {
+                        "dataset_snapshot_id": "snap-screening",
+                        "allowed_evidence_tier": "SOURCE_SCREENING_ELIGIBLE",
+                        "qualification_status": "COHERENT",
+                    }
+                ],
+                "content_identity": "qual-new",
+                "qualification_set_id": "qual-new",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "generated_research/alpha_discovery/status/latest.json").write_text(
+        json.dumps(
+            {
+                "runtime_epoch_id": "epoch-old",
+                "qualification_set_id": "qual-old",
+                "snapshot_lineage_set_id": "snap-current",
+                "current_dataset_snapshot": None,
+                "current_source_tier": "SOURCE_BLOCKED",
+                "current_experiment": None,
+                "current_campaign": None,
+                "run_id": "qarr-old",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "logs/qre_research_supervisor/latest.json").write_text(
+        json.dumps(
+            {
+                "semantic_input_identity": "qsupsem-old",
+                "watermarks": {
+                    "snapshot_lineage": "snap-current",
+                    "source_qualifications": "qual-old",
+                    "open_gap_ids": [],
+                },
+                "runtime_epoch_id": "epoch-old",
+                "qualification_set_id": "qual-old",
+                "snapshot_lineage_set_id": "snap-current",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    run_calls = 0
+
+    def _run_once(**kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        return {
+            "run_id": "qarr-new",
+            "terminal_disposition": "STOPPED_SOURCE_CERTIFICATION_BOUNDARY",
+            "execution_status": "COMPLETED",
+            "current_dataset_snapshot": "snap-screening",
+            "current_source_tier": "SOURCE_SCREENING_ELIGIBLE",
+            "current_experiment": None,
+            "current_campaign": None,
+            "runtime_epoch_id": "epoch-new",
+            "qualification_set_id": "qual-new",
+            "snapshot_lineage_set_id": "snap-current",
+            "search_ledger_id": "qsl-new",
+            "requested_execution_tier": "EMPIRICAL_SCREENING",
+            "admitted_execution_tier": "COMPILER_ONLY",
+            "scientific_disposition": "NEEDS_MORE_EVIDENCE",
+            "evidence_tier_reached": "EMPIRICAL_SCREENING",
+            "content_identity": "qarrc-new",
+        }
+
+    monkeypatch.setattr(supervisor, "run_alpha_discovery_mvp", _run_once)
+    monkeypatch.setattr(supervisor, "_open_gaps", lambda: [])
+    monkeypatch.setattr(supervisor, "_blocked_experiments", lambda: [])
+    monkeypatch.setattr(supervisor, "load_snapshot_lineage", lambda repo_root: {"snapshot_lineage": {"content_identity": "snap-current"}, "revisions": {"rows": []}})
+
+    payload = supervisor.run_cycle(repo_root=repo_root, dry_run=True)
+
+    assert run_calls == 1
+    assert payload["current_stage"] == "COMPLETE"
+    assert payload["current_source_tier"] == "SOURCE_SCREENING_ELIGIBLE"
+    assert payload["current_campaign"] is None
+    assert payload["active_ADE_requests"] == ()
+    assert payload["qualification_set_id"] == "qual-new"
+    assert payload["watermarks"]["source_qualifications"] == "qual-new"
+
+
 @pytest.mark.parametrize(
     ("health", "expected_exit"),
     [

--- a/tests/unit/test_qre_snapshot_lineage_determinism.py
+++ b/tests/unit/test_qre_snapshot_lineage_determinism.py
@@ -82,3 +82,83 @@ def test_snapshot_lineage_identity_changes_for_semantic_content_mutation(monkeyp
     second = snapshot_lineage.materialize_snapshot_lineage(repo_root, write_outputs=False, force_refresh=True)
 
     assert first["snapshot_lineage"]["content_identity"] != second["snapshot_lineage"]["content_identity"]
+
+
+def test_snapshot_lineage_uses_logical_dataset_integrity_without_synthetic_coverage(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path
+    truth = {
+        "catalog": {
+            "datasets": [
+                {
+                    "dataset_id": "certified_crypto_vendor|BTC-USD|1h",
+                    "dataset_fingerprint": "sha256:logical",
+                    "source_id": "certified_crypto_vendor",
+                    "instrument_ids": ["BTC-USD"],
+                    "timeframe": "1h",
+                    "start": "2026-01-01T00:00:00Z",
+                    "end": "2026-01-02T23:00:00Z",
+                    "partition_refs": ["data/cache/market/certified_crypto_vendor__BTC-USD__1h__20260101__20260102__abcd.parquet"],
+                    "integrity_summary": {
+                        "raw_row_count": 48,
+                        "unique_bar_count": 48,
+                        "expected_bar_count": 48,
+                        "coverage_ratio": 1.0,
+                        "exact_duplicate_row_count": 0,
+                        "overlapping_row_count": 0,
+                        "conflicting_row_count": 0,
+                        "invalid_row_count": 0,
+                    },
+                    "quality_summary": {
+                        "row_integrity_status": "ready",
+                        "effective_research_quality_status": "blocked",
+                    },
+                    "provenance": {"manifest_latest": "logs/qre_data_cache_manifest/latest.json"},
+                }
+            ],
+            "content_identity": "catalog-identity",
+        },
+        "census": {
+            "physical_files": [
+                {
+                    "portable_relative_path": "data/cache/market/certified_crypto_vendor__BTC-USD__1h__20260101__20260102__abcd.parquet",
+                    "dataset_fingerprint": "sha256:physical",
+                    "row_count": 5,
+                    "effective_research_quality_status": "blocked",
+                }
+            ],
+            "logical_datasets": [
+                {
+                    "dataset_id": "certified_crypto_vendor|BTC-USD|1h",
+                    "dataset_fingerprint": "sha256:logical",
+                    "source_id": "certified_crypto_vendor",
+                    "instrument_ids": ["BTC-USD"],
+                    "timeframe": "1h",
+                    "start": "2026-01-01T00:00:00Z",
+                    "end": "2026-01-02T23:00:00Z",
+                    "partition_refs": ["data/cache/market/certified_crypto_vendor__BTC-USD__1h__20260101__20260102__abcd.parquet"],
+                    "integrity_summary": {
+                        "raw_row_count": 48,
+                        "unique_bar_count": 48,
+                        "expected_bar_count": 48,
+                        "coverage_ratio": 1.0,
+                        "exact_duplicate_row_count": 0,
+                        "overlapping_row_count": 0,
+                        "conflicting_row_count": 0,
+                        "invalid_row_count": 0,
+                    },
+                    "quality_summary": {"row_integrity_status": "ready"},
+                    "provenance": {"manifest_latest": "logs/qre_data_cache_manifest/latest.json"},
+                }
+            ],
+        },
+    }
+    monkeypatch.setattr(snapshot_lineage, "materialize_data_truth", lambda repo_root, force_refresh=False: truth)
+
+    payload = snapshot_lineage.materialize_snapshot_lineage(repo_root, write_outputs=False, force_refresh=True)
+    rows = payload["snapshot_lineage"]["rows"]
+
+    assert len(rows) == 1
+    assert rows[0]["unique_bar_count"] == 48
+    assert rows[0]["expected_bar_count"] == 48
+    assert rows[0]["coverage_ratio"] == 1.0
+    assert rows[0]["qualification_status"] == "COHERENT"


### PR DESCRIPTION
## Summary
- build deterministic logical-snapshot source certification from data catalog integrity metrics
- enforce manifest/license/policy gates before SOURCE_SCREENING_ELIGIBLE
- remove implicit yfinance screening fallback from source resolution
- allow supervisor material cycles when source qualification genuinely improves
- document QRE source certification policy and operator actions

## Local proof
- Existing repo data: 46 logical snapshots, 0 screening eligible, 0 validation eligible, 46 blocked
- Top reasons: source_license_not_screening_eligible, duplicate_bar_ratio_too_high, conflicting_rows_present, missing_expected_bar_count/missing_calendar, insufficient_coverage
- No false promotion: yfinance remains blocked because manifest is manual_research_only and allowed_use does not include research_screening

## Local checks
- python -m ruff check .: passed
- python scripts/governance_lint.py: passed
- python -m pytest tests/unit/test_qre_alpha_source_qualification.py -q: 7 passed
- python -m pytest tests/unit/test_qre_alpha_snapshot_resolution.py -q: 3 passed
- python -m pytest tests/unit/test_qre_snapshot_lineage_determinism.py -q: 4 passed
- python -m pytest tests/unit/test_qre_research_supervisor.py -q: 18 passed
- python -m pytest tests/architecture -q: 164 passed
- git diff --check: passed
- python -m pytest tests/unit -q: timed out locally after 1204.042s without pytest summary