### PR TITLE
research: extend Tiingo candidate loop observability and variants

### DIFF
--- a/docs/research/tiingo_candidate_research_loop.md
+++ b/docs/research/tiingo_candidate_research_loop.md
@@ -46,8 +46,10 @@ logs/qre_tiingo_candidate_research_loop/
 - equal-weight benchmark comparison
 - feedback records for retain, reject, modify, block, or insufficient-evidence outcomes
 - next-run feedback consumption that can retain, suppress, modify, defer, or block candidate handling
+- research-only evidence ledger sidecar
+- bounded candidate variants under explicit caps and feedback control
+- daily status digest integration for observability
 - JSONL sidecars and an operator summary
-- daily-digest-ready input block for a later digest integration PR
 
 ## What This PR Does Not Build
 
@@ -82,7 +84,7 @@ Only admitted lifecycle records become contracts. Rejected or blocked records ar
 
 ## Candidate Materialization
 
-Each admitted input contract materializes at most one v1 research-only candidate spec unless `--max-candidates` limits it or prior feedback suppresses it.
+Each admitted input contract materializes at most one v1 research-only candidate spec by default unless `--max-candidates` limits it or prior feedback suppresses it.
 
 Implemented feature-family templates:
 
@@ -103,6 +105,28 @@ not_trade_signal=true
 trading_authority=false
 creates_orders=false
 ```
+
+## Candidate Variants
+
+Candidate variants are bounded research-only specs controlled by `max_variants_per_contract`, `max_candidates`, and prior feedback. They are not parameter mining authority and do not create executable strategies.
+
+Default behavior remains base-only:
+
+```text
+--max-variants-per-contract 1
+```
+
+When explicitly set to `2`, the module can materialize one bounded alternate variant per admitted contract, still subject to `--max-candidates`.
+
+Bounded alternate variants:
+
+- `cross_sectional_momentum`: 40 day lookback instead of 60 day lookback
+- `risk_on_risk_off_regime`: 40 day lookback instead of 60 day lookback
+- `defensive_rotation`: top 1 defensive instrument instead of top 2
+- `volatility_compression_breakout`: 30 day volatility lookback instead of 20 day
+- `mean_reversion_after_extreme_dispersion`: 75th percentile dispersion threshold instead of rolling median
+
+Variant specs preserve the parent contract and hypothesis seed, carry `variant_id`, `variant_reason`, `variant_parent_candidate_id`, and `variant_parameters`, and keep all safety flags research-only.
 
 ## Screening Metrics
 
@@ -159,6 +183,27 @@ research_only=true
 trading_authority=false
 ```
 
+## Evidence Ledger
+
+The evidence ledger is research-only screening evidence. It is not validation evidence and cannot promote candidates.
+
+Write mode emits:
+
+```text
+logs/qre_tiingo_candidate_research_loop/evidence_ledger.jsonl
+```
+
+Each screened candidate gets one deterministic evidence entry with candidate identity, candidate digest, metrics digest, metrics summary, null-control summary, screening decision, feedback decision, and audit flags. Evidence decisions are:
+
+```text
+retain_research_evidence
+weak_research_evidence
+insufficient_research_evidence
+blocked_research_evidence
+```
+
+The top-level `latest.json` includes `evidence_ledger_summary` with counts for each evidence decision. This sidecar is for auditability of screening evidence only.
+
 ## Next-Run Feedback Consumption
 
 If `--prior-feedback-input` exists, the module reads feedback records before writing any new outputs.
@@ -167,7 +212,7 @@ Prior feedback changes later candidate handling:
 
 - retain feedback rematerializes the same candidate
 - reject feedback suppresses the same candidate
-- modify feedback creates a deterministic modified candidate variant
+- modify feedback creates a deterministic bounded alternate candidate variant
 - insufficient-evidence feedback defers screening and records the need for more data
 - block feedback blocks materialization
 
@@ -183,6 +228,7 @@ logs/qre_tiingo_candidate_research_loop/input_contracts.jsonl
 logs/qre_tiingo_candidate_research_loop/candidate_specs.jsonl
 logs/qre_tiingo_candidate_research_loop/screening_results.jsonl
 logs/qre_tiingo_candidate_research_loop/feedback_records.jsonl
+logs/qre_tiingo_candidate_research_loop/evidence_ledger.jsonl
 logs/qre_tiingo_candidate_research_loop/operator_summary.md
 ```
 
@@ -213,6 +259,18 @@ The operator summary ends with:
 No orders were created. No broker/risk authority exists. No validation, promotion, strategy registration, paper, shadow, or live authority was granted.
 ```
 
+## Daily Status Digest Integration
+
+Daily digest integration is observability-only. It reads the candidate loop sidecar and reports counts, evidence, variants, feedback, and safety status. It does not create candidates or run screening.
+
+The digest optionally consumes:
+
+```text
+logs/qre_tiingo_candidate_research_loop/latest.json
+```
+
+When present and safe, it surfaces candidate-loop status, contracts admitted, candidates materialized and screened, screening decisions, feedback counts, evidence-record counts, variant counts, and explicit false authority flags.
+
 ## Relationship To QRE Feedback-Loop Closure
 
 This closes a narrow research-only feedback loop for Tiingo-derived hypotheses. It does not close the broader QRE feedback loop across strategy registration, validation, paper readiness, shadow readiness, or live readiness.
@@ -221,7 +279,7 @@ The loop is deliberately bounded to candidate screening and feedback consumption
 
 ## Next Safe PR
 
-1. include Tiingo candidate research loop status in daily digest
-2. broaden candidate parameter variants under feedback control
-3. add evidence ledger sidecar for research-only candidate screening
+1. add richer research-only evidence ledger slices by feature family
+2. broaden candidate parameter variants under tighter feedback-controlled hypotheses
+3. add research-only evidence comparison views across candidate-loop runs
 

--- a/docs/research/tiingo_hypothesis_lifecycle.md
+++ b/docs/research/tiingo_hypothesis_lifecycle.md
@@ -196,3 +196,9 @@ The full QRE feedback loop requires a downstream candidate materializer, screeni
 
 The next safe PR is a research-only candidate spec contract and materializer that consumes admitted hypothesis lifecycle records. That later PR should still avoid screening, validation, promotion, strategy registration, paper, shadow, live, and trading authority unless those scopes are explicitly approved separately.
 
+## Candidate loop observability
+
+The downstream Tiingo candidate research loop consumes admitted lifecycle records as stable input contracts. Its evidence ledger is research-only screening evidence, not validation evidence, and cannot promote candidates.
+
+Daily status digest integration for the candidate loop is observability-only. It reads the candidate-loop sidecar and reports counts, evidence, variants, feedback, and safety status. It does not create candidates or run screening.
+

