### PR TITLE
research: add Tiingo hypothesis lifecycle events

### DIFF
--- a/docs/research/tiingo_hypothesis_lifecycle.md
+++ b/docs/research/tiingo_hypothesis_lifecycle.md
@@ -1,0 +1,159 @@
+# Tiingo Hypothesis Lifecycle
+
+## Purpose
+
+`research.qre_tiingo_hypothesis_lifecycle` consumes the existing Tiingo hypothesis generator output and turns generated hypothesis seeds into research-only lifecycle records, admission decisions, deterministic events, operator updates, and a daily digest input block.
+
+This PR closes the generator-to-admission/operator-observability boundary only. It does not close the full QRE research feedback loop because candidates are not yet materialized, screened, written to feedback memory, or consumed by a later run.
+
+## Input artifact
+
+Default input:
+
+```text
+logs/qre_tiingo_hypothesis_generator_e2e/latest.json
+```
+
+The module reads this artifact only. It does not rerun the upstream Tiingo E2E harness.
+
+## Output artifacts
+
+Default mode writes nothing and prints JSON to stdout:
+
+```powershell
+python -m research.qre_tiingo_hypothesis_lifecycle
+```
+
+Write mode writes only:
+
+```text
+logs/qre_tiingo_hypothesis_lifecycle/latest.json
+logs/qre_tiingo_hypothesis_lifecycle/events.jsonl
+logs/qre_tiingo_hypothesis_lifecycle/operator_summary.md
+```
+
+`events.jsonl` is rewritten as the complete deterministic event set for the current upstream artifact. It is not an unbounded append log.
+
+## Lifecycle statuses
+
+Allowed lifecycle decisions:
+
+```text
+admitted
+rejected
+blocked
+```
+
+Allowed lifecycle statuses:
+
+```text
+generated
+admissible_for_research_candidate_formulation
+rejected_before_candidate_formulation
+blocked_missing_or_unsafe_input
+```
+
+An admitted hypothesis is admitted only for future research-only candidate formulation. It is not a candidate.
+
+## Admission policy
+
+The admission policy is `tiingo_research_candidate_admission_v1`. It is research-only and requires:
+
+- upstream report kind is `qre_tiingo_hypothesis_generator_e2e`
+- upstream final verdict is `pass_data_driven_hypothesis_generation`
+- data dependency is proven
+- trading authority is false
+- real, shuffled, and truncated modes are present
+- real mode has a valid profile and hypotheses
+- shuffled mode has hypotheses
+- real and shuffled content identities differ
+- truncated control is blocked with zero hypotheses
+- split-adjusted profile is present when corporate action events exist
+
+If any report-level gate fails, the lifecycle report fails closed with `lifecycle_verdict=blocked`.
+
+## Event journal
+
+For admitted hypotheses the module emits:
+
+```text
+hypothesis_generated
+hypothesis_admitted
+```
+
+For blocked report-level evidence it emits:
+
+```text
+hypothesis_blocked
+```
+
+Event IDs are deterministic and do not include timestamps.
+
+## Operator updates
+
+Every meaningful event gets a short operator update. Updates distinguish:
+
+```text
+admitted for future research-only candidate formulation
+```
+
+from:
+
+```text
+candidate created
+strategy registered
+trade signal
+```
+
+The latter three do not happen in this module.
+
+## Daily digest input
+
+`latest.json` includes:
+
+```text
+daily_digest_input.digest_kind = qre_hypothesis_lifecycle_daily_input
+```
+
+The block contains generated/admitted/rejected/blocked counts, highlights, blocked-reason counts, next actions, and a false authority summary. The existing daily digest can consume this in a later PR. This PR does not add a scheduler or broad digest integration.
+
+## Safety boundaries
+
+Every report keeps:
+
+```text
+trading_authority=false
+creates_candidates=false
+runs_screening=false
+promotes_candidates=false
+registers_strategy=false
+validation_authority=false
+paper_authority=false
+shadow_authority=false
+live_authority=false
+```
+
+A hypothesis admitted by this module is not a strategy, not a trade signal, not validation-ready, not paper-ready, not shadow-ready, and not live-ready.
+
+## What this PR does not do
+
+This PR does not:
+
+- create candidate specs
+- run screening
+- validate hypotheses
+- promote candidates
+- register strategies
+- start paper, shadow, or live paths
+- grant trading authority
+- mutate `research/research_latest.json`
+- mutate `research/strategy_matrix.csv`
+
+## Why this does not close the full QRE feedback loop yet
+
+The full QRE feedback loop requires a downstream candidate materializer, screening result, evidence or memory writeback, later-run consumption, and tests proving a changed decision. This module stops before candidate materialization and emits only lifecycle/admission/observability artifacts.
+
+## Next safe PR
+
+The next safe PR is a research-only candidate spec contract and materializer that consumes admitted hypothesis lifecycle records. That later PR should still avoid screening, validation, promotion, strategy registration, paper, shadow, live, and trading authority unless those scopes are explicitly approved separately.
+

