### PR TITLE
feat: add qre source onboarding harness

### DIFF
--- a/docs/governance/qre_source_onboarding_harness.md
+++ b/docs/governance/qre_source_onboarding_harness.md
@@ -1,0 +1,73 @@
+# QRE Source Onboarding Harness
+
+The source onboarding harness accepts operator-supplied OHLCV data and a declarative source manifest, then emits QRE data-catalog and source-certification artifacts for the existing source qualification policy. It does not grant trading authority, start campaigns, create candidates, call providers, or change frozen research contracts.
+
+## Manifest Contract
+
+Schema version: `qre_source_manifest_v1`.
+
+Required fields:
+
+- `source_id`, `provider_id`, `source_family`, `asset_class`, `venue`
+- `allowed_use`
+- `license_policy_status`
+- `calendar.type` and `calendar.timezone`
+- `data.schema` plus timestamp, symbol, OHLCV column mappings
+- `timeframe` or `timeframes`
+- `universe.symbols`
+
+Screening is allowed only when all of these are true:
+
+- `allowed_use` contains `research_screening`
+- `license_policy_status` is `PASS`
+- `operator_license_attestation` is present with `provided_by`, `attested_at_utc`, and a non-secret `evidence_ref`
+- imported bars satisfy the existing `qre_alpha_source_qualification_pr4_v1` metrics and thresholds
+
+Missing license proof maps to `source_license_not_screening_eligible` and operator action `provide_screening_license_attestation`.
+
+## Local File Adapter
+
+Supported command:
+
+```text
+python -m research.qre_source_onboarding import-local --manifest <path> --bars <csv> --out generated_research/data_catalog/imports/<source_id>/<snapshot_id>
+```
+
+The adapter supports CSV with mapped `timestamp`, `symbol`, `open`, `high`, `low`, `close`, and `volume` columns. Rows are normalized to UTC, sorted deterministically by symbol and timestamp, deduplicated, checked for conflicting duplicates and OHLCV validity, and fingerprinted from canonical content only. File path and mtime are excluded from identities.
+
+Supported calendars:
+
+- `crypto_24_7` for hourly or daily continuous markets
+- `weekday_daily` for weekday-only daily bars
+
+Unsupported or missing calendars produce `missing_calendar` and no synthetic coverage.
+
+## Artifacts
+
+The harness writes only QRE onboarding and qualification artifacts:
+
+- `generated_research/data_catalog/onboarding/latest.json`
+- `generated_research/data_catalog/onboarding/source_manifest_latest.json`
+- `generated_research/data_catalog/onboarding/import_audit_latest.json`
+- `generated_research/data_catalog/source_certification/latest.json`
+- `generated_research/alpha_discovery/source_qualifications/latest.json`
+- `generated_research/alpha_discovery/source_resolution/latest.json`
+
+Artifacts include manifest hash, data fingerprint, row counts, expected bars, coverage, duplicate/conflict metrics, invalid row metrics, qualification tier, blocked reasons, operator actions, policy version, and generation time.
+
+## Secrets
+
+Provider credentials are out of scope for local import. Future provider skeletons must use environment variables or Docker secrets only:
+
+- `QRE_DATABENTO_API_KEY`
+- `QRE_TIINGO_API_KEY`
+- `QRE_NASDAQ_DATA_LINK_API_KEY`
+- `QRE_ALPHA_VANTAGE_API_KEY`
+
+Secrets must never appear in manifests, logs, artifacts, fixtures, or CI output.
+
+## Provider Onboarding Priority
+
+1. Local exports from Databento, Tiingo, Nasdaq Data Link, Binance, Coinbase, or Kraken: lowest integration risk because QRE does not call provider endpoints.
+2. Public crypto candle APIs: possible read-only adapter later, but policy must remain operator-attested and default to manual review.
+3. Commercial provider APIs: add only after credentials, terms, rate limits, and allowed-use evidence are explicitly provided.

--- a/packages/qre_research/alpha_discovery/source_qualification.py
+++ b/packages/qre_research/alpha_discovery/source_qualification.py
@@ -52,9 +52,10 @@ SCREENING_REQUIRED_FIELDS = (
 )
 
 
-def _registry_rows() -> dict[str, dict[str, Any]]:
+def _registry_rows(extra_manifest_rows: list[dict[str, Any]] | None = None) -> dict[str, dict[str, Any]]:
     registry = build_source_manifest_registry()
-    rows = registry.get("rows") or []
+    rows = list(registry.get("rows") or [])
+    rows.extend(extra_manifest_rows or [])
     resolved: dict[str, dict[str, Any]] = {}
     for row in rows:
         if not isinstance(row, dict):
@@ -65,14 +66,14 @@ def _registry_rows() -> dict[str, dict[str, Any]]:
     return resolved
 
 
-def _source_manifest_for(source_id: str) -> dict[str, Any] | None:
+def _source_manifest_for(source_id: str, extra_manifest_rows: list[dict[str, Any]] | None = None) -> dict[str, Any] | None:
     key = str(source_id or "").lower()
     aliases = (
         key,
         "yahoo_finance_yfinance_manifest" if key == "yfinance" else key,
         "yahoo_finance_yfinance" if key == "yfinance" else key,
     )
-    rows = _registry_rows()
+    rows = _registry_rows(extra_manifest_rows)
     for alias in aliases:
         manifest = rows.get(alias)
         if manifest is not None:
@@ -181,7 +182,13 @@ def _screening_reasons(snapshot: dict[str, Any]) -> list[str]:
     return reasons
 
 
