### PR TITLE
research: add Tiingo research-only candidate loop

### DIFF
--- a/docs/research/tiingo_candidate_research_loop.md
+++ b/docs/research/tiingo_candidate_research_loop.md
@@ -1,0 +1,227 @@
+# Tiingo Candidate Research Loop
+
+## Purpose
+
+This PR closes a research-only mini-loop from admitted Tiingo hypothesis seeds to candidate specs, screening results, feedback records, and next-run feedback consumption.
+
+The module is an observability and research-screening bridge. It consumes the governed Tiingo hypothesis lifecycle artifact and turns admitted lifecycle records into deterministic research-only candidate specs, screens those specs against local Tiingo bars, writes feedback records, and lets a later run consume that feedback.
+
+## Scope
+
+The loop is:
+
+```text
+Tiingo hypothesis lifecycle artifact
+-> stable seed input contract
+-> deterministic research-only candidate spec
+-> screening metrics and null controls
+-> feedback record
+-> next-run feedback consumption
+```
+
+The implementation lives in:
+
+```text
+research/qre_tiingo_candidate_research_loop.py
+```
+
+Default mode prints JSON and writes nothing:
+
+```powershell
+python -m research.qre_tiingo_candidate_research_loop
+```
+
+Write mode writes only:
+
+```text
+logs/qre_tiingo_candidate_research_loop/
+```
+
+## What This PR Builds
+
+- stable input contracts from admitted Tiingo lifecycle records
+- deterministic research-only candidate specs for the five admitted Tiingo feature families
+- screening metrics over local Tiingo bars
+- seeded shuffled-selection null controls
+- equal-weight benchmark comparison
+- feedback records for retain, reject, modify, block, or insufficient-evidence outcomes
+- next-run feedback consumption that can retain, suppress, modify, defer, or block candidate handling
+- JSONL sidecars and an operator summary
+- daily-digest-ready input block for a later digest integration PR
+
+## What This PR Does Not Build
+
+This does not create validation-ready strategies, paper/shadow/live readiness, trading signals, orders, broker instructions, or risk approvals.
+
+It also does not:
+
+- call `research.run_research`
+- call a campaign launcher
+- register strategies
+- promote candidates
+- start validation
+- enable paper mode
+- enable shadow mode
+- enable live mode
+- create orders or positions
+- grant broker, risk, or trading authority
+- mutate `research/research_latest.json`
+- mutate `research/strategy_matrix.csv`
+
+## Input Contracts
+
+The module consumes:
+
+```text
+logs/qre_tiingo_hypothesis_lifecycle/latest.json
+```
+
+It fails closed unless the lifecycle artifact is present, well-formed, from `qre_tiingo_hypothesis_lifecycle`, has `summary.lifecycle_verdict=pass_research_only_admission_boundary`, has `summary.daily_digest_ready=true`, and keeps all lifecycle authority flags false.
+
+Only admitted lifecycle records become contracts. Rejected or blocked records are skipped. Contract IDs are deterministic and based on the hypothesis seed ID, source hypothesis ID, source snapshot ID, feature family, and source hypothesis digest.
+
+## Candidate Materialization
+
+Each admitted input contract materializes at most one v1 research-only candidate spec unless `--max-candidates` limits it or prior feedback suppresses it.
+
+Implemented feature-family templates:
+
+- `cross_sectional_momentum`
+- `risk_on_risk_off_regime`
+- `defensive_rotation`
+- `volatility_compression_breakout`
+- `mean_reversion_after_extreme_dispersion`
+
+Unknown families are blocked with `blocked_unknown_candidate_family`.
+
+Candidate specs are not executable strategy registrations. They keep:
+
+```text
+research_only=true
+screening_only=true
+not_trade_signal=true
+trading_authority=false
+creates_orders=false
+```
+
+## Screening Metrics
+
+Screening uses local Tiingo bars only. It does not download data or call external APIs.
+
+The screening protocol is:
+
+```text
+tiingo_research_candidate_screening_v1
+```
+
+Metrics include:
+
+- observation count
+- rebalance count
+- selection count
+- candidate total return
+- equal-weight benchmark total return
+- excess return
+- annualized return
+- annualized volatility
+- sharpe-like score
+- max drawdown
+- win rate
+- turnover proxy
+
+Minimum evidence gates require at least 252 observations, 12 rebalance windows, 16 null iterations, and finite candidate and benchmark metrics.
+
+## Null Controls
+
+Each screened candidate receives seeded null controls:
+
+- `shuffled_selection_null`
+- `equal_weight_benchmark`
+
+The shuffled-selection null is deterministic for a fixed seed and changes when the seed changes.
+
+## Feedback Records
+
+Each screening result maps to one feedback record:
+
+```text
+screening_pass -> retain_for_more_screening
+null_not_beaten -> modify_candidate_later
+screening_fail -> reject_candidate_for_now
+insufficient_evidence -> insufficient_evidence
+blocked_unsafe_input -> block_candidate
+```
+
+Feedback records are consumable by the next run and keep:
+
+```text
+research_only=true
+trading_authority=false
+```
+
+## Next-Run Feedback Consumption
+
+If `--prior-feedback-input` exists, the module reads feedback records before writing any new outputs.
+
+Prior feedback changes later candidate handling:
+
+- retain feedback rematerializes the same candidate
+- reject feedback suppresses the same candidate
+- modify feedback creates a deterministic modified candidate variant
+- insufficient-evidence feedback defers screening and records the need for more data
+- block feedback blocks materialization
+
+This is the minimum closed research-only loop for this phase.
+
+## Output Artifacts
+
+Write mode produces:
+
+```text
+logs/qre_tiingo_candidate_research_loop/latest.json
+logs/qre_tiingo_candidate_research_loop/input_contracts.jsonl
+logs/qre_tiingo_candidate_research_loop/candidate_specs.jsonl
+logs/qre_tiingo_candidate_research_loop/screening_results.jsonl
+logs/qre_tiingo_candidate_research_loop/feedback_records.jsonl
+logs/qre_tiingo_candidate_research_loop/operator_summary.md
+```
+
+Generated logs are not committed.
+
+## Safety Boundaries
+
+Every report keeps:
+
+```text
+research_only=true
+screening_only=true
+trading_authority=false
+creates_orders=false
+broker_authority=false
+risk_authority=false
+promotes_candidates=false
+registers_strategy=false
+validation_authority=false
+paper_authority=false
+shadow_authority=false
+live_authority=false
+```
+
+The operator summary ends with:
+
+```text
+No orders were created. No broker/risk authority exists. No validation, promotion, strategy registration, paper, shadow, or live authority was granted.
+```
+
+## Relationship To QRE Feedback-Loop Closure
+
+This closes a narrow research-only feedback loop for Tiingo-derived hypotheses. It does not close the broader QRE feedback loop across strategy registration, validation, paper readiness, shadow readiness, or live readiness.
+
+The loop is deliberately bounded to candidate screening and feedback consumption. It provides a deterministic proof that research feedback can affect the next candidate handling decision without granting active trading authority.
+
+## Next Safe PR
+
+1. include Tiingo candidate research loop status in daily digest
+2. broaden candidate parameter variants under feedback control
+3. add evidence ledger sidecar for research-only candidate screening
+