--- a/research/qre_tiingo_hypothesis_lifecycle.py
+++ b/research/qre_tiingo_hypothesis_lifecycle.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+REPORT_KIND: Final[str] = "qre_tiingo_hypothesis_lifecycle"
+SCHEMA_VERSION: Final[int] = 1
+SOURCE_REPORT_KIND: Final[str] = "qre_tiingo_hypothesis_generator_e2e"
+DEFAULT_INPUT_PATH: Final[Path] = Path("logs/qre_tiingo_hypothesis_generator_e2e/latest.json")
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_tiingo_hypothesis_lifecycle")
+LATEST_NAME: Final[str] = "latest.json"
+EVENTS_NAME: Final[str] = "events.jsonl"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+PASS_VERDICT: Final[str] = "pass_data_driven_hypothesis_generation"
+
+REQUIRED_CANDIDATE_SPEC_FIELDS: Final[tuple[str, ...]] = (
+    "candidate_id",
+    "parent_hypothesis_seed_id",
+    "source_snapshot_id",
+    "feature_family",
+    "signal_definition",
+    "selection_rule",
+    "rebalance_rule",
+    "holding_period",
+    "benchmark",
+    "null_control_requirement",
+    "split_adjustment_requirement",
+    "screening_only",
+    "trading_authority",
+)
+FORBIDDEN_AUTHORITIES: Final[tuple[str, ...]] = (
+    "candidate_promotion",
+    "strategy_registration",
+    "validation",
+    "paper",
+    "shadow",
+    "live",
+    "trading",
+    "broker",
+    "orders",
+)
+KNOWN_FAMILIES: Final[tuple[str, ...]] = (
+    "cross_sectional_momentum",
+    "risk_on_risk_off_regime",
+    "defensive_rotation",
+    "volatility_compression_breakout",
+    "mean_reversion_after_extreme_dispersion",
+)
+SAFETY: Final[dict[str, bool]] = {
+    "trading_authority": False,
+    "creates_candidates": False,
+    "runs_screening": False,
+    "promotes_candidates": False,
+    "registers_strategy": False,
+    "validation_authority": False,
+    "paper_authority": False,
+    "shadow_authority": False,
+    "live_authority": False,
+}
+ADMISSION_POLICY: Final[dict[str, Any]] = {
+    "name": "tiingo_research_candidate_admission_v1",
+    "authority": "research_only",
+    "creates_candidates": False,
+    "runs_screening": False,
+    "allows_promotion": False,
+    "allows_validation": False,
+    "allows_strategy_registration": False,
+    "allows_paper_shadow_live": False,
+    "requires_trading_authority_false": True,
+    "requires_final_verdict": PASS_VERDICT,
+    "requires_data_dependency_proven": True,
+    "requires_split_adjusted_profile_if_corporate_actions_present": True,
+    "requires_real_and_shuffled_identity_difference": True,
+    "requires_truncated_control_blocked": True,
+}
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _stable_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _stable_payload(value[key]) for key in sorted(value)}
+    if isinstance(value, list | tuple):
+        return [_stable_payload(item) for item in value]
+    return value
+
+
+def _digest(value: Any, *, length: int = 16) -> str:
+    payload = json.dumps(_stable_payload(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:length]
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, "missing_upstream_report"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None, "malformed_upstream_report"
+    if not isinstance(payload, dict):
+        return None, "malformed_upstream_report"
+    return payload, None
+
+
+def _source_report_path(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _source_report_kind(payload: dict[str, Any]) -> Any:
+    return payload.get("report_kind") or payload.get("source_report_kind")
+
+
+def _mode(payload: dict[str, Any], name: str) -> dict[str, Any] | None:
+    modes = payload.get("modes")
+    if not isinstance(modes, dict):
+        return None
+    value = modes.get(name)
+    return value if isinstance(value, dict) else None
+
+
+def _content_identities(mode: dict[str, Any]) -> list[str]:
+    values = mode.get("content_identities")
+    if isinstance(values, list):
+        return [str(item) for item in values]
+    hypotheses = mode.get("hypotheses")
+    if isinstance(hypotheses, list):
+        return [str(row.get("content_identity") or row.get("hypothesis_id") or "") for row in hypotheses if isinstance(row, dict)]
+    return []
+
+
+def _truncated_control_blocked(truncated: dict[str, Any]) -> bool:
+    if int(truncated.get("hypotheses_count") or 0) != 0:
+        return False
+    blocked = {str(item) for item in truncated.get("blocked_reasons") or []}
+    profile = truncated.get("data_profile") if isinstance(truncated.get("data_profile"), dict) else {}
+    insufficient = bool(profile.get("insufficient_history")) or bool(profile.get("insufficient_cross_section"))
+    return insufficient or bool(blocked & {"insufficient_history", "insufficient_cross_section"})
+
+
+def _validate_upstream(payload: dict[str, Any] | None, *, load_error: str | None) -> list[str]:
+    if load_error is not None:
+        return [load_error]
+    if payload is None:
+        return ["missing_upstream_report"]
+    reasons: list[str] = []
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    safety = payload.get("safety") if isinstance(payload.get("safety"), dict) else {}
+    source_snapshot_id = payload.get("source_snapshot_id")
+
+    if _source_report_kind(payload) != SOURCE_REPORT_KIND:
+        reasons.append("unexpected_upstream_report_kind")
+    if not source_snapshot_id:
+        reasons.append("missing_source_snapshot_id")
+    if summary.get("final_verdict") != PASS_VERDICT:
+        reasons.append("upstream_final_verdict_not_pass")
+    if summary.get("data_dependency_proven") is not True:
+        reasons.append("data_dependency_not_proven")
+    if safety.get("trading_authority") is not False:
+        reasons.append("unsafe_trading_authority")
+
+    real = _mode(payload, "real")
+    shuffled = _mode(payload, "shuffled_returns")
+    truncated = _mode(payload, "truncated")
+    if real is None:
+        reasons.append("missing_real_mode")
+    if shuffled is None:
+        reasons.append("missing_shuffled_mode")
+    if truncated is None:
+        reasons.append("missing_truncated_mode")
+
+    if real is not None:
+        profile = real.get("data_profile") if isinstance(real.get("data_profile"), dict) else {}
+        if real.get("data_profile_valid") is not True or not profile:
+            reasons.append("invalid_real_data_profile")
+        if int(real.get("hypotheses_count") or 0) <= 0 or not real.get("hypotheses"):
+            reasons.append("missing_real_hypotheses")
+        events = profile.get("corporate_action_events")
+        if events and profile.get("adjusted_price_continuity_applied") is not True:
+            reasons.append("split_adjustment_required_but_missing")
+    if shuffled is not None and (int(shuffled.get("hypotheses_count") or 0) <= 0 or not shuffled.get("hypotheses")):
+        reasons.append("missing_shuffled_hypotheses")
+    if real is not None and shuffled is not None and _content_identities(real) == _content_identities(shuffled):
+        reasons.append("real_shuffled_identity_not_different")
+    if truncated is not None and not _truncated_control_blocked(truncated):
+        reasons.append("truncated_control_not_blocked")
+
+    if real is not None and source_snapshot_id:
+        for hypothesis in real.get("hypotheses") or []:
+            if not _valid_hypothesis_shape(hypothesis, source_snapshot_id=str(source_snapshot_id)):
+                reasons.append("malformed_upstream_hypothesis")
+                break
+    return sorted(dict.fromkeys(reasons))
+
+
+def _valid_hypothesis_shape(hypothesis: Any, *, source_snapshot_id: str) -> bool:
+    if not isinstance(hypothesis, dict):
+        return False
+    return (
+        bool(hypothesis.get("hypothesis_id"))
+        and bool(hypothesis.get("feature_family"))
+        and bool(hypothesis.get("content_identity"))
+        and hypothesis.get("source_snapshot_id") == source_snapshot_id
+        and hypothesis.get("trading_authority") is False
+        and hypothesis.get("not_trade_signal") is True
+    )
+
+
+def _seed_id(hypothesis: dict[str, Any], *, source_snapshot_id: str) -> str:
+    return "seed_tiingo_" + _digest(
+        {
+            "source_hypothesis_id": hypothesis.get("hypothesis_id"),
+            "source_snapshot_id": source_snapshot_id,
+            "feature_family": hypothesis.get("feature_family"),
+            "content_identity": hypothesis.get("content_identity"),
+        }
+    )
+
+
+def _event_id(event_type: str, lifecycle: dict[str, Any]) -> str:
+    return "evt_tiingo_" + _digest(
+        {
+            "event_type": event_type,
+            "hypothesis_seed_id": lifecycle.get("hypothesis_seed_id"),
+            "source_snapshot_id": lifecycle.get("source_snapshot_id"),
+            "decision": lifecycle.get("decision"),
+            "status": lifecycle.get("status"),
+        }
+    )
+
+
+def _source_digest(hypothesis: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "digest": "sha256:" + _digest(hypothesis, length=64),
+        "keys": sorted(str(key) for key in hypothesis),
+    }
+
+
+def _lifecycle_record(hypothesis: dict[str, Any], *, source_snapshot_id: str, source_report_path: str) -> dict[str, Any]:
+    family = str(hypothesis.get("feature_family") or "")
+    seed_id = _seed_id(hypothesis, source_snapshot_id=source_snapshot_id)
+    return {
+        "hypothesis_seed_id": seed_id,
+        "source_hypothesis_id": str(hypothesis.get("hypothesis_id")),
+        "source_snapshot_id": source_snapshot_id,
+        "source_report_path": source_report_path,
+        "feature_family": family,
+        "status": "admissible_for_research_candidate_formulation",
+        "decision": "admitted",
+        "decision_reasons": ["upstream_tiingo_evidence_passed_research_only_admission_policy"],
+        "blocked_reasons": [],
+        "required_candidate_spec_fields": list(REQUIRED_CANDIDATE_SPEC_FIELDS),
+        "allowed_candidate_families": [family] if family in KNOWN_FAMILIES else [],
+        "forbidden_authorities": list(FORBIDDEN_AUTHORITIES),
+        "next_action": "materialize_research_candidate_later",
+        "operator_update_required": True,
+        "trading_authority": False,
+        "creates_candidates": False,
+        "runs_screening": False,
+        "source_hypothesis_digest": _source_digest(hypothesis),
+    }
+
+
+def _blocked_event(*, reason: str, source_snapshot_id: str | None, source_report_path: str) -> dict[str, Any]:
+    lifecycle = {
+        "hypothesis_seed_id": "seed_tiingo_blocked_" + _digest(
+            {"reason": reason, "source_snapshot_id": source_snapshot_id or "unknown", "source_report_path": source_report_path}
+        ),
+        "source_hypothesis_id": "upstream_report",
+        "source_snapshot_id": source_snapshot_id or "unknown",
+        "status": "blocked_missing_or_unsafe_input",
+        "decision": "blocked",
+    }
+    return {
+        "event_id": _event_id("hypothesis_blocked", lifecycle),
+        "event_type": "hypothesis_blocked",
+        "hypothesis_seed_id": lifecycle["hypothesis_seed_id"],
+        "source_hypothesis_id": lifecycle["source_hypothesis_id"],
+        "source_snapshot_id": lifecycle["source_snapshot_id"],
+        "status": lifecycle["status"],
+        "decision": lifecycle["decision"],
+        "operator_update_required": True,
+        "operator_message": f"Tiingo hypothesis lifecycle blocked before admission: {reason}. No candidate created and no screening run.",
+        "trading_authority": False,
+        "creates_candidates": False,
+        "runs_screening": False,
+    }
+
+
+def _event(event_type: str, lifecycle: dict[str, Any]) -> dict[str, Any]:
+    if event_type == "hypothesis_generated":
+        message = "Tiingo hypothesis seed observed from upstream generator output. No candidate created and no trading authority granted."
+    elif event_type == "hypothesis_admitted":
+        message = "Tiingo hypothesis admitted for research-only candidate formulation later. No candidate created and no trading authority granted."
+    else:
+        message = "Tiingo hypothesis did not pass research-only admission. No candidate created and no screening run."
+    return {
+        "event_id": _event_id(event_type, lifecycle),
+        "event_type": event_type,
+        "hypothesis_seed_id": lifecycle["hypothesis_seed_id"],
+        "source_hypothesis_id": lifecycle["source_hypothesis_id"],
+        "source_snapshot_id": lifecycle["source_snapshot_id"],
+        "status": lifecycle["status"],
+        "decision": lifecycle["decision"],
+        "operator_update_required": True,
+        "operator_message": message,
+        "trading_authority": False,
+        "creates_candidates": False,
+        "runs_screening": False,
+    }
+
+
+def _operator_update(event: dict[str, Any]) -> dict[str, Any]:
+    event_type = str(event.get("event_type"))
+    severity = "info" if event_type in {"hypothesis_generated", "hypothesis_admitted"} else "blocked"
+    next_action = "materialize_research_candidate_later" if event_type == "hypothesis_admitted" else "repair_upstream_evidence"
+    if event_type == "hypothesis_generated":
+        next_action = "materialize_research_candidate_later" if event.get("decision") == "admitted" else "repair_upstream_evidence"
+    return {
+        "update_type": event_type,
+        "severity": severity,
+        "hypothesis_seed_id": event.get("hypothesis_seed_id"),
+        "message": event.get("operator_message"),
+        "next_action": next_action,
+    }
+
+
+def _daily_digest_input(
+    *,
+    source_snapshot_id: str | None,
+    generated: int,
+    admitted: int,
+    rejected: int,
+    blocked: int,
+    blocked_reasons: list[str],
+    lifecycle: list[dict[str, Any]],
+) -> dict[str, Any]:
+    reason_counts = {reason: blocked_reasons.count(reason) for reason in sorted(set(blocked_reasons))}
+    next_actions = sorted({str(row.get("next_action")) for row in lifecycle if row.get("next_action")})
+    return {
+        "digest_kind": "qre_hypothesis_lifecycle_daily_input",
+        "source": REPORT_KIND,
+        "source_snapshot_id": source_snapshot_id or "unknown",
+        "counts": {
+            "generated": generated,
+            "admitted": admitted,
+            "rejected": rejected,
+            "blocked": blocked,
+        },
+        "highlights": [
+            f"Tiingo lifecycle generated={generated} admitted={admitted} rejected={rejected} blocked={blocked}."
+        ],
+        "blocked_reasons": reason_counts,
+        "next_actions": next_actions,
+        "authority_summary": dict(SAFETY),
+    }
+
+
+def _is_digest_ready(digest: dict[str, Any], summary: dict[str, Any]) -> bool:
+    counts = digest.get("counts") if isinstance(digest.get("counts"), dict) else {}
+    authority = digest.get("authority_summary") if isinstance(digest.get("authority_summary"), dict) else {}
+    return (
+        digest.get("digest_kind") == "qre_hypothesis_lifecycle_daily_input"
+        and counts.get("generated") == summary.get("hypotheses_generated_events")
+        and counts.get("admitted") == summary.get("hypotheses_admitted")
+        and counts.get("rejected") == summary.get("hypotheses_rejected")
+        and counts.get("blocked") == summary.get("hypotheses_blocked")
+        and all(authority.get(key) is False for key in SAFETY)
+    )
+
+
+def build_lifecycle_report(
+    *,
+    repo_root: Path = Path("."),
+    input_path: Path = DEFAULT_INPUT_PATH,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    source_path = input_path if input_path.is_absolute() else repo_root / input_path
+    source_report_path = _source_report_path(source_path, repo_root)
+    upstream, load_error = _read_json(source_path)
+    blocked_reasons = _validate_upstream(upstream, load_error=load_error)
+    source_snapshot_id = str(upstream.get("source_snapshot_id")) if isinstance(upstream, dict) and upstream.get("source_snapshot_id") else None
+
+    lifecycle: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    if blocked_reasons:
+        events.append(
+            _blocked_event(
+                reason=blocked_reasons[0],
+                source_snapshot_id=source_snapshot_id,
+                source_report_path=source_report_path,
+            )
+        )
+    else:
+        real = _mode(upstream or {}, "real") or {}
+        hypotheses = [dict(row) for row in real.get("hypotheses") or [] if isinstance(row, dict)]
+        for hypothesis in hypotheses:
+            record = _lifecycle_record(hypothesis, source_snapshot_id=source_snapshot_id or "unknown", source_report_path=source_report_path)
+            lifecycle.append(record)
+            events.append(_event("hypothesis_generated", record))
+            events.append(_event("hypothesis_admitted", record))
+
+    generated_count = sum(1 for event in events if event["event_type"] == "hypothesis_generated")
+    admitted_count = sum(1 for row in lifecycle if row["decision"] == "admitted")
+    rejected_count = sum(1 for row in lifecycle if row["decision"] == "rejected")
+    blocked_count = sum(1 for event in events if event["event_type"] == "hypothesis_blocked")
+    summary = {
+        "input_verdict": ((upstream.get("summary") or {}).get("final_verdict") if isinstance(upstream, dict) else None) or "unavailable",
+        "lifecycle_verdict": "blocked" if blocked_reasons else "pass_research_only_admission_boundary",
+        "hypotheses_seen": len(lifecycle),
+        "hypotheses_generated_events": generated_count,
+        "hypotheses_admitted": admitted_count,
+        "hypotheses_rejected": rejected_count,
+        "hypotheses_blocked": blocked_count,
+        "operator_updates_count": 0,
+        "daily_digest_ready": False,
+    }
+    operator_updates = [_operator_update(event) for event in events if event.get("operator_update_required") is True]
+    summary["operator_updates_count"] = len(operator_updates)
+    digest = _daily_digest_input(
+        source_snapshot_id=source_snapshot_id,
+        generated=generated_count,
+        admitted=admitted_count,
+        rejected=rejected_count,
+        blocked=blocked_count,
+        blocked_reasons=blocked_reasons,
+        lifecycle=lifecycle,
+    )
+    summary["daily_digest_ready"] = _is_digest_ready(digest, summary)
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "source_report_kind": SOURCE_REPORT_KIND,
+        "source_report_path": source_report_path,
+        "source_snapshot_id": source_snapshot_id or "unknown",
+        "generated_at": _utcnow(),
+        "trading_authority": False,
+        "summary": summary,
+        "admission_policy": dict(ADMISSION_POLICY),
+        "hypothesis_lifecycle": lifecycle,
+        "events": events,
+        "operator_updates": operator_updates,
+        "daily_digest_input": digest,
+        "safety": dict(SAFETY),
+        "blocked_reasons": blocked_reasons,
+    }
+
+
+def render_operator_summary(report: dict[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
+    safety = report.get("safety") if isinstance(report.get("safety"), dict) else {}
+    blocked = report.get("blocked_reasons") or []
+    lines = [
+        "# Tiingo Hypothesis Lifecycle",
+        "",
+        f"- Input verdict: {summary.get('input_verdict')}",
+        f"- Lifecycle verdict: {summary.get('lifecycle_verdict')}",
+        f"- Hypotheses seen: {summary.get('hypotheses_seen')}",
+        f"- Generated events: {summary.get('hypotheses_generated_events')}",
+        f"- Admitted: {summary.get('hypotheses_admitted')}",
+        f"- Rejected: {summary.get('hypotheses_rejected')}",
+        f"- Blocked: {summary.get('hypotheses_blocked')}",
+        f"- Daily digest ready: {str(summary.get('daily_digest_ready')).lower()}",
+        f"- Trading authority: {str(safety.get('trading_authority')).lower()}",
+        f"- Candidate creation: {str(safety.get('creates_candidates')).lower()}",
+        f"- Screening run: {str(safety.get('runs_screening')).lower()}",
+        "- Next safe action: "
+        + (
+            "materialize research-only candidate specs in a later PR"
+            if summary.get("hypotheses_admitted")
+            else "repair upstream evidence"
+        ),
+        "",
+        "hypothesis_seed_id | source_hypothesis_id | decision | status | next_action | reason",
+        "---|---|---|---|---|---",
+    ]
+    lifecycle = report.get("hypothesis_lifecycle") if isinstance(report.get("hypothesis_lifecycle"), list) else []
+    if lifecycle:
+        for row in lifecycle:
+            reasons = row.get("blocked_reasons") or row.get("decision_reasons") or []
+            lines.append(
+                " | ".join(
+                    [
+                        str(row.get("hypothesis_seed_id")),
+                        str(row.get("source_hypothesis_id")),
+                        str(row.get("decision")),
+                        str(row.get("status")),
+                        str(row.get("next_action")),
+                        ", ".join(str(item) for item in reasons) if reasons else "none",
+                    ]
+                )
+            )
+    else:
+        lines.append(
+            "none | upstream_report | blocked | blocked_missing_or_unsafe_input | repair_upstream_evidence | "
+            + (", ".join(str(item) for item in blocked) if blocked else "none")
+        )
+    lines.extend(
+        [
+            "",
+            "No candidates were created. No screening was run. No trading, validation, promotion, strategy registration, paper, shadow, or live authority exists.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(
+    report: dict[str, Any],
+    *,
+    repo_root: Path = Path("."),
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+) -> dict[str, str]:
+    repo_root = repo_root.resolve()
+    resolved = output_dir if output_dir.is_absolute() else repo_root / output_dir
+    resolved = resolved.resolve()
+    allowed = (repo_root / DEFAULT_OUTPUT_DIR).resolve()
+    if resolved != allowed:
+        raise ValueError("output_dir_must_be_logs_qre_tiingo_hypothesis_lifecycle")
+    latest = resolved / LATEST_NAME
+    events_path = resolved / EVENTS_NAME
+    summary_path = resolved / SUMMARY_NAME
+    latest_text = json.dumps(_stable_payload(report), indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    events_text = "".join(json.dumps(_stable_payload(event), sort_keys=True, ensure_ascii=True) + "\n" for event in report.get("events", []))
+    _atomic_write_text(latest, latest_text)
+    _atomic_write_text(events_path, events_text)
+    _atomic_write_text(summary_path, render_operator_summary(report))
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "events": events_path.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m research.qre_tiingo_hypothesis_lifecycle")
+    parser.add_argument("--input", default=str(DEFAULT_INPUT_PATH))
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--repo-root", default=".")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    report = build_lifecycle_report(repo_root=repo_root, input_path=Path(args.input))
+    if args.write:
+        write_outputs(report, repo_root=repo_root, output_dir=Path(args.output_dir))
+    print(json.dumps(_stable_payload(report), indent=2, sort_keys=True, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_tiingo_hypothesis_lifecycle.py
+++ b/tests/unit/test_qre_tiingo_hypothesis_lifecycle.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_tiingo_hypothesis_lifecycle as lifecycle
+
+UPSTREAM_PATH = Path("logs/qre_tiingo_hypothesis_generator_e2e/latest.json")
+SNAPSHOT_ID = "qdsnap_2b1258c6f592fa08"
+
+
+def _hypothesis(index: int, *, family: str = "cross_sectional_momentum") -> dict:
+    identity = f"tiingo_hyp_{family}_{index}"
+    return {
+        "hypothesis_id": identity,
+        "content_identity": identity,
+        "source_id": "tiingo_eod_equities_free",
+        "source_snapshot_id": SNAPSHOT_ID,
+        "generated_from_data_profile": True,
+        "feature_family": family,
+        "instruments_used": ["SPY", "QQQ"],
+        "lookback_window": 60,
+        "signal_definition": "Rank ETFs by 60d return.",
+        "expected_direction": "Higher ranked ETFs persist.",
+        "falsification_condition": "Null control matches identity.",
+        "feature_refs": ["momentum_rank_60d"],
+        "data_profile_digest": "profile_digest",
+        "screening_only": True,
+        "not_trade_signal": True,
+        "trading_authority": False,
+        "confidence": 0.7,
+        "blocked_reasons": [],
+    }
+
+
+def _mode(
+    name: str,
+    *,
+    hypotheses: list[dict] | None = None,
+    valid_profile: bool = True,
+    insufficient_history: bool = False,
+    insufficient_cross_section: bool = False,
+    corporate_events: bool = False,
+    adjusted: bool = True,
+) -> dict:
+    hypotheses = list(hypotheses or [])
+    profile = {
+        "source_id": "tiingo_eod_equities_free",
+        "source_snapshot_id": SNAPSHOT_ID,
+        "data_profile_digest": "profile_digest",
+        "universe": ["SPY", "QQQ"],
+        "insufficient_history": insufficient_history,
+        "insufficient_cross_section": insufficient_cross_section,
+        "corporate_action_events": [{"symbol": "XLK"}] if corporate_events else [],
+        "adjusted_price_continuity_applied": adjusted,
+    }
+    blocked = []
+    if insufficient_history:
+        blocked.append("insufficient_history")
+    if insufficient_cross_section:
+        blocked.append("insufficient_cross_section")
+    return {
+        "mode": name,
+        "data_profile_valid": valid_profile,
+        "blocked_reasons": blocked,
+        "data_profile": profile,
+        "hypotheses": hypotheses,
+        "hypotheses_count": len(hypotheses),
+        "content_identities": [row["content_identity"] for row in hypotheses],
+        "safety": {
+            "network_called": False,
+            "run_research_called": False,
+            "campaign_launcher_called": False,
+            "validation_executed": False,
+            "candidate_promotion_allowed": False,
+            "strategy_registration_allowed": False,
+            "execution_performed": False,
+            "paper_shadow_live_allowed": False,
+            "trading_authority": False,
+        },
+    }
+
+
+def _valid_payload() -> dict:
+    real = [_hypothesis(1), _hypothesis(2, family="risk_on_risk_off_regime")]
+    shuffled = [
+        _hypothesis(1, family="defensive_rotation"),
+        _hypothesis(2, family="volatility_compression_breakout"),
+    ]
+    truncated = _mode("truncated", insufficient_history=True)
+    return {
+        "report_kind": "qre_tiingo_hypothesis_generator_e2e",
+        "schema_version": "1.0",
+        "source_id": "tiingo_eod_equities_free",
+        "source_snapshot_id": SNAPSHOT_ID,
+        "source_tier": "SOURCE_SCREENING_ELIGIBLE",
+        "timeframe": "1d",
+        "modes": {
+            "real": _mode("real", hypotheses=real),
+            "shuffled_returns": _mode("shuffled_returns", hypotheses=shuffled),
+            "truncated": truncated,
+        },
+        "summary": {
+            "real_data_hypotheses_count": len(real),
+            "shuffled_control_hypotheses_count": len(shuffled),
+            "truncated_control_hypotheses_count": 0,
+            "real_content_identities": [row["content_identity"] for row in real],
+            "shuffled_content_identities": [row["content_identity"] for row in shuffled],
+            "truncated_content_identities": [],
+            "data_dependency_proven": True,
+            "data_dependency_blockers": [],
+            "final_verdict": "pass_data_driven_hypothesis_generation",
+        },
+        "safety": {
+            "network_called": False,
+            "run_research_called": False,
+            "campaign_launcher_called": False,
+            "validation_executed": False,
+            "candidate_promotion_allowed": False,
+            "strategy_registration_allowed": False,
+            "execution_performed": False,
+            "paper_shadow_live_allowed": False,
+            "trading_authority": False,
+        },
+    }
+
+
+def _write_payload(root: Path, payload: dict) -> Path:
+    path = root / UPSTREAM_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _build(root: Path) -> dict:
+    return lifecycle.build_lifecycle_report(repo_root=root, input_path=UPSTREAM_PATH)
+
+
+def _assert_blocked(root: Path, reason: str) -> None:
+    report = _build(root)
+    assert report["summary"]["lifecycle_verdict"] == "blocked"
+    assert reason in report["blocked_reasons"]
+    assert report["trading_authority"] is False
+    assert report["safety"]["creates_candidates"] is False
+    assert report["safety"]["runs_screening"] is False
+
+
+def test_missing_upstream_report_fails_closed(tmp_path: Path) -> None:
+    _assert_blocked(tmp_path, "missing_upstream_report")
+
+
+def test_malformed_upstream_report_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / UPSTREAM_PATH
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    _assert_blocked(tmp_path, "malformed_upstream_report")
+
+
+def test_unexpected_report_kind_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["report_kind"] = "wrong"
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "unexpected_upstream_report_kind")
+
+
+def test_unsafe_trading_authority_true_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["safety"]["trading_authority"] = True
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "unsafe_trading_authority")
+
+
+def test_final_verdict_not_pass_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["summary"]["final_verdict"] = "fail_static_or_template_driven"
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "upstream_final_verdict_not_pass")
+
+
+def test_data_dependency_false_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["summary"]["data_dependency_proven"] = False
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "data_dependency_not_proven")
+
+
+def test_missing_source_snapshot_id_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload.pop("source_snapshot_id")
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "missing_source_snapshot_id")
+
+
+def test_missing_real_mode_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["modes"].pop("real")
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "missing_real_mode")
+
+
+def test_missing_shuffled_mode_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["modes"].pop("shuffled_returns")
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "missing_shuffled_mode")
+
+
+def test_missing_truncated_mode_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["modes"].pop("truncated")
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "missing_truncated_mode")
+
+
+def test_invalid_real_data_profile_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["modes"]["real"]["data_profile_valid"] = False
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "invalid_real_data_profile")
+
+
+def test_missing_real_hypotheses_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["modes"]["real"]["hypotheses"] = []
+    payload["modes"]["real"]["hypotheses_count"] = 0
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "missing_real_hypotheses")
+
+
+def test_missing_shuffled_hypotheses_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["modes"]["shuffled_returns"]["hypotheses"] = []
+    payload["modes"]["shuffled_returns"]["hypotheses_count"] = 0
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "missing_shuffled_hypotheses")
+
+
+def test_real_shuffled_identity_collision_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    real_ids = payload["modes"]["real"]["content_identities"]
+    payload["modes"]["shuffled_returns"]["content_identities"] = list(real_ids)
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "real_shuffled_identity_not_different")
+
+
+def test_truncated_control_not_blocked_fails_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["modes"]["truncated"] = _mode("truncated", hypotheses=[_hypothesis(8)])
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "truncated_control_not_blocked")
+
+
+def test_split_events_without_adjustment_fail_closed(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["modes"]["real"]["data_profile"]["corporate_action_events"] = [{"symbol": "XLK"}]
+    payload["modes"]["real"]["data_profile"]["adjusted_price_continuity_applied"] = False
+    _write_payload(tmp_path, payload)
+    _assert_blocked(tmp_path, "split_adjustment_required_but_missing")
+
+
+def test_valid_upstream_report_produces_lifecycle_records(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    report = _build(tmp_path)
+    assert report["summary"]["lifecycle_verdict"] == "pass_research_only_admission_boundary"
+    assert len(report["hypothesis_lifecycle"]) == 2
+    assert report["summary"]["hypotheses_seen"] == 2
+
+
+def test_valid_upstream_report_admits_hypotheses(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    report = _build(tmp_path)
+    assert {row["decision"] for row in report["hypothesis_lifecycle"]} == {"admitted"}
+    assert {row["status"] for row in report["hypothesis_lifecycle"]} == {
+        "admissible_for_research_candidate_formulation"
+    }
+
+
+def test_deterministic_hypothesis_seed_id_values(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    first = _build(tmp_path)
+    second = _build(tmp_path)
+    assert [row["hypothesis_seed_id"] for row in first["hypothesis_lifecycle"]] == [
+        row["hypothesis_seed_id"] for row in second["hypothesis_lifecycle"]
+    ]
+
+
+def test_deterministic_event_id_values(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    first = _build(tmp_path)
+    second = _build(tmp_path)
+    assert [row["event_id"] for row in first["events"]] == [row["event_id"] for row in second["events"]]
+
+
+def test_default_mode_writes_nothing(tmp_path: Path, capsys) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    status = lifecycle.main(["--repo-root", str(tmp_path)])
+    parsed = json.loads(capsys.readouterr().out)
+    assert status == 0
+    assert parsed["report_kind"] == lifecycle.REPORT_KIND
+    assert not (tmp_path / lifecycle.DEFAULT_OUTPUT_DIR / "latest.json").exists()
+
+
+def test_write_writes_only_lifecycle_logs(tmp_path: Path, capsys) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    lifecycle.main(["--repo-root", str(tmp_path), "--write"])
+    capsys.readouterr()
+    files = sorted(path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*") if path.is_file())
+    created = [path for path in files if path != UPSTREAM_PATH.as_posix()]
+    assert created
+    assert all(path.startswith("logs/qre_tiingo_hypothesis_lifecycle/") for path in created)
+    assert "research/research_latest.json" not in files
+    assert "research/strategy_matrix.csv" not in files
+
+
+def test_write_writes_required_artifacts(tmp_path: Path, capsys) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    lifecycle.main(["--repo-root", str(tmp_path), "--write"])
+    capsys.readouterr()
+    base = tmp_path / lifecycle.DEFAULT_OUTPUT_DIR
+    assert (base / "latest.json").is_file()
+    assert (base / "events.jsonl").is_file()
+    assert (base / "operator_summary.md").is_file()
+
+
+def test_events_jsonl_matches_latest_events(tmp_path: Path, capsys) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    lifecycle.main(["--repo-root", str(tmp_path), "--write"])
+    capsys.readouterr()
+    base = tmp_path / lifecycle.DEFAULT_OUTPUT_DIR
+    latest = json.loads((base / "latest.json").read_text(encoding="utf-8"))
+    rows = [json.loads(line) for line in (base / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert rows == latest["events"]
+
+
+def test_operator_updates_are_emitted_for_meaningful_events(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    admitted = _build(tmp_path)
+    assert admitted["operator_updates"]
+    assert {row["update_type"] for row in admitted["operator_updates"]} == {
+        event["event_type"] for event in admitted["events"]
+    }
+    blocked = lifecycle.build_lifecycle_report(repo_root=tmp_path, input_path=Path("missing.json"))
+    assert blocked["operator_updates"][0]["update_type"] == "hypothesis_blocked"
+
+
+def test_daily_digest_input_contains_counts_and_authority_summary(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    report = _build(tmp_path)
+    digest = report["daily_digest_input"]
+    assert digest["counts"] == {"generated": 2, "admitted": 2, "rejected": 0, "blocked": 0}
+    assert report["summary"]["daily_digest_ready"] is True
+    assert all(value is False for value in digest["authority_summary"].values())
+
+
+def test_admitted_records_do_not_create_candidates(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    report = _build(tmp_path)
+    assert all(row["creates_candidates"] is False for row in report["hypothesis_lifecycle"])
+    assert all(row["runs_screening"] is False for row in report["hypothesis_lifecycle"])
+
+
+def test_safety_flags_all_remain_false(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    report = _build(tmp_path)
+    assert all(value is False for value in report["safety"].values())
+    assert report["trading_authority"] is False
+
+
+def test_forbidden_values_are_not_active_statuses_or_decisions(tmp_path: Path) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    report = _build(tmp_path)
+    forbidden = {"promote_to_validation", "register_strategy", "paper_ready", "shadow_ready", "live_ready", "trade", "order", "position"}
+    values = set()
+    for row in report["hypothesis_lifecycle"]:
+        values.add(row["decision"])
+        values.add(row["status"])
+        values.add(row["next_action"])
+    for event in report["events"]:
+        values.add(event["decision"])
+        values.add(event["status"])
+    assert values.isdisjoint(forbidden)
+
+
+def test_operator_summary_contains_generated_admitted_rejected_blocked_counts(tmp_path: Path, capsys) -> None:
+    _write_payload(tmp_path, _valid_payload())
+    lifecycle.main(["--repo-root", str(tmp_path), "--write"])
+    capsys.readouterr()
+    text = (tmp_path / lifecycle.DEFAULT_OUTPUT_DIR / "operator_summary.md").read_text(encoding="utf-8")
+    assert "- Generated events: 2" in text
+    assert "- Admitted: 2" in text
+    assert "- Rejected: 0" in text
+    assert "- Blocked: 0" in text
+    assert "No candidates were created" in text
+    assert "No screening was run" in text
+


### PR DESCRIPTION
Summary:
- consumes Tiingo hypothesis E2E output
- creates research-only lifecycle records
- applies admitted/rejected/blocked admission boundary
- emits deterministic lifecycle events
- emits operator updates
- emits daily digest input
- does not create candidates
- does not run screening
- does not promote or register strategies

Validation:
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_lifecycle.py -q
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_generator_e2e.py -q
- python -m ruff check research/qre_tiingo_hypothesis_lifecycle.py tests/unit/test_qre_tiingo_hypothesis_lifecycle.py
- git diff --check
- manual lifecycle run if upstream artifact exists

Safety:
- trading_authority=false
- creates_candidates=false
- runs_screening=false
- promotes_candidates=false
- registers_strategy=false
- validation_authority=false
- paper/shadow/live authority=false
- frozen contracts not modified