-def qualify_datasets(*, repo_root: Path | None = None, dataset_catalog: dict[str, Any], policy_reconciliation: dict[str, Any]) -> dict[str, Any]:
+def qualify_datasets(
+    *,
+    repo_root: Path | None = None,
+    dataset_catalog: dict[str, Any],
+    policy_reconciliation: dict[str, Any],
+    extra_manifest_rows: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     rows = []
     current_status = str(policy_reconciliation.get("current_yfinance_status") or "unknown")
     snapshots: list[dict[str, Any]] = []
@@ -264,7 +271,7 @@ def qualify_datasets(*, repo_root: Path | None = None, dataset_catalog: dict[str
     )
     for snapshot in snapshots:
         source_id = str(snapshot.get("source_id") or "")
-        manifest = _source_manifest_for(source_id)
+        manifest = _source_manifest_for(source_id, extra_manifest_rows)
         allowed_tier = SOURCE_TIER_BLOCKED
         reason_codes = list(dict.fromkeys(_screening_reasons(snapshot)))
         if manifest is None:

--- a/research/qre_source_onboarding.py
+++ b/research/qre_source_onboarding.py
@@ -1,0 +1,688 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import Counter, defaultdict
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from packages.qre_research.alpha_discovery.contracts import (
+    DatasetSnapshot,
+    canonical_payload,
+    content_id,
+    stable_digest,
+)
+from packages.qre_research.alpha_discovery.snapshot_lineage import append_snapshot_row
+from packages.qre_research.alpha_discovery.source_qualification import (
+    SOURCE_POLICY_VERSION,
+    qualify_datasets,
+)
+
+ONBOARDING_DIR = Path("generated_research/data_catalog/onboarding")
+SOURCE_CERTIFICATION_PATH = Path("generated_research/data_catalog/source_certification/latest.json")
+SOURCE_QUALIFICATIONS_PATH = Path("generated_research/alpha_discovery/source_qualifications/latest.json")
+SOURCE_RESOLUTION_PATH = Path("generated_research/alpha_discovery/source_resolution/latest.json")
+SCHEMA_VERSION = "qre_source_onboarding_v1"
+MANIFEST_SCHEMA_VERSION = "qre_source_manifest_v1"
+
+SECRET_ENV_VARS = (
+    "QRE_DATABENTO_API_KEY",
+    "QRE_TIINGO_API_KEY",
+    "QRE_NASDAQ_DATA_LINK_API_KEY",
+    "QRE_ALPHA_VANTAGE_API_KEY",
+)
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    if path.is_file() and path.read_text(encoding="utf-8-sig") == text:
+        return
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8", newline="\n")
+    tmp.replace(path)
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("manifest must be a YAML mapping")
+    return payload
+
+
+def _manifest_hash(manifest: dict[str, Any]) -> str:
+    return "sha256:" + stable_digest(canonical_payload(manifest))
+
+
+def _required_manifest_actions(manifest: dict[str, Any]) -> list[str]:
+    actions: list[str] = []
+    required_paths = {
+        "source_id": ("source_id",),
+        "provider_id": ("provider_id",),
+        "allowed_use": ("allowed_use",),
+        "calendar": ("calendar",),
+        "timeframe": ("timeframe",),
+        "schema_mapping": ("data",),
+        "universe": ("universe",),
+    }
+    for action, path in required_paths.items():
+        value: Any = manifest
+        for key in path:
+            value = value.get(key) if isinstance(value, dict) else None
+        if value in (None, "", [], {}):
+            actions.append(f"missing_{action}")
+    data = manifest.get("data") if isinstance(manifest.get("data"), dict) else {}
+    for key in ("timestamp_column", "symbol_column", "open_column", "high_column", "low_column", "close_column", "volume_column"):
+        if not data.get(key):
+            actions.append(f"missing_{key}")
+    allowed_use = {str(value) for value in manifest.get("allowed_use") or []}
+    license_status = str(manifest.get("license_policy_status") or "").upper()
+    attestation = manifest.get("operator_license_attestation") if isinstance(manifest.get("operator_license_attestation"), dict) else {}
+    if "research_screening" in allowed_use and (license_status != "PASS" or not attestation):
+        actions.append("missing_license_attestation")
+        actions.append("provide_screening_license_attestation")
+    if "research_screening" not in allowed_use:
+        actions.append("missing_license_attestation")
+        actions.append("provide_screening_license_attestation")
+    return sorted(dict.fromkeys(actions))
+
+
+def validate_manifest_file(path: Path) -> dict[str, Any]:
+    manifest = _load_manifest(path)
+    actions = _required_manifest_actions(manifest)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "qre_source_onboarding_manifest_validation",
+        "manifest_path": path.name,
+        "source_id": manifest.get("source_id"),
+        "provider_id": manifest.get("provider_id"),
+        "manifest_hash": _manifest_hash(manifest),
+        "valid": not actions,
+        "operator_actions": actions,
+        "secret_boundary": {
+            "accepted_env_vars": SECRET_ENV_VARS,
+            "secrets_written_to_artifacts": False,
+        },
+    }
+    return canonical_payload(payload)
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def _format_ts(value: datetime) -> str:
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _timeframe_delta(timeframe: str) -> timedelta | None:
+    text = str(timeframe or "").lower()
+    if text.endswith("h") and text[:-1].isdigit():
+        return timedelta(hours=int(text[:-1]))
+    if text.endswith("d") and text[:-1].isdigit():
+        return timedelta(days=int(text[:-1]))
+    return None
+
+
+def _expected_bar_count(*, calendar: dict[str, Any], timeframe: str, start: datetime | None, end: datetime | None, symbol_count: int) -> int | None:
+    if start is None or end is None or end < start or symbol_count <= 0:
+        return None
+    calendar_type = str(calendar.get("type") or "")
+    delta = _timeframe_delta(timeframe)
+    if delta is None:
+        return None
+    if calendar_type == "crypto_24_7":
+        return int(((end - start).total_seconds() // delta.total_seconds()) + 1) * symbol_count
+    if calendar_type == "weekday_daily" and timeframe == "1d":
+        count = 0
+        current = start.date()
+        final = end.date()
+        while current <= final:
+            if current.weekday() < 5:
+                count += 1
+            current += timedelta(days=1)
+        return count * symbol_count
+    return None
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_rows(*, bars_path: Path, manifest: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    data = dict(manifest.get("data") or {})
+    columns = {
+        "timestamp": str(data.get("timestamp_column") or "timestamp"),
+        "symbol": str(data.get("symbol_column") or "symbol"),
+        "open": str(data.get("open_column") or "open"),
+        "high": str(data.get("high_column") or "high"),
+        "low": str(data.get("low_column") or "low"),
+        "close": str(data.get("close_column") or "close"),
+        "volume": str(data.get("volume_column") or "volume"),
+    }
+    rows: list[dict[str, Any]] = []
+    missing_columns: list[str] = []
+    with bars_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = set(reader.fieldnames or [])
+        missing_columns = [value for value in columns.values() if value not in fieldnames]
+        if missing_columns:
+            return [], {"missing_required_columns": tuple(sorted(missing_columns)), "raw_row_count": 0}
+        for raw in reader:
+            ts = _parse_timestamp(raw.get(columns["timestamp"]))
+            open_ = _to_float(raw.get(columns["open"]))
+            high = _to_float(raw.get(columns["high"]))
+            low = _to_float(raw.get(columns["low"]))
+            close = _to_float(raw.get(columns["close"]))
+            volume = _to_float(raw.get(columns["volume"]))
+            invalid = ts is None or open_ is None or high is None or low is None or close is None or volume is None
+            if not invalid:
+                invalid = high < max(open_, close) or low > min(open_, close) or volume < 0
+            rows.append(
+                {
+                    "timestamp_utc": _format_ts(ts) if ts else None,
+                    "symbol": str(raw.get(columns["symbol"]) or "").strip(),
+                    "open": open_,
+                    "high": high,
+                    "low": low,
+                    "close": close,
+                    "volume": volume,
+                    "invalid": bool(invalid),
+                }
+            )
+    return rows, {"missing_required_columns": (), "raw_row_count": len(rows)}
+
+
+def _quality_metrics(*, rows: list[dict[str, Any]], manifest: dict[str, Any], requested_end: str | None) -> dict[str, Any]:
+    valid_rows = [row for row in rows if not row["invalid"] and row["timestamp_utc"] and row["symbol"]]
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in valid_rows:
+        grouped[(str(row["symbol"]), str(row["timestamp_utc"]))].append(row)
+
+    canonical_rows: list[dict[str, Any]] = []
+    exact_duplicates = 0
+    conflicts = 0
+    overlaps = 0
+    for _key, key_rows in sorted(grouped.items()):
+        values = [tuple(item[column] for column in ("open", "high", "low", "close", "volume")) for item in key_rows]
+        unique_values = list(dict.fromkeys(values))
+        if len(key_rows) > 1:
+            overlaps += len(key_rows) - 1
+        if len(unique_values) == 1:
+            exact_duplicates += max(len(key_rows) - 1, 0)
+            canonical_rows.append({key_name: key_value for key_name, key_value in key_rows[0].items() if key_name != "invalid"})
+        else:
+            conflicts += 1
+
+    canonical_rows.sort(key=lambda row: (str(row["symbol"]), str(row["timestamp_utc"])))
+    timestamps = [_parse_timestamp(row["timestamp_utc"]) for row in canonical_rows]
+    timestamps = [value for value in timestamps if value is not None]
+    start = min(timestamps) if timestamps else None
+    end = _parse_timestamp(requested_end) if requested_end else (max(timestamps) if timestamps else None)
+    symbols = tuple(sorted({str(row["symbol"]) for row in canonical_rows if str(row["symbol"])}))
+    manifest_symbols = tuple(str(value) for value in (manifest.get("universe") or {}).get("symbols") or () if str(value))
+    symbol_count = len(manifest_symbols or symbols)
+    expected = _expected_bar_count(
+        calendar=dict(manifest.get("calendar") or {}),
+        timeframe=str(manifest.get("timeframe") or (manifest.get("timeframes") or [""])[0]),
+        start=start,
+        end=end,
+        symbol_count=symbol_count,
+    )
+    unique_count = len(canonical_rows)
+    coverage = None if expected in (None, 0) else round(unique_count / expected, 6)
+    fingerprint_payload = canonical_payload(canonical_rows)
+    return {
+        "canonical_rows": canonical_rows,
+        "raw_row_count": len(rows),
+        "unique_bar_count": unique_count,
+        "exact_duplicate_row_count": exact_duplicates,
+        "overlapping_row_count": overlaps,
+        "conflicting_row_count": conflicts,
+        "invalid_row_count": sum(1 for row in rows if row["invalid"]),
+        "expected_bar_count": expected,
+        "coverage_ratio": coverage,
+        "missing_bar_count": max(expected - unique_count, 0) if expected is not None else None,
+        "start": _format_ts(start) if start else None,
+        "end": _format_ts(end) if end else None,
+        "instrument_ids": symbols,
+        "data_fingerprint": "sha256:" + stable_digest(fingerprint_payload),
+    }
+
+
+def _manifest_registry_row(manifest: dict[str, Any], manifest_hash: str) -> dict[str, Any]:
+    return canonical_payload(
+        {
+            "source_id": manifest.get("source_id"),
+            "provider_id": manifest.get("provider_id"),
+            "source_name": manifest.get("source_name") or manifest.get("source_id"),
+            "source_type": "market_price_data",
+            "source_category": "operator_onboarded_local_file",
+            "source_status": manifest.get("source_status") or "manual_review_required",
+            "access_method": "local_file_import",
+            "authentication_required": False,
+            "cost_model": "operator_supplied",
+            "license_terms_status": "reviewed" if str(manifest.get("license_policy_status") or "").upper() == "PASS" else "review_required",
+            "license_policy_status": manifest.get("license_policy_status"),
+            "license_terms_reference": (manifest.get("operator_license_attestation") or {}).get("evidence_ref") or "operator_license_attestation_required",
+            "allowed_use": tuple(manifest.get("allowed_use") or ()),
+            "forbidden_use": (
+                "broker_execution",
+                "buy_list",
+                "candidate_promotion",
+                "capital_allocation",
+                "live_activation",
+                "paper_activation",
+                "sell_list",
+                "shadow_activation",
+                "strategy_registration",
+                "trade_signal",
+            ),
+            "asset_coverage": (manifest.get("asset_class"),),
+            "exchange_coverage": (manifest.get("venue"),),
+            "calendar_model": (manifest.get("calendar") or {}).get("type"),
+            "schema_version": manifest.get("schema_version"),
+            "manifest_status": "PASS" if not _required_manifest_actions(manifest) else "WARN",
+            "manifest_block_reasons": tuple(_required_manifest_actions(manifest)),
+            "reproducibility_method": "operator_local_file_import",
+            "operator_notes": "Onboarded local OHLCV source. Manifest presence never grants trading authority.",
+            "manifest_hash": manifest_hash,
+        }
+    )
+
+
+def _catalog_dataset(*, manifest: dict[str, Any], snapshot_id: str, metrics: dict[str, Any], manifest_hash: str) -> dict[str, Any]:
+    source_id = str(manifest["source_id"])
+    timeframe = str(manifest.get("timeframe") or (manifest.get("timeframes") or [""])[0])
+    dataset_id = "|".join((source_id, ",".join(metrics["instrument_ids"]), timeframe))
+    return canonical_payload(
+        {
+            "dataset_id": dataset_id,
+            "dataset_snapshot_id": snapshot_id,
+            "dataset_fingerprint": metrics["data_fingerprint"],
+            "source_id": source_id,
+            "source_manifest_id": manifest_hash,
+            "instrument_ids": metrics["instrument_ids"],
+            "timeframe": timeframe,
+            "start": metrics["start"],
+            "end": metrics["end"],
+            "row_count": metrics["unique_bar_count"],
+            "quality_summary": {
+                "effective_research_quality_status": "ready",
+                "row_integrity_status": "ready",
+                "minimum_required_history": "derived",
+                "minimum_required_rows": 48,
+            },
+            "identity_summary": {"instrument_identity_status": "ready", "instrument_ids": metrics["instrument_ids"]},
+            "integrity_summary": {
+                "raw_row_count": metrics["raw_row_count"],
+                "unique_bar_count": metrics["unique_bar_count"],
+                "expected_bar_count": metrics["expected_bar_count"],
+                "coverage_ratio": metrics["coverage_ratio"],
+                "exact_duplicate_row_count": metrics["exact_duplicate_row_count"],
+                "overlapping_row_count": metrics["overlapping_row_count"],
+                "conflicting_row_count": metrics["conflicting_row_count"],
+                "invalid_row_count": metrics["invalid_row_count"],
+                "activity_estimate": metrics["unique_bar_count"],
+                "validation_capacity": 0,
+            },
+            "adjustment_policy": "explicit_unadjusted" if not (manifest.get("data") or {}).get("adjusted") else "explicit_adjusted",
+            "timezone_policy": "UTC_NORMALIZED",
+            "session_policy": (manifest.get("calendar") or {}).get("type"),
+            "history_span": "derived",
+            "validation_capacity": 0,
+            "activity_estimate": metrics["unique_bar_count"],
+            "source_policy_version": SOURCE_POLICY_VERSION,
+            "qualification_policy_version": SOURCE_POLICY_VERSION,
+            "provenance": {"generated_at_utc": metrics["end"]},
+        }
+    )
+
+
+def import_local_source(
+    *,
+    repo_root: Path,
+    manifest_path: Path,
+    bars_path: Path,
+    out_dir: Path,
+    snapshot_id: str | None = None,
+    requested_end: str | None = None,
+) -> dict[str, Any]:
+    manifest = _load_manifest(manifest_path)
+    if not bars_path.is_file():
+        raise FileNotFoundError(f"missing_bars_file: {bars_path}")
+    snapshot_id = snapshot_id or content_id("qdsnap", {"manifest": manifest, "bars": bars_path.name})
+    rows, column_metrics = _normalize_rows(bars_path=bars_path, manifest=manifest)
+    metrics = _quality_metrics(rows=rows, manifest=manifest, requested_end=requested_end)
+    metrics = {**column_metrics, **metrics}
+    manifest_hash = _manifest_hash(manifest)
+    registry_row = _manifest_registry_row(manifest, manifest_hash)
+    dataset = _catalog_dataset(manifest=manifest, snapshot_id=snapshot_id, metrics=metrics, manifest_hash=manifest_hash)
+    source_id = str(manifest["source_id"])
+    timeframe = str(manifest.get("timeframe") or (manifest.get("timeframes") or [""])[0])
+    snapshot = DatasetSnapshot(
+        dataset_snapshot_id=snapshot_id,
+        logical_dataset_family_id=str(dataset["dataset_id"]),
+        acquisition_batch_ids=(content_id("qdbatch", {"source": source_id, "snapshot": snapshot_id, "fingerprint": metrics["data_fingerprint"]}),),
+        parent_snapshot_id=None,
+        instrument_ids=tuple(metrics["instrument_ids"]),
+        timeframe=timeframe,
+        start=str(metrics["start"] or ""),
+        end=str(metrics["end"] or ""),
+        unique_bar_count=int(metrics["unique_bar_count"]),
+        raw_row_count=int(metrics["raw_row_count"]),
+        exact_duplicate_row_count=int(metrics["exact_duplicate_row_count"]),
+        overlapping_row_count=int(metrics["overlapping_row_count"]),
+        conflicting_row_count=int(metrics["conflicting_row_count"]),
+        invalid_row_count=int(metrics["invalid_row_count"]),
+        expected_bar_count=metrics["expected_bar_count"],
+        coverage_ratio=metrics["coverage_ratio"],
+        fingerprint=str(metrics["data_fingerprint"]),
+        source_id=source_id,
+        source_policy_version=SOURCE_POLICY_VERSION,
+        qualification_status="COHERENT" if not metrics["conflicting_row_count"] and not metrics["invalid_row_count"] else "BLOCKED_CONFLICT",
+        immutable=True,
+        created_at_utc=str(metrics["end"] or ""),
+        partition_refs=(out_dir.relative_to(repo_root).as_posix() + "/bars_normalized.csv",),
+        compatibility_status="ROOT",
+        lineage_depth=0,
+        content_identity=content_id("qdsnaprow", {"snapshot": snapshot_id, "fingerprint": metrics["data_fingerprint"], "metrics": metrics}),
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    normalized_path = out_dir / "bars_normalized.csv"
+    with normalized_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["timestamp_utc", "symbol", "open", "high", "low", "close", "volume"])
+        writer.writeheader()
+        writer.writerows(metrics["canonical_rows"])
+    append_snapshot_row(repo_root, snapshot)
+
+    source_manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "qre_source_onboarding_manifest",
+        "source_id": source_id,
+        "snapshot_id": snapshot_id,
+        "provider_id": manifest.get("provider_id"),
+        "manifest_hash": manifest_hash,
+        "manifest": canonical_payload(manifest),
+        "registry_row": registry_row,
+        "operator_actions": _required_manifest_actions(manifest),
+        "generated_at_utc": _utcnow(),
+    }
+    import_audit = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "qre_source_onboarding_import_audit",
+        "source_id": source_id,
+        "snapshot_id": snapshot_id,
+        "provider_id": manifest.get("provider_id"),
+        "manifest_hash": manifest_hash,
+        "data_fingerprint": metrics["data_fingerprint"],
+        "imported_row_count": metrics["raw_row_count"],
+        "unique_bar_count": metrics["unique_bar_count"],
+        "expected_bar_count": metrics["expected_bar_count"],
+        "coverage_ratio": metrics["coverage_ratio"],
+        "duplicate_row_count": metrics["exact_duplicate_row_count"],
+        "conflicting_duplicate_count": metrics["conflicting_row_count"],
+        "invalid_row_count": metrics["invalid_row_count"],
+        "missing_required_columns": metrics["missing_required_columns"],
+        "source_tier": "SOURCE_BLOCKED",
+        "qualification_status": "PENDING_SOURCE_QUALIFICATION",
+        "policy_version": SOURCE_POLICY_VERSION,
+        "generated_at_utc": _utcnow(),
+    }
+    current_onboarding = _read_json(repo_root / ONBOARDING_DIR / "latest.json") or {"rows": []}
+    prior_rows = [
+        dict(row)
+        for row in current_onboarding.get("rows") or []
+        if not (str(row.get("source_id") or "") == source_id and str(row.get("snapshot_id") or "") == snapshot_id)
+    ]
+    onboarding_row = {
+        "source_id": source_id,
+        "snapshot_id": snapshot_id,
+        "provider_id": manifest.get("provider_id"),
+        "manifest_hash": manifest_hash,
+        "data_fingerprint": metrics["data_fingerprint"],
+        "operator_actions": _required_manifest_actions(manifest),
+    }
+    onboarding = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "qre_source_onboarding",
+        "operator_actions": _required_manifest_actions(manifest),
+        "rows": sorted([*prior_rows, onboarding_row], key=lambda row: (str(row.get("source_id") or ""), str(row.get("snapshot_id") or ""))),
+        "content_identity": content_id("qreonboard", {"manifest": manifest_hash, "fingerprint": metrics["data_fingerprint"], "snapshot": snapshot_id}),
+    }
+    payload = canonical_payload(
+        {
+            "source_manifest": source_manifest,
+            "import_audit": import_audit,
+            "onboarding": onboarding,
+            "snapshot": snapshot.__dict__ if hasattr(snapshot, "__dict__") else {
+                key: getattr(snapshot, key) for key in DatasetSnapshot.__dataclass_fields__
+            },
+            "dataset_catalog": {"datasets": [dataset]},
+        }
+    )
+    _write_json(repo_root / ONBOARDING_DIR / "source_manifest_latest.json", source_manifest)
+    _write_json(repo_root / ONBOARDING_DIR / f"{source_id}_{snapshot_id}_source_manifest.json", source_manifest)
+    _write_json(repo_root / ONBOARDING_DIR / "import_audit_latest.json", import_audit)
+    _write_json(repo_root / ONBOARDING_DIR / f"{source_id}_{snapshot_id}_import_audit.json", import_audit)
+    _write_json(repo_root / ONBOARDING_DIR / "latest.json", onboarding)
+    _write_json(repo_root / ONBOARDING_DIR / f"{source_id}_{snapshot_id}_catalog.json", {"schema_version": SCHEMA_VERSION, "datasets": [dataset]})
+    return payload
+
+
+def _load_onboarded_manifest(repo_root: Path, source_id: str | None = None) -> dict[str, Any] | None:
+    payload = _read_json(repo_root / ONBOARDING_DIR / "source_manifest_latest.json")
+    if payload is not None and (source_id is None or str(payload.get("source_id") or "") == source_id):
+        return payload
+    if source_id is None:
+        return None
+    matches = sorted((repo_root / ONBOARDING_DIR).glob(f"{source_id}_*_source_manifest.json"))
+    for match in matches:
+        payload = _read_json(match)
+        if payload is not None and str(payload.get("source_id") or "") == source_id:
+            return payload
+    return None
+
+
+def qualify_onboarded_source(*, repo_root: Path, source_id: str, snapshot_id: str | None = None) -> dict[str, Any]:
+    manifest_payload = _load_onboarded_manifest(repo_root, source_id)
+    if manifest_payload is None:
+        raise FileNotFoundError(f"missing_source_manifest: {source_id}")
+    catalog_path = repo_root / ONBOARDING_DIR / f"{source_id}_{snapshot_id or manifest_payload.get('snapshot_id')}_catalog.json"
+    catalog = _read_json(catalog_path)
+    if catalog is None:
+        raise FileNotFoundError(f"missing_onboarding_catalog: {catalog_path}")
+    registry_row = dict(manifest_payload.get("registry_row") or {})
+    policy = {
+        "current_yfinance_status": "manual_research_only",
+        "content_identity": content_id("qsp", {"onboarded_source": source_id, "manifest": manifest_payload.get("manifest_hash")}),
+        "policy_version": SOURCE_POLICY_VERSION,
+    }
+    qualification = qualify_datasets(
+        repo_root=repo_root,
+        dataset_catalog=catalog,
+        policy_reconciliation=policy,
+        extra_manifest_rows=[registry_row],
+    )
+    rows = qualification.get("rows") or []
+    row = dict(rows[0]) if rows else {}
+    source_certification = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "qre_source_certification",
+        "source_id": source_id,
+        "snapshot_id": snapshot_id or manifest_payload.get("snapshot_id"),
+        "qualification_status": row.get("qualification_status"),
+        "source_tier": row.get("allowed_evidence_tier"),
+        "blocked_reasons": row.get("reason_codes") or [],
+        "operator_actions": _operator_actions_for_reasons(row.get("reason_codes") or []),
+        "policy_version": SOURCE_POLICY_VERSION,
+        "content_identity": content_id("qresourcecert", row),
+        "generated_at_utc": _utcnow(),
+    }
+    blockers = list(row.get("reason_codes") or [])
+    resolution_row = {
+        "resolution_id": content_id("qsr", {"source": source_id, "snapshot": snapshot_id or manifest_payload.get("snapshot_id"), "blockers": blockers}),
+        "requirement_id": "qre_source_onboarding",
+        "candidate_sources": [source_id],
+        "selected_source": source_id,
+        "selected_snapshot": snapshot_id or manifest_payload.get("snapshot_id"),
+        "current_source_tier": row.get("allowed_evidence_tier"),
+        "target_source_tier": "SOURCE_SCREENING_ELIGIBLE",
+        "qualification_actions": ["use_onboarded_local_snapshot"],
+        "credential_requirements": [],
+        "license_requirements": ["operator_license_attestation"] if "source_license_not_screening_eligible" in blockers else [],
+        "cross_source_requirements": [],
+        "unresolved_blockers": blockers,
+        "operator_action_required": bool(source_certification["operator_actions"]),
+        "automatic_actions_allowed": not bool(source_certification["operator_actions"]),
+        "trading_authority": False,
+    }
+    resolution_row["content_identity"] = content_id("qsrc", resolution_row)
+    resolution = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "qre_alpha_source_resolution",
+        "rows": [resolution_row],
+        "content_identity": content_id("qsrset", resolution_row),
+    }
+    onboarding = _read_json(repo_root / ONBOARDING_DIR / "latest.json") or {"rows": []}
+    for onboarding_row in onboarding.get("rows") or []:
+        if str(onboarding_row.get("source_id") or "") != source_id:
+            continue
+        if snapshot_id is not None and str(onboarding_row.get("snapshot_id") or "") != snapshot_id:
+            continue
+        onboarding_row["qualification_status"] = row.get("qualification_status")
+        onboarding_row["source_tier"] = row.get("allowed_evidence_tier")
+        onboarding_row["blocked_reasons"] = row.get("reason_codes") or []
+        onboarding_row["operator_actions"] = source_certification["operator_actions"]
+        onboarding["operator_actions"] = source_certification["operator_actions"]
+    if onboarding.get("rows"):
+        onboarding["content_identity"] = content_id("qreonboard", onboarding["rows"])
+    _write_json(repo_root / SOURCE_QUALIFICATIONS_PATH, qualification)
+    _write_json(repo_root / SOURCE_CERTIFICATION_PATH, source_certification)
+    _write_json(repo_root / SOURCE_RESOLUTION_PATH, resolution)
+    _write_json(repo_root / ONBOARDING_DIR / "latest.json", onboarding)
+    return canonical_payload(
+        {
+            "source_qualification": qualification,
+            "source_certification": source_certification,
+            "source_resolution": resolution,
+            "onboarding": onboarding,
+        }
+    )
+
+
+def _operator_actions_for_reasons(reasons: list[str] | tuple[str, ...]) -> list[str]:
+    actions = []
+    mapping = {
+        "source_license_not_screening_eligible": "provide_screening_license_attestation",
+        "missing_calendar": "provide_supported_calendar",
+        "missing_expected_bar_count": "provide_supported_calendar",
+        "insufficient_coverage": "provide_more_complete_bars",
+        "conflicting_rows_present": "repair_conflicting_duplicate_bars",
+        "duplicate_bar_ratio_too_high": "deduplicate_source_export",
+    }
+    for reason in reasons:
+        action = mapping.get(str(reason))
+        if action:
+            actions.append(action)
+    return sorted(dict.fromkeys(actions))
+
+
+def summarize_onboarding(*, repo_root: Path) -> dict[str, Any]:
+    onboarding = _read_json(repo_root / ONBOARDING_DIR / "latest.json") or {"rows": []}
+    qualifications = _read_json(repo_root / SOURCE_QUALIFICATIONS_PATH) or {"rows": []}
+    rows = [dict(row) for row in qualifications.get("rows") or [] if isinstance(row, dict)]
+    reason_counts = Counter(reason for row in rows for reason in row.get("reason_codes") or [])
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "qre_source_onboarding_summary",
+        "summary": {
+            "source_count": len({str(row.get("source_id") or "") for row in onboarding.get("rows") or [] if str(row.get("source_id") or "")}),
+            "snapshot_count": len(rows),
+            "screening_eligible_count": sum(1 for row in rows if row.get("allowed_evidence_tier") == "SOURCE_SCREENING_ELIGIBLE"),
+            "validation_eligible_count": sum(1 for row in rows if row.get("allowed_evidence_tier") == "SOURCE_VALIDATION_ELIGIBLE"),
+            "blocked_count": sum(1 for row in rows if row.get("allowed_evidence_tier") == "SOURCE_BLOCKED"),
+            "blocked_reasons": dict(sorted(reason_counts.items())),
+        },
+        "rows": onboarding.get("rows") or [],
+        "content_identity": content_id("qreonboardsummary", {"rows": onboarding.get("rows") or [], "qualifications": rows}),
+    }
+    return canonical_payload(payload)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m research.qre_source_onboarding")
+    sub = parser.add_subparsers(dest="command", required=True)
+    validate = sub.add_parser("validate-manifest")
+    validate.add_argument("--manifest", required=True)
+    local = sub.add_parser("import-local")
+    local.add_argument("--manifest", required=True)
+    local.add_argument("--bars", required=True)
+    local.add_argument("--out", required=True)
+    local.add_argument("--snapshot-id")
+    local.add_argument("--repo-root", default=".")
+    qualify = sub.add_parser("qualify")
+    qualify.add_argument("--source-id", required=True)
+    qualify.add_argument("--snapshot-id")
+    qualify.add_argument("--repo-root", default=".")
+    audit = sub.add_parser("audit")
+    audit.add_argument("--source-id", required=True)
+    audit.add_argument("--repo-root", default=".")
+    summarize = sub.add_parser("summarize")
+    summarize.add_argument("--repo-root", default=".")
+    args = parser.parse_args(argv)
+    if args.command == "validate-manifest":
+        payload = validate_manifest_file(Path(args.manifest))
+    elif args.command == "import-local":
+        payload = import_local_source(
+            repo_root=Path(args.repo_root),
+            manifest_path=Path(args.manifest),
+            bars_path=Path(args.bars),
+            out_dir=Path(args.out),
+            snapshot_id=args.snapshot_id,
+        )
+    elif args.command == "qualify":
+        payload = qualify_onboarded_source(repo_root=Path(args.repo_root), source_id=args.source_id, snapshot_id=args.snapshot_id)
+    elif args.command == "audit":
+        payload = _read_json(Path(args.repo_root) / SOURCE_CERTIFICATION_PATH) or {}
+    else:
+        payload = summarize_onboarding(repo_root=Path(args.repo_root))
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+__all__ = [
+    "import_local_source",
+    "main",
+    "qualify_onboarded_source",
+    "summarize_onboarding",
+    "validate_manifest_file",
+]

