### PR TITLE
research: add split-adjusted Tiingo hypothesis profiles

### DIFF
--- a/research/qre_tiingo_hypothesis_generator_e2e.py
+++ b/research/qre_tiingo_hypothesis_generator_e2e.py
@@ -24,6 +24,9 @@ DEFAULT_OUTPUT_DIR = Path("logs/qre_tiingo_hypothesis_generator_e2e")
 EXPECTED_UNIVERSE = ("SPY", "QQQ", "IWM", "DIA", "TLT", "GLD", "XLK", "XLF", "XLE", "XLV")
 OLD_CONTROLLED_UNIVERSE = frozenset({"AAPL", "ADYEN", "ASML", "EWJ", "MSFT", "SONY", "TM"})
 REQUIRED_COLUMNS = ("symbol", "date", "open", "high", "low", "close", "volume")
+RESEARCH_PRICE_COLUMNS = ("open", "high", "low", "close")
+COMMON_SPLIT_RATIOS = (2.0, 3.0, 4.0, 1.5)
+SPLIT_RATIO_TOLERANCE = 0.08
 SAFE_FLAGS = {
     "network_called": False,
     "run_research_called": False,
@@ -235,6 +238,99 @@ def _daily_returns(closes: list[float]) -> list[float]:
     return returns
 
 
+def _research_price(row: dict[str, Any], field: str) -> float:
+    adjusted_key = f"adjusted_{field}_for_research"
+    return float(row.get(adjusted_key, row[field]))
+
+
+def _nearest_common_split_ratio(ratio: float) -> float | None:
+    candidates = tuple(COMMON_SPLIT_RATIOS) + tuple(1.0 / value for value in COMMON_SPLIT_RATIOS)
+    for candidate in candidates:
+        if abs(ratio - candidate) / candidate <= SPLIT_RATIO_TOLERANCE:
+            return candidate
+    return None
+
+
+def _ohlc_ratios(previous: dict[str, Any], current: dict[str, Any]) -> dict[str, float] | None:
+    ratios: dict[str, float] = {}
+    for field in RESEARCH_PRICE_COLUMNS:
+        current_value = float(current[field])
+        if current_value <= 0:
+            return None
+        ratios[field] = float(previous[field]) / current_value
+    return ratios
+
+
+def _confirmed_split_ratio(ratios: dict[str, float]) -> float | None:
+    close_ratio = ratios["close"]
+    matched = _nearest_common_split_ratio(close_ratio)
+    if matched is None:
+        return None
+    return matched if all(abs(value - matched) / matched <= SPLIT_RATIO_TOLERANCE for value in ratios.values()) else None
+
+
+def _is_unresolved_discontinuity(ratios: dict[str, float]) -> bool:
+    return _nearest_common_split_ratio(ratios["close"]) is not None
+
+
+def apply_research_price_continuity(
+    bars: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, list[str]]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in bars:
+        grouped[str(row["symbol"])].append(dict(row))
+
+    adjusted: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    unresolved: dict[str, list[str]] = {}
+    for symbol in sorted(grouped):
+        rows = sorted(grouped[symbol], key=lambda row: str(row["date"]))
+        factors = [1.0 for _row in rows]
+        symbol_events: list[dict[str, Any]] = []
+        symbol_unresolved: list[str] = []
+        for idx, (previous, current) in enumerate(pairwise(rows), start=1):
+            ratios = _ohlc_ratios(previous, current)
+            if ratios is None:
+                symbol_unresolved.append(f"{symbol}:{current['date']}:invalid_ohlc_ratio")
+                continue
+            split_ratio = _confirmed_split_ratio(ratios)
+            if split_ratio is not None:
+                adjustment_factor = 1.0 / split_ratio
+                for prior_idx in range(idx):
+                    factors[prior_idx] *= adjustment_factor
+                symbol_events.append(
+                    {
+                        "symbol": symbol,
+                        "event_type": "split_like_price_discontinuity",
+                        "effective_date": str(current["date"]),
+                        "previous_date": str(previous["date"]),
+                        "detected_ratio": ratios["close"],
+                        "matched_common_ratio": split_ratio,
+                        "research_adjustment_factor": adjustment_factor,
+                        "ohlc_ratio_confirmation": ratios,
+                    }
+                )
+            elif _is_unresolved_discontinuity(ratios):
+                symbol_unresolved.append(f"{symbol}:{current['date']}:unresolved_price_discontinuity")
+
+        if symbol_unresolved:
+            unresolved[symbol] = symbol_unresolved
+            continue
+        events.extend(symbol_events)
+        for row, factor in zip(rows, factors, strict=True):
+            normalized = dict(row)
+            for field in RESEARCH_PRICE_COLUMNS:
+                normalized[f"raw_{field}"] = float(row[field])
+                normalized[f"adjusted_{field}_for_research"] = float(row[field]) * factor
+            normalized["research_price_adjustment_factor"] = factor
+            normalized["research_price_is_adjusted"] = factor != 1.0
+            adjusted.append(normalized)
+
+    events.sort(key=lambda event: (event["symbol"], event["effective_date"]))
+    adjusted.sort(key=lambda row: (row["symbol"], row["date"]))
+    return adjusted, events, unresolved
+
+
 def _return_nd(closes: list[float], window: int) -> float | None:
     if len(closes) <= window or closes[-window - 1] <= 0:
         return None
@@ -313,6 +409,7 @@ def build_data_profile(
     source_snapshot_id: str = EXPECTED_SNAPSHOT_ID,
     source_tier: str = EXPECTED_SOURCE_TIER,
 ) -> dict[str, Any]:
+    bars, corporate_action_events, unresolved_discontinuities = apply_research_price_continuity(bars)
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in bars:
         if row["symbol"] in EXPECTED_UNIVERSE:
@@ -332,7 +429,7 @@ def build_data_profile(
     coverage_ratio = None if not expected_rows else round(row_count / expected_rows, 6)
 
     per_symbol_row_count = {symbol: len(grouped[symbol]) for symbol in universe}
-    closes = {symbol: [float(row["close"]) for row in grouped[symbol]] for symbol in universe}
+    closes = {symbol: [_research_price(row, "close") for row in grouped[symbol]] for symbol in universe}
     returns_by_symbol = {symbol: _daily_returns(closes[symbol]) for symbol in universe}
     return_20 = {symbol: _return_nd(closes[symbol], 20) for symbol in universe}
     return_60 = {symbol: _return_nd(closes[symbol], 60) for symbol in universe}
@@ -353,6 +450,19 @@ def build_data_profile(
         "date_end": date_end,
         "coverage_ratio": coverage_ratio,
         "per_symbol_row_count": per_symbol_row_count,
+        "raw_price_lineage": {
+            "raw_ohlc_columns": list(REQUIRED_COLUMNS),
+            "research_price_columns": [
+                "adjusted_open_for_research",
+                "adjusted_high_for_research",
+                "adjusted_low_for_research",
+                "adjusted_close_for_research",
+            ],
+            "raw_prices_preserved": True,
+        },
+        "corporate_action_events": corporate_action_events,
+        "adjusted_price_continuity_applied": bool(corporate_action_events),
+        "excluded_symbols_due_to_unresolved_discontinuities": unresolved_discontinuities,
         "per_symbol_return_20d": return_20,
         "per_symbol_return_60d": return_60,
         "per_symbol_return_120d": return_120,
@@ -372,7 +482,14 @@ def build_data_profile(
         "insufficient_history": any(count < 121 for count in per_symbol_row_count.values()) or not universe,
         "insufficient_cross_section": len(universe) < 3,
     }
-    fingerprint_basis = [{key: row[key] for key in REQUIRED_COLUMNS} for row in sorted(bars, key=lambda item: (item["symbol"], item["date"]))]
+    fingerprint_basis = [
+        {
+            **{key: row[key] for key in REQUIRED_COLUMNS},
+            "adjusted_close_for_research": row.get("adjusted_close_for_research"),
+            "research_price_adjustment_factor": row.get("research_price_adjustment_factor"),
+        }
+        for row in sorted(bars, key=lambda item: (item["symbol"], item["date"]))
+    ]
     profile["data_fingerprint"] = "sha256:" + _digest(fingerprint_basis, length=32)
     profile["data_profile_digest"] = "sha256:" + _digest(profile, length=32)
     return _stable_payload(profile)
@@ -493,13 +610,14 @@ def generate_hypotheses(profile: dict[str, Any], *, max_hypotheses: int) -> list
 
 def shuffled_returns_bars(bars: list[dict[str, Any]], *, seed: int) -> list[dict[str, Any]]:
     rng = random.Random(seed)
+    bars, _events, _unresolved = apply_research_price_continuity(bars)
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in bars:
         grouped[row["symbol"]].append(row)
     shuffled: list[dict[str, Any]] = []
     for symbol in sorted(grouped):
         rows = sorted(grouped[symbol], key=lambda row: row["date"])
-        closes = [float(row["close"]) for row in rows]
+        closes = [_research_price(row, "close") for row in rows]
         returns = _daily_returns(closes)
         rng.shuffle(returns)
         synthetic_close = [closes[0]]
@@ -510,7 +628,21 @@ def shuffled_returns_bars(bars: list[dict[str, Any]], *, seed: int) -> list[dict
             open_ = synthetic_close[idx - 1] if idx else close
             high = max(open_, close)
             low = min(open_, close)
-            shuffled.append({**row, "open": open_, "high": high, "low": low, "close": close})
+            shuffled.append(
+                {
+                    **row,
+                    "open": open_,
+                    "high": high,
+                    "low": low,
+                    "close": close,
+                    "adjusted_open_for_research": open_,
+                    "adjusted_high_for_research": high,
+                    "adjusted_low_for_research": low,
+                    "adjusted_close_for_research": close,
+                    "research_price_adjustment_factor": 1.0,
+                    "research_price_is_adjusted": False,
+                }
+            )
     return sorted(shuffled, key=lambda row: (row["symbol"], row["date"]))
 
 
@@ -715,6 +847,7 @@ def main(argv: list[str] | None = None) -> int:
 
 
 __all__ = [
+    "apply_research_price_continuity",
     "build_all_payload",
     "build_data_profile",
     "build_report",

--- a/tests/unit/test_qre_tiingo_hypothesis_generator_e2e.py
+++ b/tests/unit/test_qre_tiingo_hypothesis_generator_e2e.py
@@ -12,7 +12,9 @@ from research.qre_tiingo_hypothesis_generator_e2e import (
     EXPECTED_SOURCE_TIER,
     EXPECTED_UNIVERSE,
     SAFE_FLAGS,
+    apply_research_price_continuity,
     build_report,
+    load_tiingo_bars,
     write_outputs,
 )
 
@@ -44,7 +46,18 @@ def _write_resolution(
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _write_fixture_bars(root: Path, *, symbols: tuple[str, ...] = ("SPY", "QQQ", "TLT", "GLD", "XLK"), days: int = 130) -> None:
+def _write_fixture_bars(
+    root: Path,
+    *,
+    symbols: tuple[str, ...] = ("SPY", "QQQ", "TLT", "GLD", "XLK"),
+    days: int = 130,
+    start: date = date(2021, 1, 4),
+    split_symbols: tuple[str, ...] = (),
+    split_date: date = date(2025, 12, 5),
+    unresolved_symbol: str | None = None,
+    unresolved_date: date = date(2025, 12, 5),
+    smooth_prices: bool = False,
+) -> None:
     path = root / "data/imports/tiingo_eod_equities_free/tiingo_eod_etf_20210101_20251231/bars.csv"
     path.parent.mkdir(parents=True, exist_ok=True)
     rows = []
@@ -52,17 +65,27 @@ def _write_fixture_bars(root: Path, *, symbols: tuple[str, ...] = ("SPY", "QQQ",
     current_day = 0
     date_index = 0
     while date_index < days:
-        current = date(2021, 1, 4) + timedelta(days=current_day)
+        current = start + timedelta(days=current_day)
         current_day += 1
         if current.weekday() >= 5:
             continue
         for symbol in symbols:
             drift = slopes.get(symbol, 0.001)
             wave = ((date_index % 9) - 4) * 0.0007
-            close = 100.0 * (1.0 + drift + wave) ** date_index
+            if smooth_prices:
+                close = 100.0 * ((1.0 + drift) ** date_index) * (1.0 + wave)
+            else:
+                close = 100.0 * (1.0 + drift + wave) ** date_index
             open_ = close / (1.0 + wave if abs(wave) > 0.00001 else 1.0001)
             high = max(open_, close) * 1.002
             low = min(open_, close) * 0.998
+            if symbol in split_symbols and current >= split_date:
+                open_ *= 0.5
+                high *= 0.5
+                low *= 0.5
+                close *= 0.5
+            if symbol == unresolved_symbol and current == unresolved_date:
+                close *= 0.5
             rows.append(
                 {
                     "date": current.isoformat(),
@@ -221,6 +244,97 @@ def test_safety_flags_are_always_false_for_forbidden_authority_paths(tmp_path: P
 
     assert payload["safety"] == SAFE_FLAGS
     assert all(mode["safety"] == SAFE_FLAGS for mode in payload["modes"].values())
+
+
+def test_xle_xlk_style_two_for_one_split_events_are_detected(tmp_path: Path) -> None:
+    _write_resolution(tmp_path)
+    _write_fixture_bars(
+        tmp_path,
+        symbols=EXPECTED_UNIVERSE,
+        days=145,
+        start=date(2025, 6, 9),
+        split_symbols=("XLE", "XLK"),
+        smooth_prices=True,
+    )
+
+    payload, status = build_report(tmp_path, mode="real", max_hypotheses=5, seed=1729)
+    profile = payload["data_profile"]
+    events = profile["corporate_action_events"]
+
+    assert status == 0
+    assert profile["adjusted_price_continuity_applied"] is True
+    assert [(event["symbol"], event["effective_date"]) for event in events] == [
+        ("XLE", "2025-12-05"),
+        ("XLK", "2025-12-05"),
+    ]
+    assert all(event["matched_common_ratio"] == 2.0 for event in events)
+
+
+def test_pre_split_prices_are_adjusted_continuously(tmp_path: Path) -> None:
+    _write_resolution(tmp_path)
+    _write_fixture_bars(
+        tmp_path,
+        symbols=EXPECTED_UNIVERSE,
+        days=145,
+        start=date(2025, 6, 9),
+        split_symbols=("XLE", "XLK"),
+        smooth_prices=True,
+    )
+    raw_bars, blocked = load_tiingo_bars(tmp_path)
+    assert blocked is None
+
+    adjusted_bars, events, unresolved = apply_research_price_continuity(raw_bars or [])
+    xlk_rows = {row["date"]: row for row in adjusted_bars if row["symbol"] == "XLK"}
+    event_return = (xlk_rows["2025-12-05"]["adjusted_close_for_research"] / xlk_rows["2025-12-04"]["adjusted_close_for_research"]) - 1.0
+
+    assert len(events) == 2
+    assert unresolved == {}
+    assert xlk_rows["2025-12-04"]["research_price_adjustment_factor"] == 0.5
+    assert xlk_rows["2025-12-04"]["adjusted_close_for_research"] == xlk_rows["2025-12-04"]["raw_close"] * 0.5
+    assert event_return > -0.1
+    assert abs(event_return + 0.5) > 0.25
+
+
+def test_xle_xlk_remain_usable_after_successful_split_adjustment(tmp_path: Path) -> None:
+    _write_resolution(tmp_path)
+    _write_fixture_bars(
+        tmp_path,
+        symbols=EXPECTED_UNIVERSE,
+        days=145,
+        start=date(2025, 6, 9),
+        split_symbols=("XLE", "XLK"),
+        smooth_prices=True,
+    )
+
+    payload, _status = build_report(tmp_path, mode="all", max_hypotheses=5, seed=1729)
+    real_profile = payload["modes"]["real"]["data_profile"]
+
+    assert "XLE" in real_profile["universe"]
+    assert "XLK" in real_profile["universe"]
+    assert real_profile["excluded_symbols_due_to_unresolved_discontinuities"] == {}
+    assert payload["summary"]["data_dependency_proven"] is True
+    assert payload["safety"] == SAFE_FLAGS
+    assert all(mode["safety"] == SAFE_FLAGS for mode in payload["modes"].values())
+
+
+def test_unresolved_price_discontinuity_is_excluded(tmp_path: Path) -> None:
+    _write_resolution(tmp_path)
+    _write_fixture_bars(
+        tmp_path,
+        symbols=EXPECTED_UNIVERSE,
+        days=145,
+        start=date(2025, 6, 9),
+        unresolved_symbol="XLE",
+        smooth_prices=True,
+    )
+
+    payload, status = build_report(tmp_path, mode="real", max_hypotheses=5, seed=1729)
+    profile = payload["data_profile"]
+
+    assert status == 0
+    assert "XLE" not in profile["universe"]
+    assert "XLE" in profile["excluded_symbols_due_to_unresolved_discontinuities"]
+    assert profile["adjusted_price_continuity_applied"] is False
 
 
 def test_write_writes_only_under_expected_logs_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add deterministic split-like OHLC discontinuity detection for Tiingo research profiles
- preserve raw OHLC lineage while using adjusted research prices for profile features and controls
- exclude unresolved split-like discontinuities while keeping successfully adjusted XLE/XLK usable

## Checks
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_generator_e2e.py -q
- python -m ruff check research/qre_tiingo_hypothesis_generator_e2e.py tests/unit/test_qre_tiingo_hypothesis_generator_e2e.py
- git diff --check