--- a/research/qre_daily_status_digest.py
+++ b/research/qre_daily_status_digest.py
@@ -25,12 +25,30 @@ DEFAULT_SHADOW_READINESS_LATEST: Final[Path] = Path("logs/qre_shadow_readiness_g
 DEFAULT_TIINGO_HYPOTHESIS_LIFECYCLE_LATEST: Final[Path] = Path(
     "logs/qre_tiingo_hypothesis_lifecycle/latest.json"
 )
+DEFAULT_TIINGO_CANDIDATE_LOOP_LATEST: Final[Path] = Path(
+    "logs/qre_tiingo_candidate_research_loop/latest.json"
+)
 DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_daily_status_digest")
 TIINGO_HYPOTHESIS_LIFECYCLE_REPORT_KIND: Final[str] = "qre_tiingo_hypothesis_lifecycle"
+TIINGO_CANDIDATE_LOOP_REPORT_KIND: Final[str] = "qre_tiingo_candidate_research_loop"
 TIINGO_HYPOTHESIS_LIFECYCLE_SAFETY_KEYS: Final[tuple[str, ...]] = (
     "trading_authority",
     "creates_candidates",
     "runs_screening",
+    "promotes_candidates",
+    "registers_strategy",
+    "validation_authority",
+    "paper_authority",
+    "shadow_authority",
+    "live_authority",
+)
+TIINGO_CANDIDATE_LOOP_AUTHORITY_KEYS: Final[tuple[str, ...]] = (
+    "research_only",
+    "screening_only",
+    "trading_authority",
+    "creates_orders",
+    "broker_authority",
+    "risk_authority",
     "promotes_candidates",
     "registers_strategy",
     "validation_authority",
@@ -127,6 +145,56 @@ def _empty_tiingo_lifecycle_counts() -> dict[str, int]:
 
 def _false_tiingo_lifecycle_authority_summary() -> dict[str, bool]:
     return {key: False for key in TIINGO_HYPOTHESIS_LIFECYCLE_SAFETY_KEYS}
+
+
+def _false_tiingo_candidate_loop_authority_summary() -> dict[str, bool]:
+    return {
+        "research_only": True,
+        "screening_only": True,
+        "trading_authority": False,
+        "creates_orders": False,
+        "broker_authority": False,
+        "risk_authority": False,
+        "promotes_candidates": False,
+        "registers_strategy": False,
+        "validation_authority": False,
+        "paper_authority": False,
+        "shadow_authority": False,
+        "live_authority": False,
+    }
+
+
+def _empty_tiingo_candidate_loop_counts() -> dict[str, int]:
+    return {
+        "contracts": 0,
+        "candidates_materialized": 0,
+        "candidates_screened": 0,
+        "screening_pass": 0,
+        "screening_fail": 0,
+        "null_not_beaten": 0,
+        "insufficient_evidence": 0,
+        "feedback_records": 0,
+        "evidence_records": 0,
+    }
+
+
+def _empty_tiingo_candidate_loop_feedback() -> dict[str, Any]:
+    return {
+        "feedback_consumed": False,
+        "feedback_applied_count": 0,
+        "next_run_feedback_ready": False,
+    }
+
+
+def _empty_tiingo_candidate_loop_variants() -> dict[str, int]:
+    return {
+        "base_candidates": 0,
+        "variant_candidates": 0,
+        "variants_materialized": 0,
+        "modified_by_prior_feedback": 0,
+        "retained_by_prior_feedback": 0,
+        "suppressed_by_prior_feedback": 0,
+    }
 
 
 def _tiingo_lifecycle_diagnostic(
@@ -272,6 +340,124 @@ def _read_tiingo_hypothesis_lifecycle(path: Path) -> dict[str, Any]:
     }
 
 
+def _tiingo_candidate_loop_diagnostic(
+    *,
+    status: str,
+    source_artifact: Path,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "source_artifact": source_artifact.as_posix(),
+        "report_kind": TIINGO_CANDIDATE_LOOP_REPORT_KIND,
+        "counts": _empty_tiingo_candidate_loop_counts(),
+        "feedback": _empty_tiingo_candidate_loop_feedback(),
+        "variants": _empty_tiingo_candidate_loop_variants(),
+        "authority_summary": _false_tiingo_candidate_loop_authority_summary(),
+        "diagnostic_reason": reason,
+    }
+
+
+def _read_tiingo_candidate_loop(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return _tiingo_candidate_loop_diagnostic(
+            status="not_available",
+            source_artifact=path,
+            reason="tiingo_candidate_loop_artifact_missing",
+        )
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return _tiingo_candidate_loop_diagnostic(
+            status="malformed_or_unreadable",
+            source_artifact=path,
+            reason="tiingo_candidate_loop_artifact_unreadable",
+        )
+    if not isinstance(parsed, dict):
+        return _tiingo_candidate_loop_diagnostic(
+            status="malformed_or_unreadable",
+            source_artifact=path,
+            reason="tiingo_candidate_loop_artifact_not_object",
+        )
+    summary = parsed.get("summary") if isinstance(parsed.get("summary"), dict) else {}
+    safety = parsed.get("safety") if isinstance(parsed.get("safety"), dict) else {}
+    daily_input = (
+        parsed.get("daily_digest_input")
+        if isinstance(parsed.get("daily_digest_input"), dict)
+        else {}
+    )
+    authority = (
+        daily_input.get("authority_summary")
+        if isinstance(daily_input.get("authority_summary"), dict)
+        else {}
+    )
+    unsafe_keys = [
+        key
+        for key in TIINGO_CANDIDATE_LOOP_AUTHORITY_KEYS
+        if any(
+            view.get(key) is not True
+            if key in {"research_only", "screening_only"}
+            else view.get(key) is not False
+            for view in (safety, authority)
+        )
+    ]
+    if unsafe_keys:
+        payload = _tiingo_candidate_loop_diagnostic(
+            status="blocked_unsafe_authority",
+            source_artifact=path,
+            reason="unsafe_tiingo_candidate_loop_authority_signal",
+        )
+        payload["unsafe_authority_keys"] = sorted(unsafe_keys)
+        return payload
+    if parsed.get("report_kind") != TIINGO_CANDIDATE_LOOP_REPORT_KIND or not summary:
+        return _tiingo_candidate_loop_diagnostic(
+            status="malformed_or_unreadable",
+            source_artifact=path,
+            reason="tiingo_candidate_loop_missing_expected_fields",
+        )
+    evidence_summary = (
+        parsed.get("evidence_ledger_summary")
+        if isinstance(parsed.get("evidence_ledger_summary"), dict)
+        else {}
+    )
+    variant_summary = (
+        parsed.get("variant_summary")
+        if isinstance(parsed.get("variant_summary"), dict)
+        else {}
+    )
+    return {
+        "status": "ready",
+        "source_artifact": path.as_posix(),
+        "report_kind": TIINGO_CANDIDATE_LOOP_REPORT_KIND,
+        "loop_verdict": summary.get("loop_verdict"),
+        "counts": {
+            "contracts": int(summary.get("input_contracts_admitted") or 0),
+            "candidates_materialized": int(summary.get("candidates_materialized") or 0),
+            "candidates_screened": int(summary.get("candidates_screened") or 0),
+            "screening_pass": int(summary.get("screening_pass") or 0),
+            "screening_fail": int(summary.get("screening_fail") or 0),
+            "null_not_beaten": int(summary.get("null_not_beaten") or 0),
+            "insufficient_evidence": int(summary.get("insufficient_evidence") or 0),
+            "feedback_records": int(summary.get("feedback_records") or 0),
+            "evidence_records": int(evidence_summary.get("evidence_records") or 0),
+        },
+        "feedback": {
+            "feedback_consumed": bool(summary.get("feedback_consumed") is True),
+            "feedback_applied_count": int(summary.get("feedback_applied_count") or 0),
+            "next_run_feedback_ready": bool(summary.get("next_run_feedback_ready") is True),
+        },
+        "variants": {
+            "base_candidates": int(variant_summary.get("base_candidates") or 0),
+            "variant_candidates": int(variant_summary.get("variant_candidates") or 0),
+            "variants_materialized": int(variant_summary.get("variants_materialized") or 0),
+            "modified_by_prior_feedback": int(variant_summary.get("modified_by_prior_feedback") or 0),
+            "retained_by_prior_feedback": int(variant_summary.get("retained_by_prior_feedback") or 0),
+            "suppressed_by_prior_feedback": int(variant_summary.get("suppressed_by_prior_feedback") or 0),
+        },
+        "authority_summary": _false_tiingo_candidate_loop_authority_summary(),
+    }
+
+
 def _discover_backend_results(results_dir: Path) -> list[tuple[Path, dict[str, Any]]]:
     if not results_dir.exists():
         return []
@@ -372,6 +558,7 @@ def build_daily_status_packet(
     research_memory_current_artifacts_latest_path: Path = DEFAULT_RESEARCH_MEMORY_CURRENT_ARTIFACTS_LATEST,
     shadow_readiness_latest_path: Path = DEFAULT_SHADOW_READINESS_LATEST,
     tiingo_hypothesis_lifecycle_latest_path: Path = DEFAULT_TIINGO_HYPOTHESIS_LIFECYCLE_LATEST,
+    tiingo_candidate_loop_latest_path: Path = DEFAULT_TIINGO_CANDIDATE_LOOP_LATEST,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
     loop_packet = _read_json(loop_latest_path)
@@ -408,6 +595,7 @@ def build_daily_status_packet(
     tiingo_hypothesis_lifecycle = _read_tiingo_hypothesis_lifecycle(
         tiingo_hypothesis_lifecycle_latest_path
     )
+    tiingo_candidate_loop = _read_tiingo_candidate_loop(tiingo_candidate_loop_latest_path)
 
     build_consumed = _count_true(
         build_consumer_latest.get("build_request_consumed") if isinstance(build_consumer_latest, dict) else None,
@@ -500,6 +688,9 @@ def build_daily_status_packet(
             tiingo_hypothesis_lifecycle_latest_path.as_posix()
             if tiingo_hypothesis_lifecycle["status"] != "not_available"
             else None,
+            tiingo_candidate_loop_latest_path.as_posix()
+            if tiingo_candidate_loop["status"] != "not_available"
+            else None,
         ]
         if path is not None
     ]
@@ -572,6 +763,11 @@ def build_daily_status_packet(
             str(action) for action in tiingo_lifecycle_next_actions
         ],
         "tiingo_hypothesis_lifecycle_authority": tiingo_lifecycle_authority,
+        "tiingo_candidate_loop_status": tiingo_candidate_loop["status"],
+        "tiingo_candidate_loop_counts": tiingo_candidate_loop["counts"],
+        "tiingo_candidate_loop_feedback": tiingo_candidate_loop["feedback"],
+        "tiingo_candidate_loop_variants": tiingo_candidate_loop["variants"],
+        "tiingo_candidate_loop_authority": tiingo_candidate_loop["authority_summary"],
         "summary": {
             "autonomous_cycles": len(cycles),
             "controlled_research_inner_loops": summary.get("controlled_research_inner_loop_count"),
@@ -633,6 +829,11 @@ def build_daily_status_packet(
                 str(action) for action in tiingo_lifecycle_next_actions
             ],
             "tiingo_hypothesis_lifecycle_authority": tiingo_lifecycle_authority,
+            "tiingo_candidate_loop_status": tiingo_candidate_loop["status"],
+            "tiingo_candidate_loop_counts": tiingo_candidate_loop["counts"],
+            "tiingo_candidate_loop_feedback": tiingo_candidate_loop["feedback"],
+            "tiingo_candidate_loop_variants": tiingo_candidate_loop["variants"],
+            "tiingo_candidate_loop_authority": tiingo_candidate_loop["authority_summary"],
             "flywheel_progress": {
                 "build_request_consumed": _yes_no_unknown(
                     build_requests_consumed > 0 if build_requests_consumed else None
@@ -663,6 +864,7 @@ def build_daily_status_packet(
         "research_memory_current_artifacts": research_memory_current_artifacts,
         "shadow_readiness": shadow_readiness,
         "tiingo_hypothesis_lifecycle": tiingo_hypothesis_lifecycle,
+        "tiingo_candidate_loop": tiingo_candidate_loop,
         "flywheel_summary_fallback": {
             key: value
             for key, value in flywheel_summary.items()
@@ -715,6 +917,33 @@ def render_daily_status(packet: dict[str, Any]) -> str:
     next_safe_actions = tiingo_lifecycle.get("next_safe_actions")
     if not isinstance(next_safe_actions, list) or not next_safe_actions:
         next_safe_actions = [tiingo_lifecycle.get("diagnostic_reason") or "none"]
+    tiingo_candidate_loop = packet.get("tiingo_candidate_loop")
+    if not isinstance(tiingo_candidate_loop, dict):
+        tiingo_candidate_loop = _tiingo_candidate_loop_diagnostic(
+            status="malformed_or_unreadable",
+            source_artifact=DEFAULT_TIINGO_CANDIDATE_LOOP_LATEST,
+            reason="tiingo_candidate_loop_section_missing",
+        )
+    candidate_counts = (
+        tiingo_candidate_loop.get("counts")
+        if isinstance(tiingo_candidate_loop.get("counts"), dict)
+        else _empty_tiingo_candidate_loop_counts()
+    )
+    candidate_feedback = (
+        tiingo_candidate_loop.get("feedback")
+        if isinstance(tiingo_candidate_loop.get("feedback"), dict)
+        else _empty_tiingo_candidate_loop_feedback()
+    )
+    candidate_variants = (
+        tiingo_candidate_loop.get("variants")
+        if isinstance(tiingo_candidate_loop.get("variants"), dict)
+        else _empty_tiingo_candidate_loop_variants()
+    )
+    candidate_authority = (
+        tiingo_candidate_loop.get("authority_summary")
+        if isinstance(tiingo_candidate_loop.get("authority_summary"), dict)
+        else _false_tiingo_candidate_loop_authority_summary()
+    )
     build_request_statuses = packet.get("build_request_statuses")
     if not isinstance(build_request_statuses, dict):
         build_request_statuses = {}
@@ -790,6 +1019,31 @@ def render_daily_status(packet: dict[str, Any]) -> str:
             f"- Paper authority: {str(tiingo_authority.get('paper_authority')).lower()}",
             f"- Shadow authority: {str(tiingo_authority.get('shadow_authority')).lower()}",
             f"- Live authority: {str(tiingo_authority.get('live_authority')).lower()}",
+            "",
+            "Tiingo candidate research loop:",
+            f"- Status: {tiingo_candidate_loop.get('status')}",
+            f"- Contracts admitted: {candidate_counts.get('contracts', 0)}",
+            f"- Candidates materialized: {candidate_counts.get('candidates_materialized', 0)}",
+            f"- Candidates screened: {candidate_counts.get('candidates_screened', 0)}",
+            f"- Screening pass: {candidate_counts.get('screening_pass', 0)}",
+            f"- Screening fail: {candidate_counts.get('screening_fail', 0)}",
+            f"- Null not beaten: {candidate_counts.get('null_not_beaten', 0)}",
+            f"- Insufficient evidence: {candidate_counts.get('insufficient_evidence', 0)}",
+            f"- Feedback records: {candidate_counts.get('feedback_records', 0)}",
+            f"- Evidence records: {candidate_counts.get('evidence_records', 0)}",
+            f"- Feedback consumed: {str(candidate_feedback.get('feedback_consumed')).lower()}",
+            f"- Feedback applied count: {candidate_feedback.get('feedback_applied_count', 0)}",
+            f"- Next-run feedback ready: {str(candidate_feedback.get('next_run_feedback_ready')).lower()}",
+            f"- Base candidates: {candidate_variants.get('base_candidates', 0)}",
+            f"- Variant candidates: {candidate_variants.get('variant_candidates', 0)}",
+            "- Candidate creation: research-only specs",
+            "- Screening run: research-only",
+            "- Candidate creation means research-only candidate specs, not executable strategies.",
+            f"- Trading authority: {str(candidate_authority.get('trading_authority')).lower()}",
+            f"- Validation authority: {str(candidate_authority.get('validation_authority')).lower()}",
+            f"- Paper authority: {str(candidate_authority.get('paper_authority')).lower()}",
+            f"- Shadow authority: {str(candidate_authority.get('shadow_authority')).lower()}",
+            f"- Live authority: {str(candidate_authority.get('live_authority')).lower()}",
             "",
             "Research intelligence progress:",
             "- Learning is feeding back into the next market-intake seed.",
@@ -875,6 +1129,7 @@ def run_daily_status_digest(
     research_memory_current_artifacts_latest_path: Path = DEFAULT_RESEARCH_MEMORY_CURRENT_ARTIFACTS_LATEST,
     shadow_readiness_latest_path: Path = DEFAULT_SHADOW_READINESS_LATEST,
     tiingo_hypothesis_lifecycle_latest_path: Path = DEFAULT_TIINGO_HYPOTHESIS_LIFECYCLE_LATEST,
+    tiingo_candidate_loop_latest_path: Path = DEFAULT_TIINGO_CANDIDATE_LOOP_LATEST,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
     write: bool = False,
 ) -> dict[str, Any]:
@@ -890,6 +1145,7 @@ def run_daily_status_digest(
         research_memory_current_artifacts_latest_path=research_memory_current_artifacts_latest_path,
         shadow_readiness_latest_path=shadow_readiness_latest_path,
         tiingo_hypothesis_lifecycle_latest_path=tiingo_hypothesis_lifecycle_latest_path,
+        tiingo_candidate_loop_latest_path=tiingo_candidate_loop_latest_path,
     )
     if write:
         packet["_artifact_paths"] = write_outputs(packet, output_dir=output_dir)
@@ -916,6 +1172,10 @@ def main(argv: list[str] | None = None) -> int:
         "--tiingo-hypothesis-lifecycle-latest",
         default=DEFAULT_TIINGO_HYPOTHESIS_LIFECYCLE_LATEST.as_posix(),
     )
+    parser.add_argument(
+        "--tiingo-candidate-loop-latest",
+        default=DEFAULT_TIINGO_CANDIDATE_LOOP_LATEST.as_posix(),
+    )
     parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
     args = parser.parse_args(argv)
     packet = run_daily_status_digest(
@@ -934,6 +1194,7 @@ def main(argv: list[str] | None = None) -> int:
         tiingo_hypothesis_lifecycle_latest_path=Path(
             args.tiingo_hypothesis_lifecycle_latest
         ),
+        tiingo_candidate_loop_latest_path=Path(args.tiingo_candidate_loop_latest),
         output_dir=Path(args.output_dir),
         write=args.write,
     )

--- a/research/qre_tiingo_candidate_research_loop.py
+++ b/research/qre_tiingo_candidate_research_loop.py
@@ -141,9 +141,16 @@ def _source_path(path: Path, repo_root: Path) -> str:
         return resolved.as_posix()
 
 
-def _run_config(*, max_candidates: int, null_iterations: int, seed: int) -> dict[str, Any]:
+def _run_config(
+    *,
+    max_candidates: int,
+    max_variants_per_contract: int,
+    null_iterations: int,
+    seed: int,
+) -> dict[str, Any]:
     return {
         "max_candidates": max_candidates,
+        "max_variants_per_contract": max_variants_per_contract,
         "null_iterations": null_iterations,
         "seed": seed,
         "screening_only": True,
@@ -169,6 +176,18 @@ def _empty_summary() -> dict[str, Any]:
         "suppressed_by_prior_feedback": 0,
         "modified_by_prior_feedback": 0,
         "retained_by_prior_feedback": 0,
+    }
+
+
+def _empty_variant_summary() -> dict[str, int]:
+    return {
+        "base_candidates": 0,
+        "variant_candidates": 0,
+        "variants_requested": 0,
+        "variants_materialized": 0,
+        "modified_by_prior_feedback": 0,
+        "retained_by_prior_feedback": 0,
+        "suppressed_by_prior_feedback": 0,
     }
 
 
@@ -227,6 +246,7 @@ def _base_report(
         "feedback_records": [],
         "evidence_ledger": [],
         "evidence_ledger_summary": _empty_evidence_ledger_summary(),
+        "variant_summary": _empty_variant_summary(),
         "prior_feedback": {
             "feedback_consumed": False,
             "feedback_source_path": None,
@@ -355,7 +375,8 @@ def build_input_contracts(lifecycle: dict[str, Any]) -> tuple[list[dict[str, Any
 
 
 def _candidate_template(feature_family: str, *, variant: str = "v1") -> dict[str, Any] | None:
-    lookback = 40 if variant == "modified_by_prior_feedback" else 60
+    alternate_variant = variant in {"alternate", "modified_by_prior_feedback"}
+    lookback = 40 if alternate_variant else 60
     if feature_family == "cross_sectional_momentum":
         return {
             "candidate_family": "cross_sectional_momentum",
@@ -389,7 +410,7 @@ def _candidate_template(feature_family: str, *, variant: str = "v1") -> dict[str
             "universe": list(EXPECTED_UNIVERSE),
         }
     if feature_family == "defensive_rotation":
-        defensive_count = 1 if variant == "modified_by_prior_feedback" else 2
+        defensive_count = 1 if alternate_variant else 2
         return {
             "candidate_family": "defensive_rotation",
             "signal_definition": {
@@ -408,7 +429,7 @@ def _candidate_template(feature_family: str, *, variant: str = "v1") -> dict[str
             "universe": list(EXPECTED_UNIVERSE),
         }
     if feature_family == "volatility_compression_breakout":
-        vol_lookback = 30 if variant == "modified_by_prior_feedback" else 20
+        vol_lookback = 30 if alternate_variant else 20
         return {
             "candidate_family": "volatility_compression_breakout",
             "signal_definition": {
@@ -424,7 +445,7 @@ def _candidate_template(feature_family: str, *, variant: str = "v1") -> dict[str
             "universe": list(EXPECTED_UNIVERSE),
         }
     if feature_family == "mean_reversion_after_extreme_dispersion":
-        threshold = "p75" if variant == "modified_by_prior_feedback" else "rolling_median"
+        threshold = "p75" if alternate_variant else "rolling_median"
         return {
             "candidate_family": "mean_reversion_after_extreme_dispersion",
             "signal_definition": {
@@ -447,14 +468,34 @@ def materialize_candidate_spec(
     *,
     variant: str = "v1",
     feedback_note: str | None = None,
+    variant_parent_candidate_id: str | None = None,
 ) -> tuple[dict[str, Any] | None, str | None]:
     family = str(contract.get("feature_family"))
     template = _candidate_template(family, variant=variant)
     if template is None:
         return None, "blocked_unknown_candidate_family"
+    variant_id = "base" if variant == "v1" else "variant_" + _digest(
+        {
+            "contract_id": contract["contract_id"],
+            "feature_family": family,
+            "variant": variant,
+            "template": template,
+        },
+        length=10,
+    )
+    variant_parameters = {}
+    if family in {"cross_sectional_momentum", "risk_on_risk_off_regime"}:
+        variant_parameters["lookback_window"] = template["signal_definition"]["lookback_trading_days"]
+    elif family == "defensive_rotation":
+        variant_parameters["defensive_count"] = template["selection_rule"]["defensive_count"]
+    elif family == "volatility_compression_breakout":
+        variant_parameters["volatility_lookback"] = template["signal_definition"]["volatility_lookback_trading_days"]
+    elif family == "mean_reversion_after_extreme_dispersion":
+        variant_parameters["dispersion_threshold"] = template["signal_definition"]["dispersion_threshold"]
     id_basis = {
         "contract_id": contract["contract_id"],
         "feature_family": family,
+        "variant_id": variant_id,
         "signal_definition": template["signal_definition"],
         "selection_rule": template["selection_rule"],
         "rebalance_rule": template["rebalance_rule"],
@@ -488,6 +529,16 @@ def materialize_candidate_spec(
         "creates_orders": False,
         "forbidden_authorities": list(contract.get("forbidden_authorities") or []),
         "prior_feedback_variant": variant,
+        "variant_id": variant_id,
+        "variant_reason": "base_candidate"
+        if variant == "v1"
+        else (
+            "prior_feedback_modified_spec"
+            if variant == "modified_by_prior_feedback"
+            else "bounded_alternate_candidate"
+        ),
+        "variant_parent_candidate_id": variant_parent_candidate_id,
+        "variant_parameters": {} if variant == "v1" else variant_parameters,
     }
     if feedback_note:
         candidate["prior_feedback_note"] = feedback_note
@@ -1164,6 +1215,7 @@ def build_report(
     prior_feedback_input: Path = DEFAULT_PRIOR_FEEDBACK_INPUT,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
     max_candidates: int = 5,
+    max_variants_per_contract: int = 1,
     null_iterations: int = 32,
     seed: int = 1729,
 ) -> dict[str, Any]:
@@ -1172,7 +1224,12 @@ def build_report(
     upstream_path = upstream_e2e_input if upstream_e2e_input.is_absolute() else repo_root / upstream_e2e_input
     bars_path = bars_input if bars_input.is_absolute() else repo_root / bars_input
     prior_path = prior_feedback_input if prior_feedback_input.is_absolute() else repo_root / prior_feedback_input
-    config = _run_config(max_candidates=max_candidates, null_iterations=null_iterations, seed=seed)
+    config = _run_config(
+        max_candidates=max_candidates,
+        max_variants_per_contract=max_variants_per_contract,
+        null_iterations=null_iterations,
+        seed=seed,
+    )
     lifecycle, lifecycle_error = _read_json(lifecycle_path)
     upstream, _upstream_error = _read_json(upstream_path)
     prior_feedback = read_prior_feedback(prior_path)
@@ -1211,8 +1268,15 @@ def build_report(
         "modified_by_prior_feedback": 0,
         "retained_by_prior_feedback": 0,
     }
+    variant_summary = _empty_variant_summary()
+    requested_variants_per_contract = max(1, min(2, max_variants_per_contract))
+    variant_summary["variants_requested"] = sum(
+        max(0, requested_variants_per_contract - 1) for _contract in contracts
+    )
 
-    for contract in contracts[: max(0, max_candidates)]:
+    for contract in contracts:
+        if len(candidate_specs) >= max(0, max_candidates):
+            break
         action, note, application = _apply_prior_feedback(contract, feedback_map.get(contract["contract_id"]))
         if application is not None:
             applications.append(application)
@@ -1223,14 +1287,32 @@ def build_report(
         if action in {"suppress", "block"}:
             blocked_reasons.append(str(note))
             continue
-        variant = "modified_by_prior_feedback" if action == "modify" else "v1"
-        candidate, block_reason = materialize_candidate_spec(contract, variant=variant, feedback_note=note)
-        if block_reason is not None or candidate is None:
-            blocked_reasons.append(block_reason or "candidate_materialization_failed")
-            continue
-        candidate_specs.append(candidate)
-        if action == "defer_screening":
-            deferred_candidate_ids.add(candidate["candidate_id"])
+        if action == "modify":
+            variant_plan = [("modified_by_prior_feedback", str((feedback_map.get(contract["contract_id"]) or {}).get("candidate_id") or ""))]
+        else:
+            variant_plan = [("v1", None)]
+            if requested_variants_per_contract > 1:
+                variant_plan.append(("alternate", None))
+        for variant, parent_candidate_id in variant_plan[:requested_variants_per_contract]:
+            if len(candidate_specs) >= max(0, max_candidates):
+                break
+            candidate, block_reason = materialize_candidate_spec(
+                contract,
+                variant=variant,
+                feedback_note=note,
+                variant_parent_candidate_id=parent_candidate_id,
+            )
+            if block_reason is not None or candidate is None:
+                blocked_reasons.append(block_reason or "candidate_materialization_failed")
+                continue
+            candidate_specs.append(candidate)
+            if candidate["variant_id"] == "base":
+                variant_summary["base_candidates"] += 1
+            else:
+                variant_summary["variant_candidates"] += 1
+                variant_summary["variants_materialized"] += 1
+            if action == "defer_screening":
+                deferred_candidate_ids.add(candidate["candidate_id"])
 
     prior_feedback["feedback_application"] = applications
     if not candidate_specs:
@@ -1246,6 +1328,7 @@ def build_report(
         report["summary"]["input_contracts_seen"] = len(contracts) + len(skipped)
         report["summary"]["input_contracts_admitted"] = len(contracts)
         report["summary"]["suppressed_by_prior_feedback"] = counters["suppressed_by_prior_feedback"]
+        report["variant_summary"] = variant_summary
         return report
 
     bars, bars_reasons = load_bars(bars_path)
@@ -1286,6 +1369,7 @@ def build_report(
     summary["feedback_applied_count"] = prior_feedback["feedback_applied_count"]
     summary["next_run_feedback_ready"] = bool(feedback_records)
     summary.update(counters)
+    variant_summary.update(counters)
     if bars_reasons:
         summary["loop_verdict"] = "blocked_no_screening_data"
         blocked_reasons.extend(bars_reasons)
@@ -1307,6 +1391,7 @@ def build_report(
             "feedback_records": feedback_records,
             "evidence_ledger": evidence_ledger,
             "evidence_ledger_summary": summarize_evidence_ledger(evidence_ledger),
+            "variant_summary": variant_summary,
             "prior_feedback": {key: value for key, value in prior_feedback.items() if key != "_records"},
             "next_run_plan": _next_run_plan(feedback_records),
             "blocked_reasons": sorted(dict.fromkeys(blocked_reasons)),
@@ -1350,6 +1435,8 @@ def render_operator_summary(report: dict[str, Any]) -> str:
         f"- Insufficient evidence: {summary['insufficient_evidence']}",
         f"- Feedback records: {summary['feedback_records']}",
         f"- Evidence records: {report.get('evidence_ledger_summary', {}).get('evidence_records', 0)}",
+        f"- Base candidates: {report.get('variant_summary', {}).get('base_candidates', 0)}",
+        f"- Variant candidates: {report.get('variant_summary', {}).get('variant_candidates', 0)}",
         f"- Feedback consumed: {str(summary['feedback_consumed']).lower()}",
         f"- Feedback applied count: {summary['feedback_applied_count']}",
         f"- Next run feedback ready: {str(summary['next_run_feedback_ready']).lower()}",
@@ -1482,6 +1569,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--prior-feedback-input", default=DEFAULT_PRIOR_FEEDBACK_INPUT.as_posix())
     parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
     parser.add_argument("--max-candidates", type=int, default=5)
+    parser.add_argument("--max-variants-per-contract", type=int, default=1)
     parser.add_argument("--null-iterations", type=int, default=32)
     parser.add_argument("--seed", type=int, default=1729)
     parser.add_argument("--write", action="store_true")
@@ -1496,6 +1584,7 @@ def main(argv: list[str] | None = None) -> int:
         prior_feedback_input=Path(args.prior_feedback_input),
         output_dir=Path(args.output_dir),
         max_candidates=args.max_candidates,
+        max_variants_per_contract=args.max_variants_per_contract,
         null_iterations=args.null_iterations,
         seed=args.seed,
     )

--- a/research/qre_tiingo_candidate_research_loop.py
+++ b/research/qre_tiingo_candidate_research_loop.py
@@ -187,6 +187,7 @@ def _daily_digest_input(report: dict[str, Any]) -> dict[str, Any]:
             "null_not_beaten": summary["null_not_beaten"],
             "insufficient_evidence": summary["insufficient_evidence"],
             "feedback_records": summary["feedback_records"],
+            "evidence_records": report.get("evidence_ledger_summary", {}).get("evidence_records", 0),
         },
         "next_actions": sorted(
             {
@@ -224,6 +225,8 @@ def _base_report(
         "candidate_specs": [],
         "screening_results": [],
         "feedback_records": [],
+        "evidence_ledger": [],
+        "evidence_ledger_summary": _empty_evidence_ledger_summary(),
         "prior_feedback": {
             "feedback_consumed": False,
             "feedback_source_path": None,
@@ -235,6 +238,18 @@ def _base_report(
         "daily_digest_input": {},
         "safety": dict(SAFETY),
         "blocked_reasons": sorted(dict.fromkeys(blocked_reasons)),
+    }
+
+
+def _empty_evidence_ledger_summary() -> dict[str, Any]:
+    return {
+        "evidence_records": 0,
+        "retain_research_evidence": 0,
+        "weak_research_evidence": 0,
+        "insufficient_research_evidence": 0,
+        "blocked_research_evidence": 0,
+        "research_only": True,
+        "trading_authority": False,
     }
 
 
@@ -973,6 +988,105 @@ def feedback_from_screening(result: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _evidence_decision(screening_decision: str) -> str:
+    if screening_decision == "screening_pass":
+        return "retain_research_evidence"
+    if screening_decision in {"null_not_beaten", "screening_fail"}:
+        return "weak_research_evidence"
+    if screening_decision == "insufficient_evidence":
+        return "insufficient_research_evidence"
+    return "blocked_research_evidence"
+
+
+def build_evidence_entry(
+    *,
+    candidate: dict[str, Any],
+    screening_result: dict[str, Any],
+    feedback_record: dict[str, Any],
+) -> dict[str, Any]:
+    metrics_summary = {
+        "observation_count": int(screening_result.get("observation_count") or 0),
+        "rebalance_count": int(screening_result.get("rebalance_count") or 0),
+        "candidate_total_return": float(screening_result.get("candidate_total_return") or 0.0),
+        "benchmark_total_return": float(screening_result.get("benchmark_total_return") or 0.0),
+        "excess_return": float(screening_result.get("excess_return") or 0.0),
+        "candidate_sharpe_like": float(screening_result.get("candidate_sharpe_like") or 0.0),
+        "max_drawdown": float(screening_result.get("max_drawdown") or 0.0),
+        "win_rate": float(screening_result.get("win_rate") or 0.0),
+    }
+    null_control = (
+        screening_result.get("null_control")
+        if isinstance(screening_result.get("null_control"), dict)
+        else {}
+    )
+    null_summary = {
+        "null_iterations": int(null_control.get("null_iterations") or 0),
+        "seed": int(null_control.get("seed") or 0),
+        "beats_null_p50": bool(null_control.get("beats_null_p50") is True),
+        "beats_null_p75": bool(null_control.get("beats_null_p75") is True),
+    }
+    metrics_digest = _sha(
+        {
+            "metrics_summary": metrics_summary,
+            "null_control_summary": null_summary,
+            "screening_decision": screening_result.get("decision"),
+        }
+    )
+    evidence_decision = _evidence_decision(str(screening_result.get("decision")))
+    evidence_basis = {
+        "candidate_id": candidate.get("candidate_id"),
+        "candidate_digest": candidate.get("candidate_digest"),
+        "source_snapshot_id": candidate.get("source_snapshot_id"),
+        "screening_decision": screening_result.get("decision"),
+        "metrics_digest": metrics_digest,
+    }
+    return {
+        "evidence_id": "ev_tiingo_" + _digest(evidence_basis),
+        "evidence_schema_version": 1,
+        "evidence_kind": "tiingo_candidate_screening_evidence",
+        "candidate_id": candidate.get("candidate_id"),
+        "candidate_digest": candidate.get("candidate_digest"),
+        "parent_contract_id": candidate.get("parent_contract_id"),
+        "parent_hypothesis_seed_id": candidate.get("parent_hypothesis_seed_id"),
+        "source_hypothesis_id": candidate.get("source_hypothesis_id"),
+        "source_snapshot_id": candidate.get("source_snapshot_id"),
+        "feature_family": candidate.get("feature_family"),
+        "candidate_family": candidate.get("candidate_family"),
+        "screening_protocol": SCREENING_PROTOCOL,
+        "data_basis": {
+            "source_id": "tiingo_eod_equities_free",
+            "timeframe": "1d",
+            "split_adjustment_requirement": "required",
+            "price_basis": "split_adjusted_research_prices",
+        },
+        "metrics_digest": metrics_digest,
+        "metrics_summary": metrics_summary,
+        "null_control_summary": null_summary,
+        "screening_decision": screening_result.get("decision"),
+        "feedback_decision": feedback_record.get("feedback_decision"),
+        "evidence_decision": evidence_decision,
+        "audit_flags": {
+            "research_only": True,
+            "screening_only": True,
+            "trading_authority": False,
+            "validation_authority": False,
+            "paper_authority": False,
+            "shadow_authority": False,
+            "live_authority": False,
+        },
+    }
+
+
+def summarize_evidence_ledger(evidence_ledger: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = _empty_evidence_ledger_summary()
+    summary["evidence_records"] = len(evidence_ledger)
+    for row in evidence_ledger:
+        decision = str(row.get("evidence_decision"))
+        if decision in summary:
+            summary[decision] += 1
+    return summary
+
+
 def read_prior_feedback(path: Path) -> dict[str, Any]:
     payload, error = _read_json(path)
     if error is not None or not isinstance(payload, dict):
@@ -1089,6 +1203,7 @@ def build_report(
     candidate_specs: list[dict[str, Any]] = []
     screening_results: list[dict[str, Any]] = []
     feedback_records: list[dict[str, Any]] = []
+    evidence_ledger: list[dict[str, Any]] = []
     blocked_reasons: list[str] = []
     deferred_candidate_ids: set[str] = set()
     counters = {
@@ -1149,7 +1264,15 @@ def build_report(
         else:
             result = screen_candidate(candidate, bars, null_iterations=null_iterations, seed=seed)
         screening_results.append(result)
-        feedback_records.append(feedback_from_screening(result))
+        feedback_record = feedback_from_screening(result)
+        feedback_records.append(feedback_record)
+        evidence_ledger.append(
+            build_evidence_entry(
+                candidate=candidate,
+                screening_result=result,
+                feedback_record=feedback_record,
+            )
+        )
 
     summary = _empty_summary()
     summary["input_contracts_seen"] = len(contracts) + len(skipped)
@@ -1182,6 +1305,8 @@ def build_report(
             "candidate_specs": candidate_specs,
             "screening_results": screening_results,
             "feedback_records": feedback_records,
+            "evidence_ledger": evidence_ledger,
+            "evidence_ledger_summary": summarize_evidence_ledger(evidence_ledger),
             "prior_feedback": {key: value for key, value in prior_feedback.items() if key != "_records"},
             "next_run_plan": _next_run_plan(feedback_records),
             "blocked_reasons": sorted(dict.fromkeys(blocked_reasons)),
@@ -1224,6 +1349,7 @@ def render_operator_summary(report: dict[str, Any]) -> str:
         f"- Null not beaten: {summary['null_not_beaten']}",
         f"- Insufficient evidence: {summary['insufficient_evidence']}",
         f"- Feedback records: {summary['feedback_records']}",
+        f"- Evidence records: {report.get('evidence_ledger_summary', {}).get('evidence_records', 0)}",
         f"- Feedback consumed: {str(summary['feedback_consumed']).lower()}",
         f"- Feedback applied count: {summary['feedback_applied_count']}",
         f"- Next run feedback ready: {str(summary['next_run_feedback_ready']).lower()}",
@@ -1335,6 +1461,7 @@ def write_outputs(
         "candidate_specs": resolved / "candidate_specs.jsonl",
         "screening_results": resolved / "screening_results.jsonl",
         "feedback_records": resolved / "feedback_records.jsonl",
+        "evidence_ledger": resolved / "evidence_ledger.jsonl",
         "operator_summary": resolved / "operator_summary.md",
     }
     _atomic_write_text(paths["latest"], _json_text(report))
@@ -1342,6 +1469,7 @@ def write_outputs(
     _atomic_write_text(paths["candidate_specs"], _jsonl_text(report.get("candidate_specs", [])))
     _atomic_write_text(paths["screening_results"], _jsonl_text(report.get("screening_results", [])))
     _atomic_write_text(paths["feedback_records"], _jsonl_text(report.get("feedback_records", [])))
+    _atomic_write_text(paths["evidence_ledger"], _jsonl_text(report.get("evidence_ledger", [])))
     _atomic_write_text(paths["operator_summary"], render_operator_summary(report))
     return {key: path.relative_to(repo_root).as_posix() for key, path in paths.items()}
 
@@ -1386,6 +1514,7 @@ __all__ = [
     "REPORT_KIND",
     "SAFETY",
     "build_input_contracts",
+    "build_evidence_entry",
     "build_report",
     "feedback_from_screening",
     "load_bars",
@@ -1393,6 +1522,7 @@ __all__ = [
     "materialize_candidate_spec",
     "render_operator_summary",
     "screen_candidate",
+    "summarize_evidence_ledger",
     "write_outputs",
 ]
 

--- a/tests/unit/test_qre_daily_status_digest.py
+++ b/tests/unit/test_qre_daily_status_digest.py
@@ -88,6 +88,71 @@ def _write_tiingo_lifecycle(root: Path, payload: dict | None = None) -> Path:
     return latest_path
 
 
+def _valid_tiingo_candidate_loop_payload() -> dict:
+    authority = {
+        "research_only": True,
+        "screening_only": True,
+        "trading_authority": False,
+        "creates_orders": False,
+        "broker_authority": False,
+        "risk_authority": False,
+        "promotes_candidates": False,
+        "registers_strategy": False,
+        "validation_authority": False,
+        "paper_authority": False,
+        "shadow_authority": False,
+        "live_authority": False,
+    }
+    return {
+        "report_kind": "qre_tiingo_candidate_research_loop",
+        "schema_version": 1,
+        "source_snapshot_id": "qdsnap_test",
+        "summary": {
+            "loop_verdict": "pass_research_only_candidate_loop",
+            "input_contracts_admitted": 5,
+            "candidates_materialized": 5,
+            "candidates_screened": 5,
+            "screening_pass": 2,
+            "screening_fail": 0,
+            "null_not_beaten": 3,
+            "insufficient_evidence": 0,
+            "feedback_records": 5,
+            "feedback_consumed": False,
+            "feedback_applied_count": 0,
+            "next_run_feedback_ready": True,
+        },
+        "evidence_ledger_summary": {
+            "evidence_records": 5,
+            "retain_research_evidence": 2,
+            "weak_research_evidence": 3,
+            "insufficient_research_evidence": 0,
+            "blocked_research_evidence": 0,
+            "research_only": True,
+            "trading_authority": False,
+        },
+        "variant_summary": {
+            "base_candidates": 5,
+            "variant_candidates": 0,
+            "variants_requested": 0,
+            "variants_materialized": 0,
+            "modified_by_prior_feedback": 0,
+            "retained_by_prior_feedback": 0,
+            "suppressed_by_prior_feedback": 0,
+        },
+        "daily_digest_input": {
+            "digest_kind": "qre_tiingo_candidate_research_loop_daily_input",
+            "authority_summary": dict(authority),
+        },
+        "safety": dict(authority),
+    }
+
+
+def _write_tiingo_candidate_loop(root: Path, payload: dict | None = None) -> Path:
+    latest_path = root / "candidate_loop" / "latest.json"
+    _write_json(latest_path, payload or _valid_tiingo_candidate_loop_payload())
+    return latest_path
+
+
 def _run_digest(root: Path, **overrides) -> dict:
     loop_latest_path = overrides.pop("loop_latest_path", None) or _write_loop_latest(root)
     kwargs = {
@@ -102,6 +167,7 @@ def _run_digest(root: Path, **overrides) -> dict:
         "research_memory_current_artifacts_latest_path": root / "memory" / "latest.json",
         "shadow_readiness_latest_path": root / "shadow" / "latest.json",
         "tiingo_hypothesis_lifecycle_latest_path": root / "tiingo_lifecycle" / "latest.json",
+        "tiingo_candidate_loop_latest_path": root / "candidate_loop" / "latest.json",
         "output_dir": root / "daily",
         "write": True,
     }
@@ -656,4 +722,110 @@ def test_tiingo_lifecycle_ingestion_does_not_create_candidates_or_run_screening(
     assert authority["paper_authority"] is False
     assert authority["shadow_authority"] is False
     assert authority["live_authority"] is False
+
+
+def test_missing_tiingo_candidate_loop_artifact_is_not_available(tmp_path: Path) -> None:
+    packet = _run_digest(tmp_path)
+
+    assert packet["tiingo_candidate_loop_status"] == "not_available"
+    assert packet["tiingo_candidate_loop_counts"]["candidates_materialized"] == 0
+    assert packet["tiingo_candidate_loop_authority"]["trading_authority"] is False
+
+
+def test_valid_tiingo_candidate_loop_appears_in_digest_json(tmp_path: Path) -> None:
+    candidate_path = _write_tiingo_candidate_loop(tmp_path)
+
+    packet = _run_digest(tmp_path, tiingo_candidate_loop_latest_path=candidate_path)
+
+    assert packet["tiingo_candidate_loop_status"] == "ready"
+    assert packet["tiingo_candidate_loop_counts"] == {
+        "contracts": 5,
+        "candidates_materialized": 5,
+        "candidates_screened": 5,
+        "screening_pass": 2,
+        "screening_fail": 0,
+        "null_not_beaten": 3,
+        "insufficient_evidence": 0,
+        "feedback_records": 5,
+        "evidence_records": 5,
+    }
+    assert packet["tiingo_candidate_loop_feedback"] == {
+        "feedback_consumed": False,
+        "feedback_applied_count": 0,
+        "next_run_feedback_ready": True,
+    }
+    assert packet["tiingo_candidate_loop_variants"] == {
+        "base_candidates": 5,
+        "variant_candidates": 0,
+        "variants_materialized": 0,
+        "modified_by_prior_feedback": 0,
+        "retained_by_prior_feedback": 0,
+        "suppressed_by_prior_feedback": 0,
+    }
+    assert packet["tiingo_candidate_loop_authority"]["research_only"] is True
+    assert packet["tiingo_candidate_loop_authority"]["screening_only"] is True
+    assert packet["tiingo_candidate_loop_authority"]["trading_authority"] is False
+    assert packet["summary"]["tiingo_candidate_loop_counts"]["evidence_records"] == 5
+    assert packet["summary"]["tiingo_candidate_loop_feedback"]["feedback_consumed"] is False
+
+
+def test_tiingo_candidate_loop_operator_summary_section(tmp_path: Path) -> None:
+    candidate_path = _write_tiingo_candidate_loop(tmp_path)
+
+    _run_digest(tmp_path, tiingo_candidate_loop_latest_path=candidate_path)
+
+    rendered = (tmp_path / "daily" / "operator_summary.md").read_text(encoding="utf-8")
+    assert "Tiingo candidate research loop:" in rendered
+    assert "- Contracts admitted: 5" in rendered
+    assert "- Candidates materialized: 5" in rendered
+    assert "- Candidates screened: 5" in rendered
+    assert "- Evidence records: 5" in rendered
+    assert "- Feedback consumed: false" in rendered
+    assert "- Feedback applied count: 0" in rendered
+    assert "- Base candidates: 5" in rendered
+    assert "- Variant candidates: 0" in rendered
+    assert "- Candidate creation: research-only specs" in rendered
+    assert "Candidate creation means research-only candidate specs, not executable strategies." in rendered
+    assert "- Trading authority: false" in rendered
+    assert "- Validation authority: false" in rendered
+    assert "- Paper authority: false" in rendered
+    assert "- Shadow authority: false" in rendered
+    assert "- Live authority: false" in rendered
+
+
+def test_unsafe_tiingo_candidate_loop_authority_is_blocked(tmp_path: Path) -> None:
+    payload = _valid_tiingo_candidate_loop_payload()
+    payload["safety"]["trading_authority"] = True
+    candidate_path = _write_tiingo_candidate_loop(tmp_path, payload)
+
+    packet = _run_digest(tmp_path, tiingo_candidate_loop_latest_path=candidate_path)
+
+    assert packet["tiingo_candidate_loop_status"] == "blocked_unsafe_authority"
+    assert packet["tiingo_candidate_loop_authority"]["trading_authority"] is False
+    assert packet["tiingo_candidate_loop_authority"]["research_only"] is True
+
+
+def test_malformed_tiingo_candidate_loop_artifact_is_reported(tmp_path: Path) -> None:
+    candidate_path = tmp_path / "candidate_loop" / "latest.json"
+    candidate_path.parent.mkdir(parents=True, exist_ok=True)
+    candidate_path.write_text("{not-json", encoding="utf-8")
+
+    packet = _run_digest(tmp_path, tiingo_candidate_loop_latest_path=candidate_path)
+
+    assert packet["tiingo_candidate_loop_status"] == "malformed_or_unreadable"
+    assert packet["tiingo_candidate_loop_authority"]["trading_authority"] is False
+
+
+def test_daily_digest_candidate_loop_ingestion_does_not_create_candidates_or_screening(tmp_path: Path) -> None:
+    candidate_path = _write_tiingo_candidate_loop(tmp_path)
+
+    packet = _run_digest(tmp_path, tiingo_candidate_loop_latest_path=candidate_path)
+
+    assert packet["tiingo_candidate_loop_counts"]["candidates_materialized"] == 5
+    assert packet["tiingo_candidate_loop_counts"]["candidates_screened"] == 5
+    assert packet["safety"]["run_research_called"] is False
+    assert packet["safety"]["validation_executed"] is False
+    assert packet["safety"]["execution_allowed"] is False
+    assert packet["tiingo_candidate_loop_authority"]["creates_orders"] is False
+    assert packet["tiingo_candidate_loop_authority"]["promotes_candidates"] is False
 

--- a/tests/unit/test_qre_tiingo_candidate_research_loop.py
+++ b/tests/unit/test_qre_tiingo_candidate_research_loop.py
@@ -247,6 +247,8 @@ def test_all_known_candidate_family_templates_materialize_with_required_safety(t
     families = {candidate["feature_family"] for candidate in report["candidate_specs"]}
     assert families == set(FAMILIES)
     assert report["summary"]["candidates_materialized"] == 5
+    assert report["variant_summary"]["base_candidates"] == 5
+    assert report["variant_summary"]["variant_candidates"] == 0
     for candidate in report["candidate_specs"]:
         assert candidate["candidate_id"].startswith("cand_tiingo_")
         assert candidate["candidate_digest"].startswith("sha256:")
@@ -258,6 +260,10 @@ def test_all_known_candidate_family_templates_materialize_with_required_safety(t
         assert candidate["not_trade_signal"] is True
         assert candidate["trading_authority"] is False
         assert candidate["creates_orders"] is False
+        assert candidate["variant_id"] == "base"
+        assert candidate["variant_reason"] == "base_candidate"
+        assert candidate["variant_parent_candidate_id"] is None
+        assert candidate["variant_parameters"] == {}
         assert "orders" not in candidate
         assert "positions" not in candidate
         assert "trading_signals" not in candidate
@@ -284,6 +290,40 @@ def test_candidate_ids_are_deterministic(tmp_path: Path) -> None:
     assert [row["candidate_id"] for row in report["candidate_specs"]] == [
         row["candidate_id"] for row in report_again["candidate_specs"]
     ]
+
+
+def test_max_variants_per_contract_materializes_bounded_variants(tmp_path: Path) -> None:
+    report = _run(tmp_path, max_candidates=10, max_variants_per_contract=2)
+
+    assert report["summary"]["candidates_materialized"] == 10
+    assert report["variant_summary"]["base_candidates"] == 5
+    assert report["variant_summary"]["variant_candidates"] == 5
+    assert report["variant_summary"]["variants_materialized"] == 5
+    grouped: dict[str, list[dict]] = {}
+    for candidate in report["candidate_specs"]:
+        grouped.setdefault(candidate["parent_contract_id"], []).append(candidate)
+        assert candidate["research_only"] is True
+        assert candidate["trading_authority"] is False
+    assert all(len(rows) == 2 for rows in grouped.values())
+    for rows in grouped.values():
+        ids = {row["candidate_id"] for row in rows}
+        assert len(ids) == 2
+        assert len({row["parent_hypothesis_seed_id"] for row in rows}) == 1
+
+
+def test_bounded_variant_templates_use_expected_parameters(tmp_path: Path) -> None:
+    report = _run(tmp_path, max_candidates=10, max_variants_per_contract=2)
+    variants = {
+        candidate["feature_family"]: candidate
+        for candidate in report["candidate_specs"]
+        if candidate["variant_id"] != "base"
+    }
+
+    assert variants["cross_sectional_momentum"]["signal_definition"]["lookback_trading_days"] == 40
+    assert variants["risk_on_risk_off_regime"]["signal_definition"]["lookback_trading_days"] == 40
+    assert variants["defensive_rotation"]["selection_rule"]["defensive_count"] == 1
+    assert variants["volatility_compression_breakout"]["signal_definition"]["volatility_lookback_trading_days"] == 30
+    assert variants["mean_reversion_after_extreme_dispersion"]["signal_definition"]["dispersion_threshold"] == "p75"
 
 
 def test_missing_and_malformed_bars_block_screening(tmp_path: Path) -> None:
@@ -419,6 +459,7 @@ def test_prior_retain_feedback_rematerializes_same_candidate(tmp_path: Path) -> 
     assert second["summary"]["feedback_consumed"] is True
     assert second["summary"]["feedback_applied_count"] == 1
     assert second["summary"]["retained_by_prior_feedback"] == 1
+    assert second["variant_summary"]["retained_by_prior_feedback"] == 1
     assert first["candidate_specs"][0]["candidate_id"] in {row["candidate_id"] for row in second["candidate_specs"]}
 
 
@@ -444,9 +485,18 @@ def test_prior_reject_modify_insufficient_and_block_feedback_change_next_run(tmp
     assert second["summary"]["feedback_applied_count"] == 4
     assert second["summary"]["suppressed_by_prior_feedback"] == 1
     assert second["summary"]["modified_by_prior_feedback"] == 1
+    assert second["variant_summary"]["modified_by_prior_feedback"] == 1
+    assert second["variant_summary"]["suppressed_by_prior_feedback"] == 1
     assert "suppressed_by_prior_feedback" in second["blocked_reasons"]
     assert "blocked_by_prior_feedback" in second["blocked_reasons"]
-    assert any(candidate["prior_feedback_variant"] == "modified_by_prior_feedback" for candidate in second["candidate_specs"])
+    modified = [
+        candidate
+        for candidate in second["candidate_specs"]
+        if candidate["prior_feedback_variant"] == "modified_by_prior_feedback"
+    ]
+    assert modified
+    assert modified[0]["variant_reason"] == "prior_feedback_modified_spec"
+    assert modified[0]["variant_parent_candidate_id"]
     assert any(result["decision"] == "insufficient_evidence" for result in second["screening_results"])
     assert [row["candidate_id"] for row in first["candidate_specs"]] != [
         row["candidate_id"] for row in second["candidate_specs"]
@@ -466,6 +516,7 @@ def test_write_outputs_and_default_mode_write_nothing(tmp_path: Path) -> None:
         "candidate_specs",
         "screening_results",
         "feedback_records",
+        "evidence_ledger",
         "operator_summary",
     }
     assert (output_dir / "latest.json").is_file()
@@ -473,6 +524,7 @@ def test_write_outputs_and_default_mode_write_nothing(tmp_path: Path) -> None:
     assert (output_dir / "candidate_specs.jsonl").is_file()
     assert (output_dir / "screening_results.jsonl").is_file()
     assert (output_dir / "feedback_records.jsonl").is_file()
+    assert (output_dir / "evidence_ledger.jsonl").is_file()
     assert (output_dir / "operator_summary.md").is_file()
     assert all(path.startswith("logs/qre_tiingo_candidate_research_loop/") for path in paths.values())
 
@@ -503,6 +555,7 @@ def test_all_safety_flags_daily_digest_and_operator_summary_are_research_only(tm
     report = _run(tmp_path)
     assert report["safety"] == loop.SAFETY
     assert report["daily_digest_input"]["counts"]["input_contracts_admitted"] == 5
+    assert report["daily_digest_input"]["counts"]["evidence_records"] == 5
     assert report["daily_digest_input"]["authority_summary"] == loop.SAFETY
     summary = loop.render_operator_summary(report)
     assert "# Tiingo Candidate Research Loop" in summary
@@ -510,4 +563,80 @@ def test_all_safety_flags_daily_digest_and_operator_summary_are_research_only(tm
     assert "No broker/risk authority exists" in summary
     forbidden_active_terms = ("validation_ready", "paper_ready", "shadow_ready", "live_ready", "trade_ready")
     assert not any(term in json.dumps(report) for term in forbidden_active_terms)
+
+
+def test_evidence_ledger_has_one_deterministic_research_only_entry_per_screened_candidate(tmp_path: Path) -> None:
+    report = _run(tmp_path)
+    report_again = _run(tmp_path)
+
+    assert len(report["evidence_ledger"]) == report["summary"]["candidates_screened"]
+    assert report["evidence_ledger"] == report_again["evidence_ledger"]
+    for entry in report["evidence_ledger"]:
+        assert entry["evidence_id"].startswith("ev_tiingo_")
+        assert entry["evidence_kind"] == "tiingo_candidate_screening_evidence"
+        assert entry["screening_protocol"] == "tiingo_research_candidate_screening_v1"
+        assert entry["metrics_digest"].startswith("sha256:")
+        assert "metrics_summary" in entry
+        assert "null_control_summary" in entry
+        assert entry["audit_flags"]["research_only"] is True
+        assert entry["audit_flags"]["screening_only"] is True
+        assert entry["audit_flags"]["trading_authority"] is False
+        assert entry["audit_flags"]["validation_authority"] is False
+        assert entry["audit_flags"]["paper_authority"] is False
+        assert entry["audit_flags"]["shadow_authority"] is False
+        assert entry["audit_flags"]["live_authority"] is False
+
+
+def test_evidence_ledger_decision_mapping_and_summary_counts(tmp_path: Path) -> None:
+    report = _run(tmp_path)
+    by_screening = {entry["screening_decision"]: entry["evidence_decision"] for entry in report["evidence_ledger"]}
+
+    if "screening_pass" in by_screening:
+        assert by_screening["screening_pass"] == "retain_research_evidence"
+    if "null_not_beaten" in by_screening:
+        assert by_screening["null_not_beaten"] == "weak_research_evidence"
+    summary = report["evidence_ledger_summary"]
+    assert summary["evidence_records"] == len(report["evidence_ledger"])
+    assert summary["retain_research_evidence"] == report["summary"]["screening_pass"]
+    assert summary["weak_research_evidence"] == (
+        report["summary"]["null_not_beaten"] + report["summary"]["screening_fail"]
+    )
+    assert summary["research_only"] is True
+    assert summary["trading_authority"] is False
+
+
+def test_evidence_decision_mapping_for_all_screening_decisions() -> None:
+    candidate = {
+        "candidate_id": "cand",
+        "candidate_digest": "sha256:cand",
+        "parent_contract_id": "contract",
+        "parent_hypothesis_seed_id": "seed",
+        "source_hypothesis_id": "hyp",
+        "source_snapshot_id": "snap",
+        "feature_family": "cross_sectional_momentum",
+        "candidate_family": "cross_sectional_momentum",
+    }
+    expected = {
+        "screening_pass": "retain_research_evidence",
+        "null_not_beaten": "weak_research_evidence",
+        "screening_fail": "weak_research_evidence",
+        "insufficient_evidence": "insufficient_research_evidence",
+        "blocked_unsafe_input": "blocked_research_evidence",
+    }
+    for decision, evidence_decision in expected.items():
+        result = {
+            "candidate_id": "cand",
+            "parent_contract_id": "contract",
+            "parent_hypothesis_seed_id": "seed",
+            "source_snapshot_id": "snap",
+            "decision": decision,
+            "null_control": {"null_iterations": 32, "seed": 1729},
+        }
+        feedback = loop.feedback_from_screening(result)
+        entry = loop.build_evidence_entry(
+            candidate=candidate,
+            screening_result=result,
+            feedback_record=feedback,
+        )
+        assert entry["evidence_decision"] == evidence_decision
 


### PR DESCRIPTION
Summary:
- adds research-only Tiingo candidate evidence ledger
- adds bounded candidate variants under max_variants_per_contract/max_candidates
- includes Tiingo candidate research loop in daily status digest
- daily digest reports candidate counts, screening decisions, feedback, evidence, variants, and authority summary
- preserves research-only/screening-only safety boundaries

Validation:
- python -m pytest tests/unit/test_qre_tiingo_candidate_research_loop.py -q
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_lifecycle.py -q
- python -m pytest tests/unit/test_qre_tiingo_hypothesis_generator_e2e.py -q
- python -m ruff check research/qre_tiingo_candidate_research_loop.py research/qre_daily_status_digest.py tests/unit/test_qre_tiingo_candidate_research_loop.py tests/unit/test_qre_daily_status_digest.py
- git diff --check
- manual first-run, feedback-consumption, and daily-digest checks

Safety:
- research_only=true
- screening_only=true
- trading_authority=false
- creates_orders=false
- broker_authority=false
- risk_authority=false
- promotes_candidates=false
- registers_strategy=false
- validation_authority=false
- paper/shadow/live authority=false
- research/research_latest.json not mutated
- research/strategy_matrix.csv not mutated