--- a/tests/fixtures/source_onboarding/crypto_24_7_conflicts/manifest.yaml
+++ b/tests/fixtures/source_onboarding/crypto_24_7_conflicts/manifest.yaml
@@ -1,0 +1,34 @@
+schema_version: qre_source_manifest_v1
+source_id: local_crypto_conflict_fixture
+provider_id: local_file
+source_family: crypto
+asset_class: crypto
+venue: LOCAL_FIXTURE
+source_status: quality_gated
+allowed_use:
+  - manual_research
+  - research_screening
+license_policy_status: PASS
+calendar:
+  type: crypto_24_7
+  timezone: UTC
+data:
+  schema: ohlcv
+  adjusted: false
+  timestamp_column: timestamp
+  symbol_column: symbol
+  open_column: open
+  high_column: high
+  low_column: low
+  close_column: close
+  volume_column: volume
+timeframes:
+  - 1h
+timeframe: 1h
+universe:
+  symbols:
+    - BTC-USD
+operator_license_attestation:
+  provided_by: test_operator
+  attested_at_utc: "2026-07-06T00:00:00Z"
+  evidence_ref: "test_license_reference_without_secret"

--- a/tests/fixtures/source_onboarding/crypto_24_7_good/manifest.yaml
+++ b/tests/fixtures/source_onboarding/crypto_24_7_good/manifest.yaml
@@ -1,0 +1,34 @@
+schema_version: qre_source_manifest_v1
+source_id: local_crypto_screening_fixture
+provider_id: local_file
+source_family: crypto
+asset_class: crypto
+venue: LOCAL_FIXTURE
+source_status: quality_gated
+allowed_use:
+  - manual_research
+  - research_screening
+license_policy_status: PASS
+calendar:
+  type: crypto_24_7
+  timezone: UTC
+data:
+  schema: ohlcv
+  adjusted: false
+  timestamp_column: timestamp
+  symbol_column: symbol
+  open_column: open
+  high_column: high
+  low_column: low
+  close_column: close
+  volume_column: volume
+timeframes:
+  - 1h
+timeframe: 1h
+universe:
+  symbols:
+    - BTC-USD
+operator_license_attestation:
+  provided_by: test_operator
+  attested_at_utc: "2026-07-06T00:00:00Z"
+  evidence_ref: "test_license_reference_without_secret"

