### PR TITLE
fix: guard operator source onboarding readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,11 @@ research/run_*.v1.json
 research/*_latest.v1.json
 research/*_latest.md
 logs/research/*.jsonl
+data/imports/
+generated_research/data_catalog/imports/
+generated_research/data_catalog/onboarding/
+generated_research/data_catalog/revisions/
+generated_research/data_catalog/source_certification/
 
 # Future-proof (V3.3b resumability)
 research/resume/

--- a/docs/governance/qre_source_onboarding_harness.md
+++ b/docs/governance/qre_source_onboarding_harness.md
@@ -21,9 +21,19 @@ Screening is allowed only when all of these are true:
 - `allowed_use` contains `research_screening`
 - `license_policy_status` is `PASS`
 - `operator_license_attestation` is present with `provided_by`, `attested_at_utc`, and a non-secret `evidence_ref`
+- `source_status` is explicitly set to `quality_gated`, `screening_ready`, or `certified`
 - imported bars satisfy the existing `qre_alpha_source_qualification_pr4_v1` metrics and thresholds
 
-Missing license proof maps to `source_license_not_screening_eligible` and operator action `provide_screening_license_attestation`.
+For local CSV onboarding, the minimal screening manifest is a manual local-source
+manifest plus `allowed_use: [manual_research, research_screening]`,
+`license_policy_status: PASS`, `source_status: quality_gated`, and a non-secret
+`operator_license_attestation.evidence_ref`. Missing license proof maps to
+`source_license_not_screening_eligible` and operator action
+`provide_screening_license_attestation`; missing or non-screening `source_status`
+is reported by `validate-manifest` before qualification.
+
+Manual-research-only manifests remain allowed as manual-only sources. They are
+not automatically promoted to screening, even when the local bars are coherent.
 
 ## Local File Adapter
 
@@ -54,6 +64,16 @@ The harness writes only QRE onboarding and qualification artifacts:
 - `generated_research/alpha_discovery/source_resolution/latest.json`
 
 Artifacts include manifest hash, data fingerprint, row counts, expected bars, coverage, duplicate/conflict metrics, invalid row metrics, qualification tier, blocked reasons, operator actions, policy version, and generation time.
+
+Local data imports and generated research/catalog artifacts are operator-local
+state and should not be committed. This includes raw CSV exports, normalized
+local import directories, onboarding JSON, source-certification JSON, and source
+resolution or qualification outputs generated from a local import.
+
+`SOURCE_SCREENING_ELIGIBLE` means the immutable local snapshot may be used for
+research screening under the source qualification policy. It is not shadow,
+paper, live, broker, risk, execution, or trading authority; source resolution
+continues to emit `trading_authority: false`.
 
 ## Secrets
 

--- a/research/qre_source_onboarding.py
+++ b/research/qre_source_onboarding.py
@@ -35,6 +35,7 @@ SECRET_ENV_VARS = (
     "QRE_NASDAQ_DATA_LINK_API_KEY",
     "QRE_ALPHA_VANTAGE_API_KEY",
 )
+SCREENING_SOURCE_STATUSES = frozenset({"quality_gated", "screening_ready", "certified"})
 
 
 def _utcnow() -> str:
@@ -93,15 +94,20 @@ def _required_manifest_actions(manifest: dict[str, Any]) -> list[str]:
     for key in ("timestamp_column", "symbol_column", "open_column", "high_column", "low_column", "close_column", "volume_column"):
         if not data.get(key):
             actions.append(f"missing_{key}")
-    allowed_use = {str(value) for value in manifest.get("allowed_use") or []}
+    allowed_use = {str(value).lower() for value in manifest.get("allowed_use") or []}
     license_status = str(manifest.get("license_policy_status") or "").upper()
     attestation = manifest.get("operator_license_attestation") if isinstance(manifest.get("operator_license_attestation"), dict) else {}
-    if "research_screening" in allowed_use and (license_status != "PASS" or not attestation):
-        actions.append("missing_license_attestation")
-        actions.append("provide_screening_license_attestation")
-    if "research_screening" not in allowed_use:
-        actions.append("missing_license_attestation")
-        actions.append("provide_screening_license_attestation")
+    if "research_screening" in allowed_use:
+        source_status = str(manifest.get("source_status") or "").lower()
+        if license_status != "PASS" or not attestation or not attestation.get("evidence_ref"):
+            actions.append("missing_license_attestation")
+            actions.append("provide_screening_license_attestation")
+        if not source_status:
+            actions.append("missing_source_status")
+            actions.append("set_screening_source_status")
+        elif source_status not in SCREENING_SOURCE_STATUSES:
+            actions.append("invalid_screening_source_status")
+            actions.append("set_screening_source_status")
     return sorted(dict.fromkeys(actions))
 
 

--- a/tests/unit/test_qre_source_onboarding.py
+++ b/tests/unit/test_qre_source_onboarding.py
@@ -76,12 +76,39 @@ def _write_weekday_bars(path: Path, *, count: int = 48) -> None:
         writer.writerows(rows)
 
 
-def test_manifest_validation_reports_missing_license_attestation() -> None:
+def test_manual_only_manifest_validation_does_not_request_screening_attestation() -> None:
     result = validate_manifest_file(FIXTURES / "crypto_24_7_missing_license" / "manifest.yaml")
 
+    assert result["valid"] is True
+    assert "missing_license_attestation" not in result["operator_actions"]
+    assert "provide_screening_license_attestation" not in result["operator_actions"]
+
+
+def test_screening_manifest_validation_requires_explicit_source_status(tmp_path: Path) -> None:
+    manifest = yaml.safe_load((FIXTURES / "crypto_24_7_good" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest.pop("source_status")
+    path = tmp_path / "manifest.yaml"
+    path.write_text(yaml.safe_dump(manifest, sort_keys=True), encoding="utf-8")
+
+    result = validate_manifest_file(path)
+
     assert result["valid"] is False
-    assert "missing_license_attestation" in result["operator_actions"]
-    assert "provide_screening_license_attestation" in result["operator_actions"]
+    assert "missing_source_status" in result["operator_actions"]
+    assert "set_screening_source_status" in result["operator_actions"]
+    assert "provide_screening_license_attestation" not in result["operator_actions"]
+
+
+def test_screening_manifest_validation_rejects_manual_only_source_status(tmp_path: Path) -> None:
+    manifest = yaml.safe_load((FIXTURES / "crypto_24_7_good" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest["source_status"] = "manual_research_only"
+    path = tmp_path / "manifest.yaml"
+    path.write_text(yaml.safe_dump(manifest, sort_keys=True), encoding="utf-8")
+
+    result = validate_manifest_file(path)
+
+    assert result["valid"] is False
+    assert "invalid_screening_source_status" in result["operator_actions"]
+    assert "set_screening_source_status" in result["operator_actions"]
 
 
 def test_cli_module_entrypoint_emits_json() -> None:
@@ -145,6 +172,34 @@ def test_missing_license_fixture_stays_blocked_without_false_promotion(tmp_path:
     assert row["allowed_evidence_tier"] == SOURCE_BLOCKED
     assert "source_license_not_screening_eligible" in row["reason_codes"]
     assert qualified["onboarding"]["operator_actions"] == ["provide_screening_license_attestation"]
+
+
+def test_manual_research_only_source_with_pass_license_is_not_screening_promoted(tmp_path: Path) -> None:
+    bars = tmp_path / "bars.csv"
+    _write_crypto_bars(bars)
+    manifest = yaml.safe_load((FIXTURES / "crypto_24_7_good" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest["source_id"] = "local_crypto_manual_only_fixture"
+    manifest["source_status"] = "manual_research_only"
+    manifest["allowed_use"] = ["manual_research"]
+    manifest_path = tmp_path / "manual_only_manifest.yaml"
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=True), encoding="utf-8")
+
+    validation = validate_manifest_file(manifest_path)
+    import_local_source(
+        repo_root=tmp_path,
+        manifest_path=manifest_path,
+        bars_path=bars,
+        out_dir=tmp_path / "generated_research/data_catalog/imports/local_crypto_manual_only_fixture/snap-manual",
+        snapshot_id="snap-manual",
+    )
+    qualified = qualify_onboarded_source(repo_root=tmp_path, source_id="local_crypto_manual_only_fixture", snapshot_id="snap-manual")
+    row = qualified["source_qualification"]["rows"][0]
+    resolution_row = qualified["source_resolution"]["rows"][0]
+
+    assert validation["valid"] is True
+    assert row["allowed_evidence_tier"] == SOURCE_BLOCKED
+    assert "source_license_not_screening_eligible" in row["reason_codes"]
+    assert resolution_row["trading_authority"] is False
 
 
 def test_bad_coverage_and_conflicting_duplicates_block(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make screening-requested local source manifests surface missing/invalid source_status during validation
- require explicit operator license attestation evidence for screening validation
- document local-source screening requirements and non-trading boundary
- ignore local operator import/onboarding/certification artifacts

## Validation
- python -m pytest tests/unit/test_qre_source_onboarding.py -q
- python -m ruff check research/qre_source_onboarding.py tests/unit/test_qre_source_onboarding.py
- git diff --check

## Safety
- code/tests/docs only
- no provider data
- no credentials
- no generated local import artifacts
- no shadow/paper/live/trading activation