### PR TITLE
research: show Tiingo lifecycle details in daily digest

### DIFF
--- a/docs/research/tiingo_hypothesis_lifecycle.md
+++ b/docs/research/tiingo_hypothesis_lifecycle.md
@@ -115,7 +115,7 @@ The latter three do not happen in this module.
 daily_digest_input.digest_kind = qre_hypothesis_lifecycle_daily_input
 ```
 
-The block contains generated/admitted/rejected/blocked counts, highlights, blocked-reason counts, next actions, and a false authority summary. The existing daily digest can consume this in a later PR. This PR does not add a scheduler or broad digest integration.
+The block contains generated/admitted/rejected/blocked counts, highlights, blocked-reason counts, next actions, and a false authority summary. The daily status digest consumes this block for observability only. This integration does not add a scheduler or broaden lifecycle authority.
 
 ## Daily status digest integration
 
@@ -136,6 +136,17 @@ When the lifecycle sidecar is present and ready, the daily digest shows:
 - screening run false
 - trading authority false
 - validation, paper, shadow, and live authority false
+
+The digest JSON exposes the same lifecycle details in the persisted daily status packet and in the CLI summary:
+
+```text
+tiingo_hypothesis_lifecycle_status
+tiingo_hypothesis_lifecycle_counts
+tiingo_hypothesis_lifecycle_next_actions
+tiingo_hypothesis_lifecycle_authority
+```
+
+`logs/qre_daily_status_digest/latest.json` persists those fields, and `logs/qre_daily_status_digest/operator_summary.md` includes a Tiingo hypothesis lifecycle section with generated/admitted/rejected/blocked counts, next safe action, and explicit false authority flags.
 
 Missing lifecycle artifacts are not fatal. The daily digest reports the lifecycle status as unavailable and continues without changing candidate, screening, or trading status.
 

--- a/research/qre_daily_status_digest.py
+++ b/research/qre_daily_status_digest.py
@@ -25,7 +25,7 @@ DEFAULT_SHADOW_READINESS_LATEST: Final[Path] = Path("logs/qre_shadow_readiness_g
 DEFAULT_TIINGO_HYPOTHESIS_LIFECYCLE_LATEST: Final[Path] = Path(
     "logs/qre_tiingo_hypothesis_lifecycle/latest.json"
 )
-DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_daily_status")
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_daily_status_digest")
 TIINGO_HYPOTHESIS_LIFECYCLE_REPORT_KIND: Final[str] = "qre_tiingo_hypothesis_lifecycle"
 TIINGO_HYPOTHESIS_LIFECYCLE_SAFETY_KEYS: Final[tuple[str, ...]] = (
     "trading_authority",
@@ -196,7 +196,7 @@ def _read_tiingo_hypothesis_lifecycle(path: Path) -> dict[str, Any]:
     )
     if unsafe_keys:
         return {
-            "status": "blocked",
+            "status": "blocked_unsafe_authority",
             "source_artifact": path.as_posix(),
             "report_kind": str(parsed.get("report_kind") or TIINGO_HYPOTHESIS_LIFECYCLE_REPORT_KIND),
             "daily_digest_ready": False,
@@ -542,6 +542,23 @@ def build_daily_status_packet(
             else latest_cycle.get("next_action", {}).get("recommended_action")
         )
     )
+    tiingo_lifecycle_counts = (
+        tiingo_hypothesis_lifecycle.get("counts")
+        if isinstance(tiingo_hypothesis_lifecycle.get("counts"), dict)
+        else _empty_tiingo_lifecycle_counts()
+    )
+    tiingo_lifecycle_next_actions = tiingo_hypothesis_lifecycle.get("next_safe_actions")
+    if not isinstance(tiingo_lifecycle_next_actions, list):
+        tiingo_lifecycle_next_actions = []
+    tiingo_lifecycle_authority = (
+        tiingo_hypothesis_lifecycle.get("authority_summary")
+        if isinstance(tiingo_hypothesis_lifecycle.get("authority_summary"), dict)
+        else _false_tiingo_lifecycle_authority_summary()
+    )
+    tiingo_lifecycle_authority = {
+        key: bool(tiingo_lifecycle_authority.get(key) is True)
+        for key in TIINGO_HYPOTHESIS_LIFECYCLE_SAFETY_KEYS
+    }
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
@@ -549,6 +566,12 @@ def build_daily_status_packet(
         "period_covered": "latest_autonomous_loop_artifact",
         "source_loop_latest": loop_latest_path.as_posix(),
         "artifact_paths_used": artifact_paths_used,
+        "tiingo_hypothesis_lifecycle_status": tiingo_hypothesis_lifecycle["status"],
+        "tiingo_hypothesis_lifecycle_counts": tiingo_lifecycle_counts,
+        "tiingo_hypothesis_lifecycle_next_actions": [
+            str(action) for action in tiingo_lifecycle_next_actions
+        ],
+        "tiingo_hypothesis_lifecycle_authority": tiingo_lifecycle_authority,
         "summary": {
             "autonomous_cycles": len(cycles),
             "controlled_research_inner_loops": summary.get("controlled_research_inner_loop_count"),
@@ -605,6 +628,11 @@ def build_daily_status_packet(
             ),
             "qre_exact_next_action": qre_exact_next_action,
             "tiingo_hypothesis_lifecycle_status": tiingo_hypothesis_lifecycle["status"],
+            "tiingo_hypothesis_lifecycle_counts": tiingo_lifecycle_counts,
+            "tiingo_hypothesis_lifecycle_next_actions": [
+                str(action) for action in tiingo_lifecycle_next_actions
+            ],
+            "tiingo_hypothesis_lifecycle_authority": tiingo_lifecycle_authority,
             "flywheel_progress": {
                 "build_request_consumed": _yes_no_unknown(
                     build_requests_consumed > 0 if build_requests_consumed else None

--- a/tests/unit/test_qre_daily_status_digest.py
+++ b/tests/unit/test_qre_daily_status_digest.py
@@ -475,6 +475,53 @@ def test_valid_tiingo_lifecycle_appears_in_structured_digest_output(tmp_path: Pa
         },
     }
     assert tiingo_path.as_posix() in packet["artifact_paths_used"]
+    expected_counts = {
+        "generated": 5,
+        "admitted": 5,
+        "rejected": 0,
+        "blocked": 0,
+    }
+    expected_next_actions = ["materialize_research_candidate_later"]
+    expected_authority = {
+        "trading_authority": False,
+        "creates_candidates": False,
+        "runs_screening": False,
+        "promotes_candidates": False,
+        "registers_strategy": False,
+        "validation_authority": False,
+        "paper_authority": False,
+        "shadow_authority": False,
+        "live_authority": False,
+    }
+    assert packet["tiingo_hypothesis_lifecycle_status"] == "ready"
+    assert packet["tiingo_hypothesis_lifecycle_counts"] == expected_counts
+    assert packet["tiingo_hypothesis_lifecycle_next_actions"] == expected_next_actions
+    assert packet["tiingo_hypothesis_lifecycle_authority"] == expected_authority
+    assert packet["summary"]["tiingo_hypothesis_lifecycle_status"] == "ready"
+    assert packet["summary"]["tiingo_hypothesis_lifecycle_counts"] == expected_counts
+    assert packet["summary"]["tiingo_hypothesis_lifecycle_next_actions"] == expected_next_actions
+    assert packet["summary"]["tiingo_hypothesis_lifecycle_authority"] == expected_authority
+
+
+def test_valid_tiingo_lifecycle_writes_details_to_latest_json(tmp_path: Path) -> None:
+    tiingo_path = _write_tiingo_lifecycle(tmp_path)
+
+    _run_digest(tmp_path, tiingo_hypothesis_lifecycle_latest_path=tiingo_path)
+
+    latest = json.loads((tmp_path / "daily" / "latest.json").read_text(encoding="utf-8"))
+    assert latest["tiingo_hypothesis_lifecycle_status"] == "ready"
+    assert latest["tiingo_hypothesis_lifecycle_counts"] == {
+        "generated": 5,
+        "admitted": 5,
+        "rejected": 0,
+        "blocked": 0,
+    }
+    assert latest["tiingo_hypothesis_lifecycle_next_actions"] == [
+        "materialize_research_candidate_later"
+    ]
+    assert latest["tiingo_hypothesis_lifecycle_authority"]["creates_candidates"] is False
+    assert latest["tiingo_hypothesis_lifecycle_authority"]["runs_screening"] is False
+    assert latest["tiingo_hypothesis_lifecycle_authority"]["trading_authority"] is False
 
 
 def test_valid_tiingo_lifecycle_appears_in_operator_summary(tmp_path: Path) -> None:
@@ -492,11 +539,25 @@ def test_valid_tiingo_lifecycle_appears_in_operator_summary(tmp_path: Path) -> N
     assert "- Candidate creation: false" in rendered
     assert "- Screening run: false" in rendered
     assert "- Trading authority: false" in rendered
+    assert "- Validation authority: false" in rendered
+    assert "- Paper authority: false" in rendered
+    assert "- Shadow authority: false" in rendered
+    assert "- Live authority: false" in rendered
     assert "admitted for future research-only candidate formulation; candidate created: false" in rendered
 
     daily = (tmp_path / "daily" / "daily_status.md").read_text(encoding="utf-8")
+    operator_summary = (tmp_path / "daily" / "operator_summary.md").read_text(encoding="utf-8")
     assert "- Hypotheses generated: 5" in daily
     assert "- Candidate creation: false" in daily
+    assert "Tiingo hypothesis lifecycle:" in operator_summary
+    assert "- Hypotheses generated: 5" in operator_summary
+    assert "- Admitted: 5" in operator_summary
+    assert "- Rejected: 0" in operator_summary
+    assert "- Blocked: 0" in operator_summary
+    assert "- Next safe action: materialize_research_candidate_later" in operator_summary
+    assert "- Candidate creation: false" in operator_summary
+    assert "- Screening run: false" in operator_summary
+    assert "- Trading authority: false" in operator_summary
 
 
 def test_unsafe_tiingo_lifecycle_authority_signal_is_blocked(tmp_path: Path) -> None:
@@ -519,12 +580,15 @@ def test_unsafe_tiingo_lifecycle_authority_signal_is_blocked(tmp_path: Path) -> 
         )
 
         lifecycle = packet["tiingo_hypothesis_lifecycle"]
-        assert lifecycle["status"] == "blocked"
+        assert lifecycle["status"] == "blocked_unsafe_authority"
         assert lifecycle["diagnostic_reason"] == "unsafe_tiingo_lifecycle_authority_signal"
         assert unsafe_key in lifecycle["unsafe_authority_keys"]
         assert lifecycle["authority_summary"]["trading_authority"] is False
         assert lifecycle["authority_summary"]["creates_candidates"] is False
         assert lifecycle["authority_summary"]["runs_screening"] is False
+        assert packet["tiingo_hypothesis_lifecycle_authority"]["trading_authority"] is False
+        assert packet["tiingo_hypothesis_lifecycle_authority"]["creates_candidates"] is False
+        assert packet["tiingo_hypothesis_lifecycle_authority"]["runs_screening"] is False
 
 
 def test_malformed_tiingo_lifecycle_artifact_is_reported_without_crashing(tmp_path: Path) -> None:
@@ -577,4 +641,19 @@ def test_tiingo_lifecycle_ingestion_does_not_mutate_protected_research_outputs(t
     assert strategy_matrix.read_bytes() == before_matrix
     assert packet["tiingo_hypothesis_lifecycle"]["authority_summary"]["creates_candidates"] is False
     assert packet["tiingo_hypothesis_lifecycle"]["authority_summary"]["runs_screening"] is False
+
+
+def test_tiingo_lifecycle_ingestion_does_not_create_candidates_or_run_screening(tmp_path: Path) -> None:
+    tiingo_path = _write_tiingo_lifecycle(tmp_path)
+
+    packet = _run_digest(tmp_path, tiingo_hypothesis_lifecycle_latest_path=tiingo_path)
+
+    authority = packet["tiingo_hypothesis_lifecycle_authority"]
+    assert authority["creates_candidates"] is False
+    assert authority["runs_screening"] is False
+    assert authority["trading_authority"] is False
+    assert authority["validation_authority"] is False
+    assert authority["paper_authority"] is False
+    assert authority["shadow_authority"] is False
+    assert authority["live_authority"] is False
 


### PR DESCRIPTION
Summary:
- expands Tiingo lifecycle daily digest output beyond status-only
- adds generated/admitted/rejected/blocked counts
- adds next safe action
- adds explicit authority summary
- adds operator-summary Tiingo lifecycle section

Validation:
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_lifecycle.py -q
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_generator_e2e.py -q
- python -m ruff check research/qre_daily_status_digest.py tests/unit/test_qre_daily_status_digest.py
- git diff --check
- manual compact digest verification

Safety:
- observability-only
- creates_candidates=false
- runs_screening=false
- trading_authority=false
- no validation/promotion/strategy registration
- no paper/shadow/live
- frozen contracts not modified