--- a/tests/fixtures/source_onboarding/crypto_24_7_insufficient_coverage/manifest.yaml
+++ b/tests/fixtures/source_onboarding/crypto_24_7_insufficient_coverage/manifest.yaml
@@ -1,0 +1,34 @@
+schema_version: qre_source_manifest_v1
+source_id: local_crypto_low_coverage_fixture
+provider_id: local_file
+source_family: crypto
+asset_class: crypto
+venue: LOCAL_FIXTURE
+source_status: quality_gated
+allowed_use:
+  - manual_research
+  - research_screening
+license_policy_status: PASS
+calendar:
+  type: crypto_24_7
+  timezone: UTC
+data:
+  schema: ohlcv
+  adjusted: false
+  timestamp_column: timestamp
+  symbol_column: symbol
+  open_column: open
+  high_column: high
+  low_column: low
+  close_column: close
+  volume_column: volume
+timeframes:
+  - 1h
+timeframe: 1h
+universe:
+  symbols:
+    - BTC-USD
+operator_license_attestation:
+  provided_by: test_operator
+  attested_at_utc: "2026-07-06T00:00:00Z"
+  evidence_ref: "test_license_reference_without_secret"

--- a/tests/fixtures/source_onboarding/crypto_24_7_missing_license/manifest.yaml
+++ b/tests/fixtures/source_onboarding/crypto_24_7_missing_license/manifest.yaml
@@ -1,0 +1,29 @@
+schema_version: qre_source_manifest_v1
+source_id: local_crypto_missing_license_fixture
+provider_id: local_file
+source_family: crypto
+asset_class: crypto
+venue: LOCAL_FIXTURE
+source_status: quality_gated
+allowed_use:
+  - manual_research
+license_policy_status: UNKNOWN
+calendar:
+  type: crypto_24_7
+  timezone: UTC
+data:
+  schema: ohlcv
+  adjusted: false
+  timestamp_column: timestamp
+  symbol_column: symbol
+  open_column: open
+  high_column: high
+  low_column: low
+  close_column: close
+  volume_column: volume
+timeframes:
+  - 1h
+timeframe: 1h
+universe:
+  symbols:
+    - BTC-USD

