### PR TITLE
fix: restore qre source onboarding cli entrypoint

### DIFF
--- a/research/qre_source_onboarding.py
+++ b/research/qre_source_onboarding.py
@@ -686,3 +686,7 @@ __all__ = [
     "summarize_onboarding",
     "validate_manifest_file",
 ]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_source_onboarding.py
+++ b/tests/unit/test_qre_source_onboarding.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import csv
 import json
 import os
+import subprocess
+import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -80,6 +82,26 @@ def test_manifest_validation_reports_missing_license_attestation() -> None:
     assert result["valid"] is False
     assert "missing_license_attestation" in result["operator_actions"]
     assert "provide_screening_license_attestation" in result["operator_actions"]
+
+
+def test_cli_module_entrypoint_emits_json() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "research.qre_source_onboarding",
+            "validate-manifest",
+            "--manifest",
+            str(FIXTURES / "crypto_24_7_good" / "manifest.yaml"),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["valid"] is True
+    assert payload["source_id"] == "local_crypto_screening_fixture"
 
 
 def test_local_import_and_qualification_promotes_good_crypto_fixture(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Restores the `python -m research.qre_source_onboarding ...` module entrypoint after the PR #737 package-boundary move.
- Adds a subprocess regression test that requires JSON stdout from the real module invocation.

## Root Cause
The implementation was moved from `packages/qre_research/source_onboarding.py` into `research/qre_source_onboarding.py` to satisfy architecture boundaries, but the thin wrapper entrypoint was deleted during the move. Direct function tests passed, while `python -m` silently exited without invoking `main()`.

## Local Proof
- Red test before fix: `test_cli_module_entrypoint_emits_json` failed because stdout was empty.
- `python -m pytest tests/unit/test_qre_source_onboarding.py -q` passed: 9.
- `python -m ruff check .` passed.
- `python scripts/governance_lint.py` passed.
- `python -m pytest tests/unit/test_qre_alpha_source_qualification.py tests/unit/test_qre_alpha_snapshot_resolution.py tests/unit/test_qre_snapshot_lineage_determinism.py tests/unit/test_qre_research_supervisor.py -q` passed: 32.
- `python -m pytest tests/architecture -q` passed: 164.
- `git diff --check` passed.

## Safety
No provider calls, no secrets, no trading-agent start, no paper/shadow/live, no artifact mutation beyond tests.