--- a/research/qre_tiingo_candidate_research_loop.py
+++ b/research/qre_tiingo_candidate_research_loop.py
@@ -1,0 +1,1401 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import os
+import random
+import statistics
+import tempfile
+from collections import defaultdict
+from contextlib import suppress
+from datetime import UTC, datetime
+from itertools import pairwise
+from pathlib import Path
+from typing import Any, Final
+
+from research.qre_tiingo_hypothesis_generator_e2e import apply_research_price_continuity
+
+REPORT_KIND: Final[str] = "qre_tiingo_candidate_research_loop"
+SCHEMA_VERSION: Final[int] = 1
+LIFECYCLE_REPORT_KIND: Final[str] = "qre_tiingo_hypothesis_lifecycle"
+UPSTREAM_REPORT_KIND: Final[str] = "qre_tiingo_hypothesis_generator_e2e"
+DEFAULT_LIFECYCLE_INPUT: Final[Path] = Path("logs/qre_tiingo_hypothesis_lifecycle/latest.json")
+DEFAULT_UPSTREAM_E2E_INPUT: Final[Path] = Path("logs/qre_tiingo_hypothesis_generator_e2e/latest.json")
+DEFAULT_BARS_INPUT: Final[Path] = Path(
+    "data/imports/tiingo_eod_equities_free/tiingo_eod_etf_20210101_20251231/bars.csv"
+)
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_tiingo_candidate_research_loop")
+DEFAULT_PRIOR_FEEDBACK_INPUT: Final[Path] = DEFAULT_OUTPUT_DIR / "latest.json"
+SCREENING_PROTOCOL: Final[str] = "tiingo_research_candidate_screening_v1"
+EXPECTED_UNIVERSE: Final[tuple[str, ...]] = (
+    "SPY",
+    "QQQ",
+    "IWM",
+    "DIA",
+    "TLT",
+    "GLD",
+    "XLK",
+    "XLF",
+    "XLE",
+    "XLV",
+)
+SAFETY: Final[dict[str, bool]] = {
+    "research_only": True,
+    "screening_only": True,
+    "trading_authority": False,
+    "creates_orders": False,
+    "broker_authority": False,
+    "risk_authority": False,
+    "promotes_candidates": False,
+    "registers_strategy": False,
+    "validation_authority": False,
+    "paper_authority": False,
+    "shadow_authority": False,
+    "live_authority": False,
+}
+LIFECYCLE_FALSE_AUTHORITY_KEYS: Final[tuple[str, ...]] = (
+    "trading_authority",
+    "creates_candidates",
+    "runs_screening",
+    "promotes_candidates",
+    "registers_strategy",
+    "validation_authority",
+    "paper_authority",
+    "shadow_authority",
+    "live_authority",
+)
+ALLOWED_LOOP_VERDICTS: Final[set[str]] = {
+    "pass_research_only_candidate_loop",
+    "blocked_missing_or_unsafe_input",
+    "blocked_no_admitted_hypotheses",
+    "blocked_no_candidate_specs",
+    "blocked_no_screening_data",
+    "partial_feedback_only",
+}
+ALLOWED_SCREENING_DECISIONS: Final[set[str]] = {
+    "screening_pass",
+    "screening_fail",
+    "null_not_beaten",
+    "insufficient_evidence",
+    "blocked_unsafe_input",
+}
+KNOWN_FAMILIES: Final[set[str]] = {
+    "cross_sectional_momentum",
+    "risk_on_risk_off_regime",
+    "defensive_rotation",
+    "volatility_compression_breakout",
+    "mean_reversion_after_extreme_dispersion",
+}
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _stable_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _stable_payload(value[key]) for key in sorted(value)}
+    if isinstance(value, list | tuple):
+        return [_stable_payload(item) for item in value]
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return round(value, 10)
+    return value
+
+
+def _digest(value: Any, *, length: int = 16) -> str:
+    payload = json.dumps(
+        _stable_payload(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:length]
+
+
+def _sha(value: Any) -> str:
+    return "sha256:" + _digest(value, length=64)
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, "missing_artifact"
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None, "malformed_artifact"
+    if not isinstance(parsed, dict):
+        return None, "malformed_artifact"
+    return parsed, None
+
+
+def _source_path(path: Path, repo_root: Path) -> str:
+    resolved = path if path.is_absolute() else repo_root / path
+    try:
+        return resolved.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _run_config(*, max_candidates: int, null_iterations: int, seed: int) -> dict[str, Any]:
+    return {
+        "max_candidates": max_candidates,
+        "null_iterations": null_iterations,
+        "seed": seed,
+        "screening_only": True,
+        "research_only": True,
+    }
+
+
+def _empty_summary() -> dict[str, Any]:
+    return {
+        "loop_verdict": "blocked_missing_or_unsafe_input",
+        "input_contracts_seen": 0,
+        "input_contracts_admitted": 0,
+        "candidates_materialized": 0,
+        "candidates_screened": 0,
+        "screening_pass": 0,
+        "screening_fail": 0,
+        "null_not_beaten": 0,
+        "insufficient_evidence": 0,
+        "feedback_records": 0,
+        "feedback_consumed": False,
+        "feedback_applied_count": 0,
+        "next_run_feedback_ready": False,
+        "suppressed_by_prior_feedback": 0,
+        "modified_by_prior_feedback": 0,
+        "retained_by_prior_feedback": 0,
+    }
+
+
+def _daily_digest_input(report: dict[str, Any]) -> dict[str, Any]:
+    summary = report["summary"]
+    return {
+        "digest_kind": "qre_tiingo_candidate_research_loop_daily_input",
+        "source": REPORT_KIND,
+        "source_snapshot_id": report.get("source_snapshot_id", "unknown"),
+        "counts": {
+            "input_contracts_admitted": summary["input_contracts_admitted"],
+            "candidates_materialized": summary["candidates_materialized"],
+            "candidates_screened": summary["candidates_screened"],
+            "screening_pass": summary["screening_pass"],
+            "screening_fail": summary["screening_fail"],
+            "null_not_beaten": summary["null_not_beaten"],
+            "insufficient_evidence": summary["insufficient_evidence"],
+            "feedback_records": summary["feedback_records"],
+        },
+        "next_actions": sorted(
+            {
+                str(record.get("next_candidate_action"))
+                for record in report.get("feedback_records", [])
+                if record.get("next_candidate_action")
+            }
+        ),
+        "authority_summary": dict(SAFETY),
+    }
+
+
+def _base_report(
+    *,
+    lifecycle: dict[str, Any] | None,
+    upstream: dict[str, Any] | None,
+    run_config: dict[str, Any],
+    blocked_reasons: list[str],
+) -> dict[str, Any]:
+    source_snapshot_id = "unknown"
+    if isinstance(lifecycle, dict) and lifecycle.get("source_snapshot_id"):
+        source_snapshot_id = str(lifecycle["source_snapshot_id"])
+    elif isinstance(upstream, dict) and upstream.get("source_snapshot_id"):
+        source_snapshot_id = str(upstream["source_snapshot_id"])
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _utcnow(),
+        "source_snapshot_id": source_snapshot_id,
+        "source_lifecycle_report_kind": LIFECYCLE_REPORT_KIND,
+        "source_hypothesis_report_kind": UPSTREAM_REPORT_KIND,
+        "run_config": run_config,
+        "summary": _empty_summary(),
+        "input_contracts": [],
+        "candidate_specs": [],
+        "screening_results": [],
+        "feedback_records": [],
+        "prior_feedback": {
+            "feedback_consumed": False,
+            "feedback_source_path": None,
+            "feedback_records_seen": 0,
+            "feedback_applied_count": 0,
+            "feedback_application": [],
+        },
+        "next_run_plan": {},
+        "daily_digest_input": {},
+        "safety": dict(SAFETY),
+        "blocked_reasons": sorted(dict.fromkeys(blocked_reasons)),
+    }
+
+
+def _blocked_report(
+    *,
+    lifecycle: dict[str, Any] | None,
+    upstream: dict[str, Any] | None,
+    run_config: dict[str, Any],
+    loop_verdict: str,
+    blocked_reasons: list[str],
+    prior_feedback: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    report = _base_report(
+        lifecycle=lifecycle,
+        upstream=upstream,
+        run_config=run_config,
+        blocked_reasons=blocked_reasons,
+    )
+    report["summary"]["loop_verdict"] = loop_verdict
+    if prior_feedback is not None:
+        report["prior_feedback"] = prior_feedback
+        report["summary"]["feedback_consumed"] = prior_feedback["feedback_consumed"]
+        report["summary"]["feedback_applied_count"] = prior_feedback["feedback_applied_count"]
+    report["daily_digest_input"] = _daily_digest_input(report)
+    return report
+
+
+def _validate_lifecycle(lifecycle: dict[str, Any] | None, load_error: str | None) -> list[str]:
+    if load_error == "missing_artifact":
+        return ["missing_lifecycle_artifact"]
+    if load_error is not None or lifecycle is None:
+        return ["malformed_lifecycle_artifact"]
+    reasons: list[str] = []
+    summary = lifecycle.get("summary") if isinstance(lifecycle.get("summary"), dict) else {}
+    safety = lifecycle.get("safety") if isinstance(lifecycle.get("safety"), dict) else {}
+    if lifecycle.get("report_kind") != LIFECYCLE_REPORT_KIND:
+        reasons.append("unexpected_lifecycle_report_kind")
+    if summary.get("lifecycle_verdict") != "pass_research_only_admission_boundary":
+        reasons.append("lifecycle_verdict_not_pass")
+    if summary.get("daily_digest_ready") is not True:
+        reasons.append("lifecycle_daily_digest_not_ready")
+    for key in LIFECYCLE_FALSE_AUTHORITY_KEYS:
+        if safety.get(key) is not False:
+            reasons.append(f"unsafe_lifecycle_authority:{key}")
+    records = lifecycle.get("hypothesis_lifecycle")
+    if not isinstance(records, list):
+        reasons.append("missing_hypothesis_lifecycle_records")
+    return sorted(dict.fromkeys(reasons))
+
+
+def build_input_contracts(lifecycle: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    rows = lifecycle.get("hypothesis_lifecycle")
+    records = rows if isinstance(rows, list) else []
+    contracts: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for row in records:
+        if not isinstance(row, dict):
+            continue
+        if row.get("decision") != "admitted" or row.get("status") != "admissible_for_research_candidate_formulation":
+            skipped.append(
+                {
+                    "source_hypothesis_id": row.get("source_hypothesis_id"),
+                    "decision": row.get("decision"),
+                    "status": row.get("status"),
+                    "reason": "not_admitted_lifecycle_record",
+                }
+            )
+            continue
+        digest_value = {
+            "hypothesis_seed_id": row.get("hypothesis_seed_id"),
+            "source_hypothesis_id": row.get("source_hypothesis_id"),
+            "source_snapshot_id": row.get("source_snapshot_id"),
+            "feature_family": row.get("feature_family"),
+            "source_hypothesis_digest": (row.get("source_hypothesis_digest") or {}).get("digest")
+            if isinstance(row.get("source_hypothesis_digest"), dict)
+            else None,
+        }
+        contract_id = "contract_tiingo_" + _digest(digest_value)
+        contract = {
+            "contract_id": contract_id,
+            "schema_version": 1,
+            "source": LIFECYCLE_REPORT_KIND,
+            "hypothesis_seed_id": str(row.get("hypothesis_seed_id")),
+            "source_hypothesis_id": str(row.get("source_hypothesis_id")),
+            "source_snapshot_id": str(row.get("source_snapshot_id")),
+            "feature_family": str(row.get("feature_family")),
+            "status": "admissible_for_research_candidate_formulation",
+            "decision": "admitted",
+            "source_hypothesis_digest": row.get("source_hypothesis_digest")
+            if isinstance(row.get("source_hypothesis_digest"), dict)
+            else {},
+            "required_candidate_spec_fields": list(row.get("required_candidate_spec_fields") or []),
+            "allowed_candidate_families": list(row.get("allowed_candidate_families") or []),
+            "forbidden_authorities": list(row.get("forbidden_authorities") or []),
+            "research_only": True,
+            "screening_only": True,
+            "trading_authority": False,
+        }
+        contract["contract_digest"] = _sha({key: value for key, value in contract.items() if key != "contract_digest"})
+        contracts.append(contract)
+    contracts.sort(key=lambda item: item["contract_id"])
+    return contracts, skipped
+
+
+def _candidate_template(feature_family: str, *, variant: str = "v1") -> dict[str, Any] | None:
+    lookback = 40 if variant == "modified_by_prior_feedback" else 60
+    if feature_family == "cross_sectional_momentum":
+        return {
+            "candidate_family": "cross_sectional_momentum",
+            "signal_definition": {
+                "type": "rank_trailing_adjusted_return",
+                "lookback_trading_days": lookback,
+                "price": "split_adjusted_research_close",
+            },
+            "selection_rule": {"type": "top_n", "count": 3},
+            "rebalance_rule": {"frequency_trading_days": 20},
+            "holding_period": {"trading_days": 20},
+            "benchmark": {"type": "equal_weight_universe"},
+            "universe": list(EXPECTED_UNIVERSE),
+        }
+    if feature_family == "risk_on_risk_off_regime":
+        return {
+            "candidate_family": "risk_on_risk_off_regime",
+            "signal_definition": {
+                "type": "spy_vs_tlt_relative_strength",
+                "lookback_trading_days": lookback,
+                "price": "split_adjusted_research_close",
+            },
+            "selection_rule": {
+                "type": "risk_on_else_defensive",
+                "risk_on_basket": ["SPY", "QQQ", "XLK"],
+                "defensive_basket": ["TLT", "GLD", "XLV"],
+            },
+            "rebalance_rule": {"frequency_trading_days": 20},
+            "holding_period": {"trading_days": 20},
+            "benchmark": {"type": "equal_weight_universe"},
+            "universe": list(EXPECTED_UNIVERSE),
+        }
+    if feature_family == "defensive_rotation":
+        defensive_count = 1 if variant == "modified_by_prior_feedback" else 2
+        return {
+            "candidate_family": "defensive_rotation",
+            "signal_definition": {
+                "type": "defensive_score_vs_spy",
+                "lookback_trading_days": 60,
+                "price": "split_adjusted_research_close",
+            },
+            "selection_rule": {
+                "type": "defensive_when_spy_negative_else_spy_qqq",
+                "defensive_count": defensive_count,
+                "defensive_basket": ["TLT", "GLD", "XLV"],
+            },
+            "rebalance_rule": {"frequency_trading_days": 20},
+            "holding_period": {"trading_days": 20},
+            "benchmark": {"type": "equal_weight_universe"},
+            "universe": list(EXPECTED_UNIVERSE),
+        }
+    if feature_family == "volatility_compression_breakout":
+        vol_lookback = 30 if variant == "modified_by_prior_feedback" else 20
+        return {
+            "candidate_family": "volatility_compression_breakout",
+            "signal_definition": {
+                "type": "volatility_compression_positive_return",
+                "volatility_lookback_trading_days": vol_lookback,
+                "return_lookback_trading_days": 20,
+                "price": "split_adjusted_research_close",
+            },
+            "selection_rule": {"type": "lowest_vol_with_positive_return", "count": 3},
+            "rebalance_rule": {"frequency_trading_days": 20},
+            "holding_period": {"trading_days": 20},
+            "benchmark": {"type": "equal_weight_universe"},
+            "universe": list(EXPECTED_UNIVERSE),
+        }
+    if feature_family == "mean_reversion_after_extreme_dispersion":
+        threshold = "p75" if variant == "modified_by_prior_feedback" else "rolling_median"
+        return {
+            "candidate_family": "mean_reversion_after_extreme_dispersion",
+            "signal_definition": {
+                "type": "cross_sectional_dispersion_return_rank",
+                "return_lookback_trading_days": 20,
+                "dispersion_threshold": threshold,
+                "price": "split_adjusted_research_close",
+            },
+            "selection_rule": {"type": "bottom_n_when_dispersion_above_threshold", "count": 3},
+            "rebalance_rule": {"frequency_trading_days": 20},
+            "holding_period": {"trading_days": 20},
+            "benchmark": {"type": "equal_weight_universe"},
+            "universe": list(EXPECTED_UNIVERSE),
+        }
+    return None
+
+
+def materialize_candidate_spec(
+    contract: dict[str, Any],
+    *,
+    variant: str = "v1",
+    feedback_note: str | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    family = str(contract.get("feature_family"))
+    template = _candidate_template(family, variant=variant)
+    if template is None:
+        return None, "blocked_unknown_candidate_family"
+    id_basis = {
+        "contract_id": contract["contract_id"],
+        "feature_family": family,
+        "signal_definition": template["signal_definition"],
+        "selection_rule": template["selection_rule"],
+        "rebalance_rule": template["rebalance_rule"],
+        "holding_period": template["holding_period"],
+        "benchmark": template["benchmark"],
+        "source_snapshot_id": contract["source_snapshot_id"],
+        "variant": variant,
+    }
+    candidate = {
+        "candidate_id": "cand_tiingo_" + _digest(id_basis),
+        "candidate_schema_version": 1,
+        "parent_contract_id": contract["contract_id"],
+        "parent_hypothesis_seed_id": contract["hypothesis_seed_id"],
+        "source_hypothesis_id": contract["source_hypothesis_id"],
+        "source_snapshot_id": contract["source_snapshot_id"],
+        "feature_family": family,
+        "candidate_family": template["candidate_family"],
+        "signal_definition": template["signal_definition"],
+        "selection_rule": template["selection_rule"],
+        "rebalance_rule": template["rebalance_rule"],
+        "holding_period": template["holding_period"],
+        "benchmark": template["benchmark"],
+        "universe": template["universe"],
+        "null_control_requirement": "required",
+        "split_adjustment_requirement": "required",
+        "screening_protocol": SCREENING_PROTOCOL,
+        "screening_only": True,
+        "research_only": True,
+        "not_trade_signal": True,
+        "trading_authority": False,
+        "creates_orders": False,
+        "forbidden_authorities": list(contract.get("forbidden_authorities") or []),
+        "prior_feedback_variant": variant,
+    }
+    if feedback_note:
+        candidate["prior_feedback_note"] = feedback_note
+    candidate["candidate_digest"] = _sha({key: value for key, value in candidate.items() if key != "candidate_digest"})
+    return candidate, None
+
+
+def _normalize_columns(fieldnames: list[str] | None) -> dict[str, str]:
+    available = {str(name).strip().lower(): str(name) for name in fieldnames or []}
+    aliases = {
+        "date": ("date", "datetime", "timestamp", "timestamp_utc"),
+        "symbol": ("symbol", "ticker"),
+        "open": ("open",),
+        "high": ("high",),
+        "low": ("low",),
+        "close": ("close", "adjclose", "adj_close"),
+        "volume": ("volume",),
+    }
+    columns: dict[str, str] = {}
+    for target, names in aliases.items():
+        for name in names:
+            if name in available:
+                columns[target] = available[name]
+                break
+    return columns
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def load_bars(path: Path) -> tuple[list[dict[str, Any]] | None, list[str]]:
+    if not path.is_file():
+        return None, ["missing_bars_input"]
+    try:
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle)
+            columns = _normalize_columns(reader.fieldnames)
+            missing = [name for name in ("date", "symbol", "open", "high", "low", "close", "volume") if name not in columns]
+            if missing:
+                return None, [f"malformed_bars_input:missing_columns:{','.join(missing)}"]
+            bars: list[dict[str, Any]] = []
+            for raw in reader:
+                symbol = str(raw.get(columns["symbol"]) or "").strip().upper()
+                if not symbol:
+                    continue
+                open_ = _to_float(raw.get(columns["open"]))
+                high = _to_float(raw.get(columns["high"]))
+                low = _to_float(raw.get(columns["low"]))
+                close = _to_float(raw.get(columns["close"]))
+                volume = _to_float(raw.get(columns["volume"]))
+                if None in (open_, high, low, close, volume):
+                    return None, ["malformed_bars_input:non_numeric_ohlcv"]
+                bars.append(
+                    {
+                        "date": str(raw.get(columns["date"]) or "")[:10],
+                        "symbol": symbol,
+                        "open": float(open_),
+                        "high": float(high),
+                        "low": float(low),
+                        "close": float(close),
+                        "volume": float(volume),
+                    }
+                )
+    except OSError:
+        return None, ["malformed_bars_input:unreadable"]
+    if not bars:
+        return None, ["malformed_bars_input:no_rows"]
+    adjusted, events, unresolved = apply_research_price_continuity(bars)
+    if unresolved:
+        return None, ["malformed_bars_input:unresolved_split_like_discontinuity"]
+    for row in adjusted:
+        row["split_adjustment_events_count"] = len(events)
+    return adjusted, []
+
+
+def _research_close(row: dict[str, Any]) -> float:
+    return float(row.get("adjusted_close_for_research", row["close"]))
+
+
+def _group_closes(bars: list[dict[str, Any]]) -> tuple[list[str], dict[str, list[float]]]:
+    by_symbol: dict[str, dict[str, float]] = defaultdict(dict)
+    for row in bars:
+        by_symbol[str(row["symbol"])][str(row["date"])] = _research_close(row)
+    common_dates = sorted(set.intersection(*(set(rows) for rows in by_symbol.values()))) if by_symbol else []
+    closes = {
+        symbol: [by_symbol[symbol][date] for date in common_dates]
+        for symbol in sorted(by_symbol)
+        if len(by_symbol[symbol]) >= 2
+    }
+    return common_dates, closes
+
+
+def _return_over(closes: list[float], start: int, end: int) -> float | None:
+    if start < 0 or end >= len(closes) or closes[start] <= 0:
+        return None
+    return closes[end] / closes[start] - 1.0
+
+
+def _trailing_return(closes: list[float], idx: int, lookback: int) -> float | None:
+    return _return_over(closes, idx - lookback, idx)
+
+
+def _trailing_vol(closes: list[float], idx: int, lookback: int) -> float | None:
+    if idx - lookback < 0:
+        return None
+    returns = [
+        closes[pos] / closes[pos - 1] - 1.0
+        for pos in range(idx - lookback + 1, idx + 1)
+        if closes[pos - 1] > 0
+    ]
+    if len(returns) < lookback:
+        return None
+    return statistics.pstdev(returns)
+
+
+def _select_symbols(candidate: dict[str, Any], closes: dict[str, list[float]], idx: int, history: list[float]) -> list[str]:
+    family = candidate["feature_family"]
+    universe = [symbol for symbol in candidate["universe"] if symbol in closes]
+    if family == "cross_sectional_momentum":
+        lookback = int(candidate["signal_definition"]["lookback_trading_days"])
+        ranked = [
+            (symbol, _trailing_return(closes[symbol], idx, lookback))
+            for symbol in universe
+        ]
+        ranked = [(symbol, value) for symbol, value in ranked if value is not None]
+        ranked.sort(key=lambda item: (-float(item[1]), item[0]))
+        return [symbol for symbol, _value in ranked[: int(candidate["selection_rule"]["count"])]]
+    if family == "risk_on_risk_off_regime":
+        lookback = int(candidate["signal_definition"]["lookback_trading_days"])
+        spy = _trailing_return(closes.get("SPY", []), idx, lookback)
+        tlt = _trailing_return(closes.get("TLT", []), idx, lookback)
+        basket = candidate["selection_rule"]["risk_on_basket"] if spy is not None and tlt is not None and spy > tlt else candidate["selection_rule"]["defensive_basket"]
+        return [symbol for symbol in basket if symbol in closes]
+    if family == "defensive_rotation":
+        lookback = int(candidate["signal_definition"]["lookback_trading_days"])
+        spy_return = _trailing_return(closes.get("SPY", []), idx, lookback)
+        if spy_return is not None and spy_return >= 0:
+            return [symbol for symbol in ("SPY", "QQQ") if symbol in closes]
+        ranked = [
+            (symbol, _trailing_return(closes[symbol], idx, lookback))
+            for symbol in candidate["selection_rule"]["defensive_basket"]
+            if symbol in closes
+        ]
+        ranked = [(symbol, value) for symbol, value in ranked if value is not None]
+        ranked.sort(key=lambda item: (-float(item[1]), item[0]))
+        return [symbol for symbol, _value in ranked[: int(candidate["selection_rule"]["defensive_count"])]]
+    if family == "volatility_compression_breakout":
+        vol_lookback = int(candidate["signal_definition"]["volatility_lookback_trading_days"])
+        return_lookback = int(candidate["signal_definition"]["return_lookback_trading_days"])
+        ranked = []
+        for symbol in universe:
+            ret = _trailing_return(closes[symbol], idx, return_lookback)
+            vol = _trailing_vol(closes[symbol], idx, vol_lookback)
+            if ret is not None and ret > 0 and vol is not None:
+                ranked.append((symbol, vol))
+        ranked.sort(key=lambda item: (float(item[1]), item[0]))
+        return [symbol for symbol, _value in ranked[: int(candidate["selection_rule"]["count"])]]
+    if family == "mean_reversion_after_extreme_dispersion":
+        lookback = int(candidate["signal_definition"]["return_lookback_trading_days"])
+        returns = {
+            symbol: _trailing_return(closes[symbol], idx, lookback)
+            for symbol in universe
+        }
+        valid = [float(value) for value in returns.values() if value is not None]
+        if len(valid) < 3:
+            return []
+        dispersion = statistics.pstdev(valid)
+        threshold_mode = candidate["signal_definition"]["dispersion_threshold"]
+        threshold = statistics.median(history) if threshold_mode == "rolling_median" and history else 0.0
+        if threshold_mode == "p75" and history:
+            threshold = _percentile(history, 75)
+        history.append(dispersion)
+        if dispersion <= threshold:
+            return []
+        ranked = [(symbol, value) for symbol, value in returns.items() if value is not None]
+        ranked.sort(key=lambda item: (float(item[1]), item[0]))
+        return [symbol for symbol, _value in ranked[: int(candidate["selection_rule"]["count"])]]
+    return []
+
+
+def _compound(returns: list[float]) -> float:
+    value = 1.0
+    for item in returns:
+        value *= 1.0 + item
+    return value - 1.0
+
+
+def _max_drawdown(returns: list[float]) -> float:
+    equity = 1.0
+    peak = 1.0
+    worst = 0.0
+    for item in returns:
+        equity *= 1.0 + item
+        peak = max(peak, equity)
+        if peak > 0:
+            worst = min(worst, equity / peak - 1.0)
+    return abs(worst)
+
+
+def _sharpe_like(returns: list[float]) -> float:
+    if len(returns) < 2:
+        return 0.0
+    vol = statistics.pstdev(returns)
+    if vol <= 0:
+        return 0.0
+    return statistics.fmean(returns) / vol * math.sqrt(252 / 20)
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = (len(ordered) - 1) * pct / 100.0
+    lower = math.floor(idx)
+    upper = math.ceil(idx)
+    if lower == upper:
+        return ordered[int(idx)]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (idx - lower)
+
+
+def _screen_candidate_returns(
+    candidate: dict[str, Any],
+    closes: dict[str, list[float]],
+) -> tuple[list[float], list[float], int, int, list[list[str]]]:
+    universe = [symbol for symbol in candidate["universe"] if symbol in closes]
+    if not universe:
+        return [], [], 0, 0, []
+    max_lookback = 60
+    signal = candidate["signal_definition"]
+    for key in ("lookback_trading_days", "volatility_lookback_trading_days", "return_lookback_trading_days"):
+        if key in signal:
+            max_lookback = max(max_lookback, int(signal[key]))
+    holding = int(candidate["holding_period"]["trading_days"])
+    frequency = int(candidate["rebalance_rule"]["frequency_trading_days"])
+    length = min(len(closes[symbol]) for symbol in universe)
+    candidate_returns: list[float] = []
+    benchmark_returns: list[float] = []
+    selections: list[list[str]] = []
+    dispersion_history: list[float] = []
+    for idx in range(max_lookback, length - holding, frequency):
+        selected = _select_symbols(candidate, closes, idx, dispersion_history)
+        if not selected:
+            continue
+        selected_returns = [_return_over(closes[symbol], idx, idx + holding) for symbol in selected]
+        benchmark_period_returns = [_return_over(closes[symbol], idx, idx + holding) for symbol in universe]
+        selected_values = [float(value) for value in selected_returns if value is not None]
+        benchmark_values = [float(value) for value in benchmark_period_returns if value is not None]
+        if selected_values and benchmark_values:
+            candidate_returns.append(statistics.fmean(selected_values))
+            benchmark_returns.append(statistics.fmean(benchmark_values))
+            selections.append(selected)
+    selection_count = sum(len(row) for row in selections)
+    return candidate_returns, benchmark_returns, length, selection_count, selections
+
+
+def _null_control(
+    *,
+    candidate: dict[str, Any],
+    closes: dict[str, list[float]],
+    selections: list[list[str]],
+    null_iterations: int,
+    seed: int,
+) -> dict[str, Any]:
+    universe = [symbol for symbol in candidate["universe"] if symbol in closes]
+    holding = int(candidate["holding_period"]["trading_days"])
+    frequency = int(candidate["rebalance_rule"]["frequency_trading_days"])
+    signal = candidate["signal_definition"]
+    max_lookback = 60
+    for key in ("lookback_trading_days", "volatility_lookback_trading_days", "return_lookback_trading_days"):
+        if key in signal:
+            max_lookback = max(max_lookback, int(signal[key]))
+    length = min(len(closes[symbol]) for symbol in universe) if universe else 0
+    rng = random.Random(seed)
+    null_total_returns: list[float] = []
+    null_sharpes: list[float] = []
+    selection_sizes = [len(item) for item in selections] or [1]
+    for iteration in range(max(0, null_iterations)):
+        returns: list[float] = []
+        size = selection_sizes[iteration % len(selection_sizes)]
+        for idx in range(max_lookback, length - holding, frequency):
+            if not universe:
+                continue
+            sampled = rng.sample(universe, k=min(size, len(universe)))
+            period = [_return_over(closes[symbol], idx, idx + holding) for symbol in sampled]
+            values = [float(value) for value in period if value is not None]
+            if values:
+                returns.append(statistics.fmean(values))
+        null_total_returns.append(_compound(returns))
+        null_sharpes.append(_sharpe_like(returns))
+    return {
+        "null_iterations": null_iterations,
+        "seed": seed,
+        "null_total_return_p50": _percentile(null_total_returns, 50),
+        "null_total_return_p75": _percentile(null_total_returns, 75),
+        "null_sharpe_like_p50": _percentile(null_sharpes, 50),
+        "beats_null_p50": False,
+        "beats_null_p75": False,
+        "equal_weight_benchmark": {"type": "equal_weight_universe"},
+        "shuffled_selection_null": {"method": "seeded_random_selection_by_rebalance"},
+    }
+
+
+def screen_candidate(
+    candidate: dict[str, Any],
+    bars: list[dict[str, Any]] | None,
+    *,
+    null_iterations: int,
+    seed: int,
+    forced_decision: str | None = None,
+    forced_reason: str | None = None,
+) -> dict[str, Any]:
+    base = {
+        "candidate_id": candidate["candidate_id"],
+        "parent_contract_id": candidate["parent_contract_id"],
+        "parent_hypothesis_seed_id": candidate["parent_hypothesis_seed_id"],
+        "source_snapshot_id": candidate["source_snapshot_id"],
+        "screening_protocol": SCREENING_PROTOCOL,
+        "screening_only": True,
+        "research_only": True,
+        "observation_count": 0,
+        "rebalance_count": 0,
+        "selection_count": 0,
+        "candidate_total_return": 0.0,
+        "benchmark_total_return": 0.0,
+        "excess_return": 0.0,
+        "candidate_annualized_return": 0.0,
+        "candidate_annualized_vol": 0.0,
+        "candidate_sharpe_like": 0.0,
+        "max_drawdown": 0.0,
+        "win_rate": 0.0,
+        "turnover_proxy": 0.0,
+        "null_control": {
+            "null_iterations": null_iterations,
+            "seed": seed,
+            "null_total_return_p50": 0.0,
+            "null_total_return_p75": 0.0,
+            "null_sharpe_like_p50": 0.0,
+            "beats_null_p50": False,
+            "beats_null_p75": False,
+            "equal_weight_benchmark": {"type": "equal_weight_universe"},
+            "shuffled_selection_null": {"method": "seeded_random_selection_by_rebalance"},
+        },
+        "decision": "blocked_unsafe_input",
+        "decision_reasons": [],
+        "blocked_reasons": [],
+        "trading_authority": False,
+        "validation_authority": False,
+        "promotes_candidates": False,
+    }
+    if forced_decision:
+        base["decision"] = forced_decision
+        base["decision_reasons"] = [forced_reason or forced_decision]
+        return base
+    if not bars:
+        base["blocked_reasons"] = ["missing_or_malformed_screening_data"]
+        return base
+    _dates, closes = _group_closes(bars)
+    candidate_returns, benchmark_returns, observations, selection_count, selections = _screen_candidate_returns(candidate, closes)
+    base["observation_count"] = observations
+    base["rebalance_count"] = len(candidate_returns)
+    base["selection_count"] = selection_count
+    if not candidate_returns or not benchmark_returns:
+        base["decision"] = "insufficient_evidence"
+        base["decision_reasons"] = ["no_screenable_rebalance_windows"]
+        return base
+    candidate_total = _compound(candidate_returns)
+    benchmark_total = _compound(benchmark_returns)
+    excess = candidate_total - benchmark_total
+    periods_per_year = 252 / 20
+    ann_return = (1.0 + candidate_total) ** (periods_per_year / max(1, len(candidate_returns))) - 1.0 if candidate_total > -1 else -1.0
+    ann_vol = statistics.pstdev(candidate_returns) * math.sqrt(periods_per_year) if len(candidate_returns) > 1 else 0.0
+    sharpe = _sharpe_like(candidate_returns)
+    max_drawdown = _max_drawdown(candidate_returns)
+    wins = sum(1 for left, right in zip(candidate_returns, benchmark_returns, strict=True) if left > right)
+    turnover = 0.0
+    if len(selections) > 1:
+        changes = []
+        for previous, current in pairwise(selections):
+            previous_set = set(previous)
+            current_set = set(current)
+            changes.append(1.0 - (len(previous_set & current_set) / max(1, len(previous_set | current_set))))
+        turnover = statistics.fmean(changes)
+    null_control = _null_control(
+        candidate=candidate,
+        closes=closes,
+        selections=selections,
+        null_iterations=null_iterations,
+        seed=seed,
+    )
+    null_control["beats_null_p50"] = candidate_total > null_control["null_total_return_p50"] and sharpe > null_control["null_sharpe_like_p50"]
+    null_control["beats_null_p75"] = candidate_total > null_control["null_total_return_p75"]
+    base.update(
+        {
+            "candidate_total_return": candidate_total,
+            "benchmark_total_return": benchmark_total,
+            "excess_return": excess,
+            "candidate_annualized_return": ann_return,
+            "candidate_annualized_vol": ann_vol,
+            "candidate_sharpe_like": sharpe,
+            "max_drawdown": max_drawdown,
+            "win_rate": wins / len(candidate_returns),
+            "turnover_proxy": turnover,
+            "null_control": null_control,
+        }
+    )
+    finite_metrics = all(
+        math.isfinite(float(base[key]))
+        for key in (
+            "candidate_total_return",
+            "benchmark_total_return",
+            "excess_return",
+            "candidate_annualized_return",
+            "candidate_annualized_vol",
+            "candidate_sharpe_like",
+            "max_drawdown",
+            "win_rate",
+            "turnover_proxy",
+        )
+    )
+    if observations < 252 or len(candidate_returns) < 12 or null_iterations < 16 or not finite_metrics:
+        base["decision"] = "insufficient_evidence"
+        base["decision_reasons"] = ["minimum_evidence_gates_failed"]
+    elif not null_control["beats_null_p50"]:
+        base["decision"] = "null_not_beaten"
+        base["decision_reasons"] = ["candidate_did_not_beat_seeded_null_p50"]
+    elif excess <= 0 or not math.isfinite(max_drawdown):
+        base["decision"] = "screening_fail"
+        base["decision_reasons"] = ["candidate_did_not_beat_equal_weight_benchmark"]
+    else:
+        base["decision"] = "screening_pass"
+        base["decision_reasons"] = ["candidate_beat_equal_weight_and_seeded_null_p50"]
+    return _stable_payload(base)
+
+
+def feedback_from_screening(result: dict[str, Any]) -> dict[str, Any]:
+    decision = str(result.get("decision"))
+    mapping = {
+        "screening_pass": (
+            "retain_for_more_screening",
+            "rematerialize_same_spec",
+            "retain_hypothesis",
+            ["candidate_passed_research_only_screening"],
+        ),
+        "null_not_beaten": (
+            "modify_candidate_later",
+            "materialize_modified_spec",
+            "modify_hypothesis_parameters_later",
+            ["candidate_did_not_beat_null_control"],
+        ),
+        "screening_fail": (
+            "reject_candidate_for_now",
+            "do_not_rematerialize_same_spec",
+            "reject_hypothesis_for_now",
+            ["candidate_failed_research_screening"],
+        ),
+        "insufficient_evidence": (
+            "insufficient_evidence",
+            "collect_more_data",
+            "needs_more_evidence",
+            ["candidate_has_insufficient_evidence"],
+        ),
+        "blocked_unsafe_input": (
+            "block_candidate",
+            "repair_input_contract",
+            "block_hypothesis",
+            ["candidate_input_blocked"],
+        ),
+    }
+    feedback_decision, next_candidate_action, next_hypothesis_action, reasons = mapping[decision]
+    basis = {
+        "candidate_id": result.get("candidate_id"),
+        "parent_contract_id": result.get("parent_contract_id"),
+        "source_snapshot_id": result.get("source_snapshot_id"),
+        "screening_decision": decision,
+        "feedback_decision": feedback_decision,
+    }
+    return {
+        "feedback_id": "fb_tiingo_" + _digest(basis),
+        "feedback_schema_version": 1,
+        "candidate_id": result.get("candidate_id"),
+        "parent_contract_id": result.get("parent_contract_id"),
+        "parent_hypothesis_seed_id": result.get("parent_hypothesis_seed_id"),
+        "source_snapshot_id": result.get("source_snapshot_id"),
+        "screening_decision": decision,
+        "feedback_decision": feedback_decision,
+        "feedback_reasons": reasons,
+        "next_candidate_action": next_candidate_action,
+        "next_hypothesis_action": next_hypothesis_action,
+        "consumable_by_next_run": True,
+        "research_only": True,
+        "trading_authority": False,
+    }
+
+
+def read_prior_feedback(path: Path) -> dict[str, Any]:
+    payload, error = _read_json(path)
+    if error is not None or not isinstance(payload, dict):
+        return {
+            "feedback_consumed": False,
+            "feedback_source_path": path.as_posix(),
+            "feedback_records_seen": 0,
+            "feedback_applied_count": 0,
+            "feedback_application": [],
+        }
+    records = payload.get("feedback_records")
+    if not isinstance(records, list):
+        records = []
+    records = [record for record in records if isinstance(record, dict) and record.get("consumable_by_next_run") is True]
+    return {
+        "feedback_consumed": bool(records),
+        "feedback_source_path": path.as_posix(),
+        "feedback_records_seen": len(records),
+        "feedback_applied_count": 0,
+        "feedback_application": [],
+        "_records": records,
+    }
+
+
+def _feedback_by_contract(prior_feedback: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rows = prior_feedback.get("_records")
+    records = rows if isinstance(rows, list) else []
+    by_contract: dict[str, dict[str, Any]] = {}
+    for record in records:
+        contract_id = str(record.get("parent_contract_id") or "")
+        if contract_id:
+            by_contract[contract_id] = record
+    return by_contract
+
+
+def _apply_prior_feedback(
+    contract: dict[str, Any],
+    feedback: dict[str, Any] | None,
+) -> tuple[str, str | None, dict[str, Any] | None]:
+    if feedback is None:
+        return "materialize", None, None
+    decision = str(feedback.get("feedback_decision"))
+    application = {
+        "contract_id": contract["contract_id"],
+        "candidate_id": feedback.get("candidate_id"),
+        "feedback_decision": decision,
+        "applied": True,
+    }
+    if decision == "retain_for_more_screening":
+        application["application"] = "retained_by_prior_feedback"
+        return "materialize", "retained_by_prior_feedback", application
+    if decision == "reject_candidate_for_now":
+        application["application"] = "suppressed_by_prior_feedback"
+        return "suppress", "suppressed_by_prior_feedback", application
+    if decision == "modify_candidate_later":
+        application["application"] = "modified_by_prior_feedback"
+        return "modify", "modified_by_prior_feedback", application
+    if decision == "insufficient_evidence":
+        application["application"] = "needs_more_evidence_from_prior_feedback"
+        return "defer_screening", "needs_more_evidence_from_prior_feedback", application
+    if decision == "block_candidate":
+        application["application"] = "blocked_by_prior_feedback"
+        return "block", "blocked_by_prior_feedback", application
+    application["applied"] = False
+    application["application"] = "unknown_feedback_decision"
+    return "materialize", None, application
+
+
+def build_report(
+    *,
+    repo_root: Path = Path("."),
+    lifecycle_input: Path = DEFAULT_LIFECYCLE_INPUT,
+    upstream_e2e_input: Path = DEFAULT_UPSTREAM_E2E_INPUT,
+    bars_input: Path = DEFAULT_BARS_INPUT,
+    prior_feedback_input: Path = DEFAULT_PRIOR_FEEDBACK_INPUT,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    max_candidates: int = 5,
+    null_iterations: int = 32,
+    seed: int = 1729,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    lifecycle_path = lifecycle_input if lifecycle_input.is_absolute() else repo_root / lifecycle_input
+    upstream_path = upstream_e2e_input if upstream_e2e_input.is_absolute() else repo_root / upstream_e2e_input
+    bars_path = bars_input if bars_input.is_absolute() else repo_root / bars_input
+    prior_path = prior_feedback_input if prior_feedback_input.is_absolute() else repo_root / prior_feedback_input
+    config = _run_config(max_candidates=max_candidates, null_iterations=null_iterations, seed=seed)
+    lifecycle, lifecycle_error = _read_json(lifecycle_path)
+    upstream, _upstream_error = _read_json(upstream_path)
+    prior_feedback = read_prior_feedback(prior_path)
+    lifecycle_reasons = _validate_lifecycle(lifecycle, lifecycle_error)
+    if lifecycle_reasons:
+        return _blocked_report(
+            lifecycle=lifecycle,
+            upstream=upstream,
+            run_config=config,
+            loop_verdict="blocked_missing_or_unsafe_input",
+            blocked_reasons=lifecycle_reasons,
+            prior_feedback=prior_feedback,
+        )
+    assert lifecycle is not None
+    contracts, skipped = build_input_contracts(lifecycle)
+    if not contracts:
+        return _blocked_report(
+            lifecycle=lifecycle,
+            upstream=upstream,
+            run_config=config,
+            loop_verdict="blocked_no_admitted_hypotheses",
+            blocked_reasons=["no_admitted_lifecycle_records"],
+            prior_feedback=prior_feedback,
+        )
+
+    feedback_map = _feedback_by_contract(prior_feedback)
+    applications: list[dict[str, Any]] = []
+    candidate_specs: list[dict[str, Any]] = []
+    screening_results: list[dict[str, Any]] = []
+    feedback_records: list[dict[str, Any]] = []
+    blocked_reasons: list[str] = []
+    deferred_candidate_ids: set[str] = set()
+    counters = {
+        "suppressed_by_prior_feedback": 0,
+        "modified_by_prior_feedback": 0,
+        "retained_by_prior_feedback": 0,
+    }
+
+    for contract in contracts[: max(0, max_candidates)]:
+        action, note, application = _apply_prior_feedback(contract, feedback_map.get(contract["contract_id"]))
+        if application is not None:
+            applications.append(application)
+            if application.get("applied") is True:
+                prior_feedback["feedback_applied_count"] += 1
+        if note in counters:
+            counters[note] += 1
+        if action in {"suppress", "block"}:
+            blocked_reasons.append(str(note))
+            continue
+        variant = "modified_by_prior_feedback" if action == "modify" else "v1"
+        candidate, block_reason = materialize_candidate_spec(contract, variant=variant, feedback_note=note)
+        if block_reason is not None or candidate is None:
+            blocked_reasons.append(block_reason or "candidate_materialization_failed")
+            continue
+        candidate_specs.append(candidate)
+        if action == "defer_screening":
+            deferred_candidate_ids.add(candidate["candidate_id"])
+
+    prior_feedback["feedback_application"] = applications
+    if not candidate_specs:
+        report = _blocked_report(
+            lifecycle=lifecycle,
+            upstream=upstream,
+            run_config=config,
+            loop_verdict="blocked_no_candidate_specs" if blocked_reasons else "blocked_no_admitted_hypotheses",
+            blocked_reasons=blocked_reasons or ["no_candidate_specs_materialized"],
+            prior_feedback=prior_feedback,
+        )
+        report["input_contracts"] = contracts
+        report["summary"]["input_contracts_seen"] = len(contracts) + len(skipped)
+        report["summary"]["input_contracts_admitted"] = len(contracts)
+        report["summary"]["suppressed_by_prior_feedback"] = counters["suppressed_by_prior_feedback"]
+        return report
+
+    bars, bars_reasons = load_bars(bars_path)
+    for candidate in candidate_specs:
+        if candidate["candidate_id"] in deferred_candidate_ids:
+            result = screen_candidate(
+                candidate,
+                None,
+                null_iterations=null_iterations,
+                seed=seed,
+                forced_decision="insufficient_evidence",
+                forced_reason="prior_feedback_requested_more_data",
+            )
+        elif bars_reasons:
+            result = screen_candidate(candidate, None, null_iterations=null_iterations, seed=seed)
+        else:
+            result = screen_candidate(candidate, bars, null_iterations=null_iterations, seed=seed)
+        screening_results.append(result)
+        feedback_records.append(feedback_from_screening(result))
+
+    summary = _empty_summary()
+    summary["input_contracts_seen"] = len(contracts) + len(skipped)
+    summary["input_contracts_admitted"] = len(contracts)
+    summary["candidates_materialized"] = len(candidate_specs)
+    summary["candidates_screened"] = sum(1 for result in screening_results if result["decision"] != "blocked_unsafe_input")
+    for decision in ("screening_pass", "screening_fail", "null_not_beaten", "insufficient_evidence"):
+        summary[decision] = sum(1 for result in screening_results if result["decision"] == decision)
+    summary["feedback_records"] = len(feedback_records)
+    summary["feedback_consumed"] = prior_feedback["feedback_consumed"]
+    summary["feedback_applied_count"] = prior_feedback["feedback_applied_count"]
+    summary["next_run_feedback_ready"] = bool(feedback_records)
+    summary.update(counters)
+    if bars_reasons:
+        summary["loop_verdict"] = "blocked_no_screening_data"
+        blocked_reasons.extend(bars_reasons)
+    elif feedback_records and not candidate_specs:
+        summary["loop_verdict"] = "partial_feedback_only"
+    else:
+        summary["loop_verdict"] = "pass_research_only_candidate_loop"
+    report = _base_report(
+        lifecycle=lifecycle,
+        upstream=upstream,
+        run_config=config,
+        blocked_reasons=blocked_reasons,
+    )
+    report.update(
+        {
+            "input_contracts": contracts,
+            "candidate_specs": candidate_specs,
+            "screening_results": screening_results,
+            "feedback_records": feedback_records,
+            "prior_feedback": {key: value for key, value in prior_feedback.items() if key != "_records"},
+            "next_run_plan": _next_run_plan(feedback_records),
+            "blocked_reasons": sorted(dict.fromkeys(blocked_reasons)),
+        }
+    )
+    report["summary"] = summary
+    report["daily_digest_input"] = _daily_digest_input(report)
+    return _stable_payload(report)
+
+
+def _next_run_plan(feedback_records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "feedback_ready": bool(feedback_records),
+        "feedback_records": len(feedback_records),
+        "actions": sorted(
+            {
+                str(record.get("next_candidate_action"))
+                for record in feedback_records
+                if record.get("next_candidate_action")
+            }
+        ),
+        "research_only": True,
+        "trading_authority": False,
+    }
+
+
+def render_operator_summary(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    safety = report["safety"]
+    lines = [
+        "# Tiingo Candidate Research Loop",
+        "",
+        f"- Loop verdict: {summary['loop_verdict']}",
+        f"- Input contracts seen: {summary['input_contracts_seen']}",
+        f"- Input contracts admitted: {summary['input_contracts_admitted']}",
+        f"- Candidates materialized: {summary['candidates_materialized']}",
+        f"- Candidates screened: {summary['candidates_screened']}",
+        f"- Screening pass: {summary['screening_pass']}",
+        f"- Screening fail: {summary['screening_fail']}",
+        f"- Null not beaten: {summary['null_not_beaten']}",
+        f"- Insufficient evidence: {summary['insufficient_evidence']}",
+        f"- Feedback records: {summary['feedback_records']}",
+        f"- Feedback consumed: {str(summary['feedback_consumed']).lower()}",
+        f"- Feedback applied count: {summary['feedback_applied_count']}",
+        f"- Next run feedback ready: {str(summary['next_run_feedback_ready']).lower()}",
+        f"- Trading authority: {str(safety['trading_authority']).lower()}",
+        f"- Candidate promotion: {str(safety['promotes_candidates']).lower()}",
+        f"- Validation authority: {str(safety['validation_authority']).lower()}",
+        f"- Paper/shadow/live authority: {str(safety['paper_authority'] or safety['shadow_authority'] or safety['live_authority']).lower()}",
+        "",
+        "Input contracts:",
+        "contract_id | hypothesis_seed_id | feature_family | status",
+        "---|---|---|---",
+    ]
+    for row in report.get("input_contracts", []):
+        lines.append(
+            f"{row.get('contract_id')} | {row.get('hypothesis_seed_id')} | {row.get('feature_family')} | {row.get('status')}"
+        )
+    if not report.get("input_contracts"):
+        lines.append("none | none | none | none")
+    lines.extend(
+        [
+            "",
+            "Candidate specs:",
+            "candidate_id | feature_family | candidate_family | screening_only | trading_authority",
+            "---|---|---|---|---",
+        ]
+    )
+    for row in report.get("candidate_specs", []):
+        lines.append(
+            f"{row.get('candidate_id')} | {row.get('feature_family')} | {row.get('candidate_family')} | {str(row.get('screening_only')).lower()} | {str(row.get('trading_authority')).lower()}"
+        )
+    if not report.get("candidate_specs"):
+        lines.append("none | none | none | true | false")
+    lines.extend(
+        [
+            "",
+            "Screening results:",
+            "candidate_id | decision | excess_return | candidate_sharpe_like | beats_null_p50 | reason",
+            "---|---|---|---|---|---",
+        ]
+    )
+    for row in report.get("screening_results", []):
+        reason = ", ".join(str(item) for item in row.get("decision_reasons", []) or row.get("blocked_reasons", [])) or "none"
+        null = row.get("null_control") if isinstance(row.get("null_control"), dict) else {}
+        lines.append(
+            f"{row.get('candidate_id')} | {row.get('decision')} | {row.get('excess_return')} | {row.get('candidate_sharpe_like')} | {str(null.get('beats_null_p50')).lower()} | {reason}"
+        )
+    if not report.get("screening_results"):
+        lines.append("none | none | 0.0 | 0.0 | false | none")
+    lines.extend(
+        [
+            "",
+            "Feedback:",
+            "feedback_id | candidate_id | feedback_decision | next_candidate_action | next_hypothesis_action",
+            "---|---|---|---|---",
+        ]
+    )
+    for row in report.get("feedback_records", []):
+        lines.append(
+            f"{row.get('feedback_id')} | {row.get('candidate_id')} | {row.get('feedback_decision')} | {row.get('next_candidate_action')} | {row.get('next_hypothesis_action')}"
+        )
+    if not report.get("feedback_records"):
+        lines.append("none | none | none | none | none")
+    lines.extend(
+        [
+            "",
+            "No orders were created. No broker/risk authority exists. No validation, promotion, strategy registration, paper, shadow, or live authority was granted.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def _json_text(value: Any) -> str:
+    return json.dumps(_stable_payload(value), indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def _jsonl_text(rows: list[dict[str, Any]]) -> str:
+    return "".join(json.dumps(_stable_payload(row), sort_keys=True, ensure_ascii=True) + "\n" for row in rows)
+
+
+def write_outputs(
+    report: dict[str, Any],
+    *,
+    repo_root: Path = Path("."),
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+) -> dict[str, str]:
+    repo_root = repo_root.resolve()
+    resolved = output_dir if output_dir.is_absolute() else repo_root / output_dir
+    resolved = resolved.resolve()
+    allowed = (repo_root / DEFAULT_OUTPUT_DIR).resolve()
+    if resolved != allowed:
+        raise ValueError("output_dir_must_be_logs_qre_tiingo_candidate_research_loop")
+    paths = {
+        "latest": resolved / "latest.json",
+        "input_contracts": resolved / "input_contracts.jsonl",
+        "candidate_specs": resolved / "candidate_specs.jsonl",
+        "screening_results": resolved / "screening_results.jsonl",
+        "feedback_records": resolved / "feedback_records.jsonl",
+        "operator_summary": resolved / "operator_summary.md",
+    }
+    _atomic_write_text(paths["latest"], _json_text(report))
+    _atomic_write_text(paths["input_contracts"], _jsonl_text(report.get("input_contracts", [])))
+    _atomic_write_text(paths["candidate_specs"], _jsonl_text(report.get("candidate_specs", [])))
+    _atomic_write_text(paths["screening_results"], _jsonl_text(report.get("screening_results", [])))
+    _atomic_write_text(paths["feedback_records"], _jsonl_text(report.get("feedback_records", [])))
+    _atomic_write_text(paths["operator_summary"], render_operator_summary(report))
+    return {key: path.relative_to(repo_root).as_posix() for key, path in paths.items()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m research.qre_tiingo_candidate_research_loop")
+    parser.add_argument("--lifecycle-input", default=DEFAULT_LIFECYCLE_INPUT.as_posix())
+    parser.add_argument("--upstream-e2e-input", default=DEFAULT_UPSTREAM_E2E_INPUT.as_posix())
+    parser.add_argument("--bars-input", default=DEFAULT_BARS_INPUT.as_posix())
+    parser.add_argument("--prior-feedback-input", default=DEFAULT_PRIOR_FEEDBACK_INPUT.as_posix())
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    parser.add_argument("--max-candidates", type=int, default=5)
+    parser.add_argument("--null-iterations", type=int, default=32)
+    parser.add_argument("--seed", type=int, default=1729)
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--repo-root", default=".")
+    args = parser.parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+    report = build_report(
+        repo_root=repo_root,
+        lifecycle_input=Path(args.lifecycle_input),
+        upstream_e2e_input=Path(args.upstream_e2e_input),
+        bars_input=Path(args.bars_input),
+        prior_feedback_input=Path(args.prior_feedback_input),
+        output_dir=Path(args.output_dir),
+        max_candidates=args.max_candidates,
+        null_iterations=args.null_iterations,
+        seed=args.seed,
+    )
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report, repo_root=repo_root, output_dir=Path(args.output_dir))
+    print(json.dumps(_stable_payload(report), indent=2, sort_keys=True, ensure_ascii=True))
+    return 0
+
+
+__all__ = [
+    "ALLOWED_LOOP_VERDICTS",
+    "ALLOWED_SCREENING_DECISIONS",
+    "DEFAULT_BARS_INPUT",
+    "DEFAULT_LIFECYCLE_INPUT",
+    "DEFAULT_OUTPUT_DIR",
+    "REPORT_KIND",
+    "SAFETY",
+    "build_input_contracts",
+    "build_report",
+    "feedback_from_screening",
+    "load_bars",
+    "main",
+    "materialize_candidate_spec",
+    "render_operator_summary",
+    "screen_candidate",
+    "write_outputs",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_tiingo_candidate_research_loop.py
+++ b/tests/unit/test_qre_tiingo_candidate_research_loop.py
@@ -1,0 +1,513 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+from research import qre_tiingo_candidate_research_loop as loop
+
+FAMILIES = (
+    "cross_sectional_momentum",
+    "risk_on_risk_off_regime",
+    "defensive_rotation",
+    "volatility_compression_breakout",
+    "mean_reversion_after_extreme_dispersion",
+)
+SYMBOLS = ("SPY", "QQQ", "IWM", "DIA", "TLT", "GLD", "XLK", "XLF", "XLE", "XLV")
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _lifecycle_record(family: str, index: int = 0, *, decision: str = "admitted") -> dict:
+    status = (
+        "admissible_for_research_candidate_formulation"
+        if decision == "admitted"
+        else "rejected_before_candidate_formulation"
+    )
+    return {
+        "hypothesis_seed_id": f"seed_tiingo_{family}_{index}",
+        "source_hypothesis_id": f"tiingo_hyp_{family}_{index}",
+        "source_snapshot_id": "qdsnap_test",
+        "feature_family": family,
+        "status": status,
+        "decision": decision,
+        "source_hypothesis_digest": {"digest": f"sha256:{family}{index}", "keys": ["feature_family"]},
+        "required_candidate_spec_fields": [
+            "candidate_id",
+            "parent_hypothesis_seed_id",
+            "source_snapshot_id",
+            "feature_family",
+            "signal_definition",
+            "selection_rule",
+            "rebalance_rule",
+            "holding_period",
+            "benchmark",
+            "null_control_requirement",
+            "split_adjustment_requirement",
+            "screening_only",
+            "trading_authority",
+        ],
+        "allowed_candidate_families": [family],
+        "forbidden_authorities": [
+            "candidate_promotion",
+            "strategy_registration",
+            "validation",
+            "paper",
+            "shadow",
+            "live",
+            "trading",
+            "broker",
+            "orders",
+        ],
+        "next_action": "materialize_research_candidate_later",
+        "trading_authority": False,
+        "creates_candidates": False,
+        "runs_screening": False,
+    }
+
+
+def _lifecycle_payload(records: list[dict] | None = None) -> dict:
+    records = records if records is not None else [_lifecycle_record(family, index) for index, family in enumerate(FAMILIES)]
+    return {
+        "report_kind": "qre_tiingo_hypothesis_lifecycle",
+        "schema_version": 1,
+        "source_report_kind": "qre_tiingo_hypothesis_generator_e2e",
+        "source_snapshot_id": "qdsnap_test",
+        "summary": {
+            "lifecycle_verdict": "pass_research_only_admission_boundary",
+            "hypotheses_seen": len(records),
+            "hypotheses_admitted": sum(1 for row in records if row["decision"] == "admitted"),
+            "hypotheses_rejected": sum(1 for row in records if row["decision"] == "rejected"),
+            "hypotheses_blocked": sum(1 for row in records if row["decision"] == "blocked"),
+            "daily_digest_ready": True,
+        },
+        "hypothesis_lifecycle": records,
+        "safety": {
+            "trading_authority": False,
+            "creates_candidates": False,
+            "runs_screening": False,
+            "promotes_candidates": False,
+            "registers_strategy": False,
+            "validation_authority": False,
+            "paper_authority": False,
+            "shadow_authority": False,
+            "live_authority": False,
+        },
+        "daily_digest_input": {
+            "counts": {
+                "generated": len(records),
+                "admitted": sum(1 for row in records if row["decision"] == "admitted"),
+                "rejected": sum(1 for row in records if row["decision"] == "rejected"),
+                "blocked": sum(1 for row in records if row["decision"] == "blocked"),
+            }
+        },
+    }
+
+
+def _upstream_payload() -> dict:
+    return {
+        "report_kind": "qre_tiingo_hypothesis_generator_e2e",
+        "source_snapshot_id": "qdsnap_test",
+        "summary": {"final_verdict": "pass_data_driven_hypothesis_generation"},
+        "safety": {"trading_authority": False},
+    }
+
+
+def _write_inputs(root: Path, *, lifecycle_payload: dict | None = None) -> tuple[Path, Path, Path]:
+    lifecycle_path = root / "lifecycle" / "latest.json"
+    upstream_path = root / "upstream" / "latest.json"
+    bars_path = root / "bars.csv"
+    _write_json(lifecycle_path, lifecycle_payload or _lifecycle_payload())
+    _write_json(upstream_path, _upstream_payload())
+    _write_bars(bars_path)
+    return lifecycle_path, upstream_path, bars_path
+
+
+def _write_bars(path: Path, *, days: int = 360, split: bool = False, malformed: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if malformed:
+        path.write_text("date,symbol,close\n2021-01-01,SPY,100\n", encoding="utf-8")
+        return
+    drifts = {
+        "SPY": 0.00055,
+        "QQQ": 0.00075,
+        "IWM": 0.00035,
+        "DIA": 0.00045,
+        "TLT": 0.00010,
+        "GLD": 0.00015,
+        "XLK": 0.00085,
+        "XLF": 0.00025,
+        "XLE": -0.00005,
+        "XLV": 0.00020,
+    }
+    lines = ["date,symbol,open,high,low,close,volume"]
+    start = date(2021, 1, 1)
+    for idx in range(days):
+        current = start + timedelta(days=idx)
+        for symbol in SYMBOLS:
+            price = 100.0 * ((1.0 + drifts[symbol]) ** idx)
+            if split and symbol == "XLK" and idx >= 300:
+                price *= 0.5
+            lines.append(
+                f"{current.isoformat()},{symbol},{price:.6f},{price * 1.01:.6f},{price * 0.99:.6f},{price:.6f},1000000"
+            )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run(root: Path, **kwargs) -> dict:
+    lifecycle_path, upstream_path, bars_path = _write_inputs(root)
+    params = {
+        "repo_root": root,
+        "lifecycle_input": lifecycle_path,
+        "upstream_e2e_input": upstream_path,
+        "bars_input": bars_path,
+        "prior_feedback_input": root / "missing_prior.json",
+        "output_dir": root / "logs" / "qre_tiingo_candidate_research_loop",
+        "max_candidates": 5,
+        "null_iterations": 32,
+        "seed": 1729,
+    }
+    params.update(kwargs)
+    return loop.build_report(**params)
+
+
+def test_missing_malformed_unexpected_and_unsafe_lifecycle_fail_closed(tmp_path: Path) -> None:
+    upstream = tmp_path / "upstream.json"
+    bars = tmp_path / "bars.csv"
+    _write_json(upstream, _upstream_payload())
+    _write_bars(bars)
+
+    missing = loop.build_report(repo_root=tmp_path, lifecycle_input=tmp_path / "missing.json", upstream_e2e_input=upstream, bars_input=bars)
+    assert missing["summary"]["loop_verdict"] == "blocked_missing_or_unsafe_input"
+    assert "missing_lifecycle_artifact" in missing["blocked_reasons"]
+
+    malformed_path = tmp_path / "malformed.json"
+    malformed_path.write_text("{not-json", encoding="utf-8")
+    malformed = loop.build_report(repo_root=tmp_path, lifecycle_input=malformed_path, upstream_e2e_input=upstream, bars_input=bars)
+    assert "malformed_lifecycle_artifact" in malformed["blocked_reasons"]
+
+    bad_kind_path = tmp_path / "bad_kind.json"
+    payload = _lifecycle_payload()
+    payload["report_kind"] = "wrong"
+    _write_json(bad_kind_path, payload)
+    bad_kind = loop.build_report(repo_root=tmp_path, lifecycle_input=bad_kind_path, upstream_e2e_input=upstream, bars_input=bars)
+    assert "unexpected_lifecycle_report_kind" in bad_kind["blocked_reasons"]
+
+    unsafe_path = tmp_path / "unsafe.json"
+    payload = _lifecycle_payload()
+    payload["safety"]["trading_authority"] = True
+    _write_json(unsafe_path, payload)
+    unsafe = loop.build_report(repo_root=tmp_path, lifecycle_input=unsafe_path, upstream_e2e_input=upstream, bars_input=bars)
+    assert "unsafe_lifecycle_authority:trading_authority" in unsafe["blocked_reasons"]
+
+
+def test_lifecycle_verdict_not_pass_and_no_admitted_records_fail_closed(tmp_path: Path) -> None:
+    lifecycle_path, upstream_path, bars_path = _write_inputs(tmp_path)
+    payload = _lifecycle_payload()
+    payload["summary"]["lifecycle_verdict"] = "blocked"
+    _write_json(lifecycle_path, payload)
+    verdict = loop.build_report(repo_root=tmp_path, lifecycle_input=lifecycle_path, upstream_e2e_input=upstream_path, bars_input=bars_path)
+    assert "lifecycle_verdict_not_pass" in verdict["blocked_reasons"]
+
+    payload = _lifecycle_payload([_lifecycle_record("cross_sectional_momentum", decision="rejected")])
+    _write_json(lifecycle_path, payload)
+    no_admitted = loop.build_report(repo_root=tmp_path, lifecycle_input=lifecycle_path, upstream_e2e_input=upstream_path, bars_input=bars_path)
+    assert no_admitted["summary"]["loop_verdict"] == "blocked_no_admitted_hypotheses"
+
+
+def test_admitted_lifecycle_records_become_deterministic_input_contracts(tmp_path: Path) -> None:
+    rejected = _lifecycle_record("risk_on_risk_off_regime", 8, decision="rejected")
+    payload = _lifecycle_payload([_lifecycle_record("cross_sectional_momentum", 1), rejected])
+    contracts, skipped = loop.build_input_contracts(payload)
+    contracts_again, _ = loop.build_input_contracts(payload)
+
+    assert len(contracts) == 1
+    assert len(skipped) == 1
+    assert contracts == contracts_again
+    assert contracts[0]["contract_id"].startswith("contract_tiingo_")
+    assert contracts[0]["contract_digest"].startswith("sha256:")
+    assert contracts[0]["trading_authority"] is False
+    assert contracts[0]["research_only"] is True
+    assert contracts[0]["screening_only"] is True
+
+
+def test_all_known_candidate_family_templates_materialize_with_required_safety(tmp_path: Path) -> None:
+    lifecycle_path, upstream_path, bars_path = _write_inputs(tmp_path)
+    report = loop.build_report(
+        repo_root=tmp_path,
+        lifecycle_input=lifecycle_path,
+        upstream_e2e_input=upstream_path,
+        bars_input=bars_path,
+        prior_feedback_input=tmp_path / "missing.json",
+    )
+
+    families = {candidate["feature_family"] for candidate in report["candidate_specs"]}
+    assert families == set(FAMILIES)
+    assert report["summary"]["candidates_materialized"] == 5
+    for candidate in report["candidate_specs"]:
+        assert candidate["candidate_id"].startswith("cand_tiingo_")
+        assert candidate["candidate_digest"].startswith("sha256:")
+        assert candidate["screening_protocol"] == "tiingo_research_candidate_screening_v1"
+        assert candidate["null_control_requirement"] == "required"
+        assert candidate["split_adjustment_requirement"] == "required"
+        assert candidate["screening_only"] is True
+        assert candidate["research_only"] is True
+        assert candidate["not_trade_signal"] is True
+        assert candidate["trading_authority"] is False
+        assert candidate["creates_orders"] is False
+        assert "orders" not in candidate
+        assert "positions" not in candidate
+        assert "trading_signals" not in candidate
+
+
+def test_unknown_candidate_family_is_blocked(tmp_path: Path) -> None:
+    payload = _lifecycle_payload([_lifecycle_record("unknown_family", 1)])
+    lifecycle_path, upstream_path, bars_path = _write_inputs(tmp_path, lifecycle_payload=payload)
+    report = loop.build_report(
+        repo_root=tmp_path,
+        lifecycle_input=lifecycle_path,
+        upstream_e2e_input=upstream_path,
+        bars_input=bars_path,
+        prior_feedback_input=tmp_path / "missing.json",
+    )
+
+    assert report["summary"]["loop_verdict"] == "blocked_no_candidate_specs"
+    assert "blocked_unknown_candidate_family" in report["blocked_reasons"]
+
+
+def test_candidate_ids_are_deterministic(tmp_path: Path) -> None:
+    report = _run(tmp_path / "a")
+    report_again = _run(tmp_path / "a")
+    assert [row["candidate_id"] for row in report["candidate_specs"]] == [
+        row["candidate_id"] for row in report_again["candidate_specs"]
+    ]
+
+
+def test_missing_and_malformed_bars_block_screening(tmp_path: Path) -> None:
+    lifecycle_path, upstream_path, bars_path = _write_inputs(tmp_path)
+    missing = loop.build_report(
+        repo_root=tmp_path,
+        lifecycle_input=lifecycle_path,
+        upstream_e2e_input=upstream_path,
+        bars_input=tmp_path / "missing_bars.csv",
+        prior_feedback_input=tmp_path / "missing.json",
+    )
+    assert missing["summary"]["loop_verdict"] == "blocked_no_screening_data"
+    assert "missing_bars_input" in missing["blocked_reasons"]
+
+    _write_bars(bars_path, malformed=True)
+    malformed = loop.build_report(
+        repo_root=tmp_path,
+        lifecycle_input=lifecycle_path,
+        upstream_e2e_input=upstream_path,
+        bars_input=bars_path,
+        prior_feedback_input=tmp_path / "missing.json",
+    )
+    assert malformed["summary"]["loop_verdict"] == "blocked_no_screening_data"
+    assert any(str(reason).startswith("malformed_bars_input") for reason in malformed["blocked_reasons"])
+
+
+def test_insufficient_observations_yield_insufficient_evidence(tmp_path: Path) -> None:
+    lifecycle_path, upstream_path, bars_path = _write_inputs(tmp_path)
+    _write_bars(bars_path, days=120)
+    report = loop.build_report(
+        repo_root=tmp_path,
+        lifecycle_input=lifecycle_path,
+        upstream_e2e_input=upstream_path,
+        bars_input=bars_path,
+        prior_feedback_input=tmp_path / "missing.json",
+    )
+    assert report["summary"]["insufficient_evidence"] >= 1
+    assert all(result["decision"] in loop.ALLOWED_SCREENING_DECISIONS for result in report["screening_results"])
+
+
+def test_screening_computes_finite_metrics_benchmark_and_seeded_null_controls(tmp_path: Path) -> None:
+    report = _run(tmp_path)
+    results = report["screening_results"]
+
+    assert results
+    for result in results:
+        assert result["screening_only"] is True
+        assert result["research_only"] is True
+        assert result["trading_authority"] is False
+        assert result["validation_authority"] is False
+        assert result["promotes_candidates"] is False
+        assert result["decision"] in loop.ALLOWED_SCREENING_DECISIONS
+        assert isinstance(result["benchmark_total_return"], float)
+        assert result["null_control"]["null_iterations"] == 32
+        assert result["null_control"]["seed"] == 1729
+        assert "equal_weight_benchmark" in result["null_control"]
+        assert "shuffled_selection_null" in result["null_control"]
+        for key in ("candidate_total_return", "benchmark_total_return", "excess_return", "candidate_sharpe_like"):
+            assert isinstance(result[key], float)
+
+
+def test_null_controls_are_deterministic_and_change_with_seed(tmp_path: Path) -> None:
+    report = _run(tmp_path / "same_a", seed=1729)
+    same = _run(tmp_path / "same_a", seed=1729)
+    different = _run(tmp_path / "different", seed=1730)
+
+    nulls = [row["null_control"] for row in report["screening_results"]]
+    same_nulls = [row["null_control"] for row in same["screening_results"]]
+    different_nulls = [row["null_control"] for row in different["screening_results"]]
+    assert nulls == same_nulls
+    assert nulls != different_nulls
+
+
+def test_split_like_discontinuity_is_adjusted_before_screening(tmp_path: Path) -> None:
+    lifecycle_path, upstream_path, bars_path = _write_inputs(tmp_path)
+    _write_bars(bars_path, split=True)
+    bars, reasons = loop.load_bars(bars_path)
+
+    assert reasons == []
+    assert bars is not None
+    xlk = {row["date"]: row for row in bars if row["symbol"] == "XLK"}
+    event_return = xlk["2021-10-28"]["adjusted_close_for_research"] / xlk["2021-10-27"]["adjusted_close_for_research"] - 1.0
+    assert event_return > -0.1
+    report = loop.build_report(
+        repo_root=tmp_path,
+        lifecycle_input=lifecycle_path,
+        upstream_e2e_input=upstream_path,
+        bars_input=bars_path,
+        prior_feedback_input=tmp_path / "missing.json",
+    )
+    assert report["screening_results"]
+
+
+def test_feedback_mapping_and_ids_are_deterministic() -> None:
+    expected = {
+        "screening_pass": ("retain_for_more_screening", "rematerialize_same_spec", "retain_hypothesis"),
+        "null_not_beaten": ("modify_candidate_later", "materialize_modified_spec", "modify_hypothesis_parameters_later"),
+        "screening_fail": ("reject_candidate_for_now", "do_not_rematerialize_same_spec", "reject_hypothesis_for_now"),
+        "insufficient_evidence": ("insufficient_evidence", "collect_more_data", "needs_more_evidence"),
+        "blocked_unsafe_input": ("block_candidate", "repair_input_contract", "block_hypothesis"),
+    }
+    for decision, mapped in expected.items():
+        result = {
+            "candidate_id": f"cand_{decision}",
+            "parent_contract_id": f"contract_{decision}",
+            "parent_hypothesis_seed_id": "seed",
+            "source_snapshot_id": "qdsnap_test",
+            "decision": decision,
+        }
+        feedback = loop.feedback_from_screening(result)
+        feedback_again = loop.feedback_from_screening(result)
+        assert feedback == feedback_again
+        assert feedback["feedback_id"].startswith("fb_tiingo_")
+        assert feedback["feedback_decision"] == mapped[0]
+        assert feedback["next_candidate_action"] == mapped[1]
+        assert feedback["next_hypothesis_action"] == mapped[2]
+        assert feedback["consumable_by_next_run"] is True
+        assert feedback["trading_authority"] is False
+
+
+def test_no_prior_feedback_reports_not_consumed(tmp_path: Path) -> None:
+    report = _run(tmp_path)
+    assert report["summary"]["feedback_consumed"] is False
+    assert report["summary"]["feedback_applied_count"] == 0
+
+
+def test_prior_retain_feedback_rematerializes_same_candidate(tmp_path: Path) -> None:
+    first = _run(tmp_path / "first")
+    prior = tmp_path / "prior.json"
+    _write_json(prior, {"feedback_records": [first["feedback_records"][0] | {"feedback_decision": "retain_for_more_screening"}]})
+    second = _run(tmp_path / "second", prior_feedback_input=prior)
+
+    assert second["summary"]["feedback_consumed"] is True
+    assert second["summary"]["feedback_applied_count"] == 1
+    assert second["summary"]["retained_by_prior_feedback"] == 1
+    assert first["candidate_specs"][0]["candidate_id"] in {row["candidate_id"] for row in second["candidate_specs"]}
+
+
+def test_prior_reject_modify_insufficient_and_block_feedback_change_next_run(tmp_path: Path) -> None:
+    first = _run(tmp_path / "first")
+    records = []
+    decisions = [
+        "reject_candidate_for_now",
+        "modify_candidate_later",
+        "insufficient_evidence",
+        "block_candidate",
+    ]
+    for feedback, decision in zip(first["feedback_records"][:4], decisions, strict=True):
+        changed = dict(feedback)
+        changed["feedback_decision"] = decision
+        records.append(changed)
+    prior = tmp_path / "prior.json"
+    _write_json(prior, {"feedback_records": records})
+
+    second = _run(tmp_path / "second", prior_feedback_input=prior)
+
+    assert second["summary"]["feedback_consumed"] is True
+    assert second["summary"]["feedback_applied_count"] == 4
+    assert second["summary"]["suppressed_by_prior_feedback"] == 1
+    assert second["summary"]["modified_by_prior_feedback"] == 1
+    assert "suppressed_by_prior_feedback" in second["blocked_reasons"]
+    assert "blocked_by_prior_feedback" in second["blocked_reasons"]
+    assert any(candidate["prior_feedback_variant"] == "modified_by_prior_feedback" for candidate in second["candidate_specs"])
+    assert any(result["decision"] == "insufficient_evidence" for result in second["screening_results"])
+    assert [row["candidate_id"] for row in first["candidate_specs"]] != [
+        row["candidate_id"] for row in second["candidate_specs"]
+    ]
+
+
+def test_write_outputs_and_default_mode_write_nothing(tmp_path: Path) -> None:
+    report = _run(tmp_path)
+    output_dir = tmp_path / "logs" / "qre_tiingo_candidate_research_loop"
+    assert not output_dir.exists()
+
+    paths = loop.write_outputs(report, repo_root=tmp_path, output_dir=output_dir)
+
+    assert set(paths) == {
+        "latest",
+        "input_contracts",
+        "candidate_specs",
+        "screening_results",
+        "feedback_records",
+        "operator_summary",
+    }
+    assert (output_dir / "latest.json").is_file()
+    assert (output_dir / "input_contracts.jsonl").is_file()
+    assert (output_dir / "candidate_specs.jsonl").is_file()
+    assert (output_dir / "screening_results.jsonl").is_file()
+    assert (output_dir / "feedback_records.jsonl").is_file()
+    assert (output_dir / "operator_summary.md").is_file()
+    assert all(path.startswith("logs/qre_tiingo_candidate_research_loop/") for path in paths.values())
+
+
+def test_write_outputs_rejects_other_output_dir(tmp_path: Path) -> None:
+    report = _run(tmp_path)
+    try:
+        loop.write_outputs(report, repo_root=tmp_path, output_dir=tmp_path / "other")
+    except ValueError as exc:
+        assert "output_dir_must_be_logs_qre_tiingo_candidate_research_loop" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected output dir rejection")
+
+
+def test_protected_research_outputs_are_not_mutated(tmp_path: Path) -> None:
+    research_latest = Path("research/research_latest.json")
+    strategy_matrix = Path("research/strategy_matrix.csv")
+    before_latest = research_latest.read_bytes()
+    before_matrix = strategy_matrix.read_bytes()
+
+    _run(tmp_path)
+
+    assert research_latest.read_bytes() == before_latest
+    assert strategy_matrix.read_bytes() == before_matrix
+
+
+def test_all_safety_flags_daily_digest_and_operator_summary_are_research_only(tmp_path: Path) -> None:
+    report = _run(tmp_path)
+    assert report["safety"] == loop.SAFETY
+    assert report["daily_digest_input"]["counts"]["input_contracts_admitted"] == 5
+    assert report["daily_digest_input"]["authority_summary"] == loop.SAFETY
+    summary = loop.render_operator_summary(report)
+    assert "# Tiingo Candidate Research Loop" in summary
+    assert "No orders were created" in summary
+    assert "No broker/risk authority exists" in summary
+    forbidden_active_terms = ("validation_ready", "paper_ready", "shadow_ready", "live_ready", "trade_ready")
+    assert not any(term in json.dumps(report) for term in forbidden_active_terms)
+


### PR DESCRIPTION
Summary:
- consumes admitted Tiingo hypothesis lifecycle records
- creates stable input contracts
- materializes deterministic research-only candidate specs
- screens candidates with metrics and seeded null controls
- writes feedback records
- proves next-run feedback consumption changes candidate handling
- writes operator summary and JSONL sidecars

Validation:
- python -m pytest tests/unit/test_qre_tiingo_candidate_research_loop.py -q
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_lifecycle.py -q
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_generator_e2e.py -q
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m ruff check research/qre_tiingo_candidate_research_loop.py tests/unit/test_qre_tiingo_candidate_research_loop.py
- git diff --check
- manual first-run and feedback-consumption run

Safety:
- research_only=true
- screening_only=true
- trading_authority=false
- creates_orders=false
- broker_authority=false
- risk_authority=false
- promotes_candidates=false
- registers_strategy=false
- validation_authority=false
- paper/shadow/live authority=false
- research/research_latest.json not mutated
- research/strategy_matrix.csv not mutated