--- a/tests/fixtures/source_onboarding/weekday_daily_good/manifest.yaml
+++ b/tests/fixtures/source_onboarding/weekday_daily_good/manifest.yaml
@@ -1,0 +1,34 @@
+schema_version: qre_source_manifest_v1
+source_id: local_weekday_screening_fixture
+provider_id: local_file
+source_family: equities
+asset_class: equities
+venue: LOCAL_FIXTURE
+source_status: quality_gated
+allowed_use:
+  - manual_research
+  - research_screening
+license_policy_status: PASS
+calendar:
+  type: weekday_daily
+  timezone: UTC
+data:
+  schema: ohlcv
+  adjusted: false
+  timestamp_column: timestamp
+  symbol_column: symbol
+  open_column: open
+  high_column: high
+  low_column: low
+  close_column: close
+  volume_column: volume
+timeframes:
+  - 1d
+timeframe: 1d
+universe:
+  symbols:
+    - TEST
+operator_license_attestation:
+  provided_by: test_operator
+  attested_at_utc: "2026-07-06T00:00:00Z"
+  evidence_ref: "test_license_reference_without_secret"

--- a/tests/unit/test_qre_source_onboarding.py
+++ b/tests/unit/test_qre_source_onboarding.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import yaml
+
+from packages.qre_research.alpha_discovery.source_qualification import (
+    SOURCE_BLOCKED,
+    SOURCE_SCREENING_ELIGIBLE,
+)
+from research.qre_source_onboarding import (
+    import_local_source,
+    qualify_onboarded_source,
+    summarize_onboarding,
+    validate_manifest_file,
+)
+
+FIXTURES = Path("tests/fixtures/source_onboarding")
+
+
+def _write_crypto_bars(path: Path, *, count: int = 48, reverse: bool = False, conflict: bool = False) -> None:
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    rows = []
+    for idx in range(count):
+        ts = start + timedelta(hours=idx)
+        rows.append(
+            {
+                "timestamp": ts.isoformat().replace("+00:00", "Z"),
+                "symbol": "BTC-USD",
+                "open": 100 + idx,
+                "high": 101 + idx,
+                "low": 99 + idx,
+                "close": 100.5 + idx,
+                "volume": 10 + idx,
+            }
+        )
+    if conflict:
+        rows.append({**rows[0], "close": 100.75})
+    if reverse:
+        rows = list(reversed(rows))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["timestamp", "symbol", "open", "high", "low", "close", "volume"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_weekday_bars(path: Path, *, count: int = 48) -> None:
+    current = datetime(2026, 1, 1, tzinfo=UTC)
+    rows = []
+    while len(rows) < count:
+        if current.weekday() < 5:
+            idx = len(rows)
+            rows.append(
+                {
+                    "timestamp": current.isoformat().replace("+00:00", "Z"),
+                    "symbol": "TEST",
+                    "open": 50 + idx,
+                    "high": 51 + idx,
+                    "low": 49 + idx,
+                    "close": 50.5 + idx,
+                    "volume": 100 + idx,
+                }
+            )
+        current += timedelta(days=1)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["timestamp", "symbol", "open", "high", "low", "close", "volume"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_manifest_validation_reports_missing_license_attestation() -> None:
+    result = validate_manifest_file(FIXTURES / "crypto_24_7_missing_license" / "manifest.yaml")
+
+    assert result["valid"] is False
+    assert "missing_license_attestation" in result["operator_actions"]
+    assert "provide_screening_license_attestation" in result["operator_actions"]
+
+
+def test_local_import_and_qualification_promotes_good_crypto_fixture(tmp_path: Path) -> None:
+    bars = tmp_path / "bars.csv"
+    _write_crypto_bars(bars)
+
+    imported = import_local_source(
+        repo_root=tmp_path,
+        manifest_path=FIXTURES / "crypto_24_7_good" / "manifest.yaml",
+        bars_path=bars,
+        out_dir=tmp_path / "generated_research/data_catalog/imports/local_crypto_screening_fixture/snap-good",
+        snapshot_id="snap-good",
+    )
+    qualified = qualify_onboarded_source(repo_root=tmp_path, source_id="local_crypto_screening_fixture", snapshot_id="snap-good")
+    row = qualified["source_qualification"]["rows"][0]
+    resolution_row = qualified["source_resolution"]["rows"][0]
+
+    assert imported["import_audit"]["unique_bar_count"] == 48
+    assert imported["import_audit"]["expected_bar_count"] == 48
+    assert imported["import_audit"]["coverage_ratio"] == 1.0
+    assert row["allowed_evidence_tier"] == SOURCE_SCREENING_ELIGIBLE
+    assert row["reason_codes"] == []
+    assert resolution_row["trading_authority"] is False
+    assert resolution_row["operator_action_required"] is False
+
+
+def test_missing_license_fixture_stays_blocked_without_false_promotion(tmp_path: Path) -> None:
+    bars = tmp_path / "bars.csv"
+    _write_crypto_bars(bars)
+
+    import_local_source(
+        repo_root=tmp_path,
+        manifest_path=FIXTURES / "crypto_24_7_missing_license" / "manifest.yaml",
+        bars_path=bars,
+        out_dir=tmp_path / "generated_research/data_catalog/imports/local_crypto_missing_license_fixture/snap-missing-license",
+        snapshot_id="snap-missing-license",
+    )
+    qualified = qualify_onboarded_source(repo_root=tmp_path, source_id="local_crypto_missing_license_fixture", snapshot_id="snap-missing-license")
+    row = qualified["source_qualification"]["rows"][0]
+
+    assert row["allowed_evidence_tier"] == SOURCE_BLOCKED
+    assert "source_license_not_screening_eligible" in row["reason_codes"]
+    assert qualified["onboarding"]["operator_actions"] == ["provide_screening_license_attestation"]
+
+
+def test_bad_coverage_and_conflicting_duplicates_block(tmp_path: Path) -> None:
+    low_bars = tmp_path / "low.csv"
+    conflict_bars = tmp_path / "conflict.csv"
+    _write_crypto_bars(low_bars, count=40)
+    _write_crypto_bars(conflict_bars, conflict=True)
+
+    import_local_source(
+        repo_root=tmp_path,
+        manifest_path=FIXTURES / "crypto_24_7_insufficient_coverage" / "manifest.yaml",
+        bars_path=low_bars,
+        out_dir=tmp_path / "generated_research/data_catalog/imports/local_crypto_low_coverage_fixture/snap-low",
+        snapshot_id="snap-low",
+        requested_end="2026-01-02T23:00:00Z",
+    )
+    low = qualify_onboarded_source(repo_root=tmp_path, source_id="local_crypto_low_coverage_fixture", snapshot_id="snap-low")
+
+    import_local_source(
+        repo_root=tmp_path,
+        manifest_path=FIXTURES / "crypto_24_7_conflicts" / "manifest.yaml",
+        bars_path=conflict_bars,
+        out_dir=tmp_path / "generated_research/data_catalog/imports/local_crypto_conflict_fixture/snap-conflict",
+        snapshot_id="snap-conflict",
+    )
+    conflict = qualify_onboarded_source(repo_root=tmp_path, source_id="local_crypto_conflict_fixture", snapshot_id="snap-conflict")
+
+    assert "insufficient_coverage" in low["source_qualification"]["rows"][0]["reason_codes"]
+    assert "conflicting_rows_present" in conflict["source_qualification"]["rows"][0]["reason_codes"]
+
+
+def test_weekday_daily_fixture_is_supported(tmp_path: Path) -> None:
+    bars = tmp_path / "weekday.csv"
+    _write_weekday_bars(bars)
+
+    imported = import_local_source(
+        repo_root=tmp_path,
+        manifest_path=FIXTURES / "weekday_daily_good" / "manifest.yaml",
+        bars_path=bars,
+        out_dir=tmp_path / "generated_research/data_catalog/imports/local_weekday_screening_fixture/snap-weekday",
+        snapshot_id="snap-weekday",
+    )
+    qualified = qualify_onboarded_source(repo_root=tmp_path, source_id="local_weekday_screening_fixture", snapshot_id="snap-weekday")
+
+    assert imported["import_audit"]["expected_bar_count"] == 48
+    assert qualified["source_qualification"]["rows"][0]["allowed_evidence_tier"] == SOURCE_SCREENING_ELIGIBLE
+
+
+def test_onboarding_identity_is_order_root_mtime_and_manifest_order_deterministic(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    bars_a = root_a / "bars.csv"
+    bars_b = root_b / "bars.csv"
+    _write_crypto_bars(bars_a)
+    _write_crypto_bars(bars_b, reverse=True)
+    os.utime(bars_b, (1_800_000_000, 1_800_000_000))
+
+    first = import_local_source(
+        repo_root=root_a,
+        manifest_path=FIXTURES / "crypto_24_7_good" / "manifest.yaml",
+        bars_path=bars_a,
+        out_dir=root_a / "generated_research/data_catalog/imports/local_crypto_screening_fixture/snap-deterministic",
+        snapshot_id="snap-deterministic",
+    )
+    original_manifest = yaml.safe_load((FIXTURES / "crypto_24_7_good" / "manifest.yaml").read_text(encoding="utf-8"))
+    reordered_manifest = root_b / "manifest.yaml"
+    reordered_manifest.parent.mkdir(parents=True, exist_ok=True)
+    reordered_manifest.write_text(yaml.safe_dump(dict(reversed(list(original_manifest.items()))), sort_keys=False), encoding="utf-8")
+    second = import_local_source(
+        repo_root=root_b,
+        manifest_path=reordered_manifest,
+        bars_path=bars_b,
+        out_dir=root_b / "generated_research/data_catalog/imports/local_crypto_screening_fixture/snap-deterministic",
+        snapshot_id="snap-deterministic",
+    )
+
+    assert first["source_manifest"]["manifest_hash"] == second["source_manifest"]["manifest_hash"]
+    assert first["import_audit"]["data_fingerprint"] == second["import_audit"]["data_fingerprint"]
+    assert first["snapshot"]["content_identity"] == second["snapshot"]["content_identity"]
+
+
+def test_fake_secret_is_not_written_to_outputs(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("QRE_DATABENTO_API_KEY", "fake-secret-value")
+    bars = tmp_path / "bars.csv"
+    _write_crypto_bars(bars)
+
+    payload = import_local_source(
+        repo_root=tmp_path,
+        manifest_path=FIXTURES / "crypto_24_7_good" / "manifest.yaml",
+        bars_path=bars,
+        out_dir=tmp_path / "generated_research/data_catalog/imports/local_crypto_screening_fixture/snap-secret",
+        snapshot_id="snap-secret",
+    )
+
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "fake-secret-value" not in serialized
+
+
+def test_summarize_reports_current_onboarding_state(tmp_path: Path) -> None:
+    bars = tmp_path / "bars.csv"
+    _write_crypto_bars(bars)
+    import_local_source(
+        repo_root=tmp_path,
+        manifest_path=FIXTURES / "crypto_24_7_good" / "manifest.yaml",
+        bars_path=bars,
+        out_dir=tmp_path / "generated_research/data_catalog/imports/local_crypto_screening_fixture/snap-summary",
+        snapshot_id="snap-summary",
+    )
+    qualify_onboarded_source(repo_root=tmp_path, source_id="local_crypto_screening_fixture", snapshot_id="snap-summary")
+
+    summary = summarize_onboarding(repo_root=tmp_path)
+
+    assert summary["summary"]["source_count"] == 1
+    assert summary["summary"]["screening_eligible_count"] == 1


### PR DESCRIPTION
## Summary
- Adds a source-agnostic QRE onboarding CLI for operator-supplied local OHLCV exports and declarative manifests.
- Validates license attestation boundaries, normalizes CSV bars, computes deterministic coverage/quality metrics, and feeds existing PR #736 source qualification policy through explicit onboarding manifest rows.
- Writes namespaced onboarding/source-certification artifacts and source qualification/resolution outputs without provider calls or trading authority.

## Safety
- No live/paper/shadow/Step 5/trading-agent activation.
- No provider calls or credentials in CI.
- Missing license attestation remains blocked with `source_license_not_screening_eligible`.
- Existing yfinance data remains blocked; no manual or hardcoded promotion.

## Local Proof
- `python -m ruff check .` passed.
- `python scripts/governance_lint.py` passed.
- `python -m pytest tests/unit/test_qre_source_onboarding.py -q` passed: 8.
- `python -m pytest tests/unit/test_qre_alpha_source_qualification.py -q` passed: 7.
- `python -m pytest tests/unit/test_qre_alpha_snapshot_resolution.py -q` passed: 3.
- `python -m pytest tests/unit/test_qre_snapshot_lineage_determinism.py -q` passed: 4.
- `python -m pytest tests/unit/test_qre_research_supervisor.py -q` passed: 18.
- `python -m pytest tests/architecture -q` passed: 164.
- `git diff --check` passed.
- `python -m pytest tests/unit -q` timed out locally after 1204 seconds with no visible pytest failure output; generated test artifacts were cleaned. GitHub unit check must pass before merge.