### PR TITLE
research: audit QRE funnel architecture and contract boundaries

### DIFF
--- a/docs/architecture/qre_canonical_contract_map.md
+++ b/docs/architecture/qre_canonical_contract_map.md
@@ -1,0 +1,68 @@
+# QRE Canonical Contract Map
+
+## Settlement Position
+
+The current repo should be treated as several partial funnels, not one proven provider-agnostic canonical loop.
+
+The Tiingo candidate research loop is valuable and should be kept, but as a provider adapter / research-only mini-loop until its artifacts are bridged to provider-agnostic contracts.
+
+The daily digest is observability-only. It must not become a producer of research objects.
+
+The run_research / registry / strategy_matrix path may still be an important canonical legacy surface, but this audit does not prove it owns the modern QRE Hypothesis, CandidateSpec, EvidenceLedger, FeedbackRecord, PresetSpec, or CampaignSpec vocabulary.
+
+## Canonical Object Ownership
+
+| Object | Current audit status | Current owner evidence | Recommendation |
+|---|---|---|---|
+| DataProvider | inferred | source manifest and provider modules | DEFINE_CANONICAL_SCHEMA |
+| SourceManifest | present | external intelligence/source manifest modules | KEEP |
+| SourceSnapshot | present | source snapshot provenance fields | KEEP |
+| DatasetFingerprint | inferred | source/data profile digest fields | DEFINE_CANONICAL_SCHEMA |
+| ObservationSnapshot | missing or ambiguous | no single owner proven | DEFINE_CANONICAL_SCHEMA |
+| Hypothesis | ambiguous | Tiingo generator plus older discovery modules | OPERATOR_DECISION_REQUIRED |
+| HypothesisSeed | present | Tiingo lifecycle | BRIDGE |
+| ResearchInputContract | present | Tiingo candidate loop | BRIDGE |
+| CandidateSpec | present but provider-specific | Tiingo candidate loop | GENERALIZE |
+| StrategySpec | ambiguous | older strategy/preset/campaign paths | OPERATOR_DECISION_REQUIRED |
+| StrategyIR | ambiguous | alpha discovery / Strategy IR references | OPERATOR_DECISION_REQUIRED |
+| PresetSpec | ambiguous | preset modules and docs | OPERATOR_DECISION_REQUIRED |
+| CampaignSpec | ambiguous | campaign modules | OPERATOR_DECISION_REQUIRED |
+| CampaignRun | inferred | campaign run/report modules | DEFINE_CANONICAL_SCHEMA |
+| ScreeningResult | present | Tiingo candidate loop and other screening modules | GENERALIZE |
+| EvidencePack | ambiguous | campaign/evidence modules | OPERATOR_DECISION_REQUIRED |
+| EvidenceLedger | present provider-specific | Tiingo candidate loop evidence ledger | BRIDGE |
+| Disposition | inferred | disposition modules | DEFINE_CANONICAL_SCHEMA |
+| FeedbackRecord | present provider-specific | Tiingo candidate loop feedback records | BRIDGE |
+| LessonMemory | ambiguous | lesson/memory modules | OPERATOR_DECISION_REQUIRED |
+| ResearchMemory | ambiguous | research memory modules | OPERATOR_DECISION_REQUIRED |
+| DailyDigestInput | present | daily digest sidecars | KEEP_AS_OBSERVABILITY |
+| OperatorSummary | present | digest and sidecar summaries | KEEP_AS_OBSERVABILITY |
+| RegistryEntry | present | registry.py | KEEP_PENDING_SCOPE_CONFIRMATION |
+| StrategyMatrixRow | present | research/strategy_matrix.csv | KEEP_AS_LEGACY_OUTPUT_CONTRACT |
+
+## Funnel Reconciliation Table
+
+| Funnel | Current status | Canonicality | Provider specificity | Keep/Bridge/Deprecate decision | Required future PR |
+|---|---|---|---|---|---|
+| Tiingo candidate research loop | research-only mini-loop | provider adapter | provider_specific | KEEP_AS_PROVIDER_ADAPTER + BRIDGE_TO_CANONICAL | Bridge Tiingo HypothesisSeed, ResearchInputContract, CandidateSpec, EvidenceLedger, and FeedbackRecord to canonical schemas |
+| Daily digest | read-only aggregation | observability_only | mixed | OBSERVABILITY_ONLY | Keep consuming sidecars; do not let digest produce research objects |
+| Alpha discovery / Strategy IR / campaign / lesson funnel | partial funnel | unknown | mixed | BRIDGE_TO_CANONICAL or UNKNOWN_REQUIRES_OPERATOR_DECISION | Map StrategyIR, CampaignSpec, EvidencePack, Disposition, LessonMemory, and ResearchMemory ownership |
+| run_research / registry / strategy_matrix | legacy or canonical backtest/report path | unknown | mixed | OPERATOR_DECISION_REQUIRED | Decide whether registry and strategy_matrix remain canonical for strategy research outputs |
+| test/smoke fixture funnels | fixture semantics | test_fixture_only | unknown | TEST_FIXTURE_ONLY | Quarantine fixture-only claims from architecture docs |
+
+## Recommended PR Sequence
+
+1. PR A: settle canonical contract vocabulary.
+2. PR B: bridge Tiingo artifacts to canonical Hypothesis/CandidateSpec.
+3. PR C: bridge canonical CandidateSpec to StrategySpec/PresetSpec/CampaignSpec.
+4. PR D: connect campaign evidence to FeedbackMemory/LessonMemory.
+5. PR E: make next hypothesis generation consume canonical memory.
+6. PR F: deprecate or quarantine duplicate legacy funnels.
+
+## Rules For Future Work
+
+- Provider-specific terms stop at adapter, source manifest, snapshot, dataset fingerprint, and provenance layers.
+- CandidateSpec, StrategySpec, PresetSpec, CampaignSpec, EvidencePack, FeedbackRecord, and readiness policy must be provider-agnostic.
+- Observability modules consume artifacts and summarize status; they do not create research objects.
+- Legacy run_research outputs remain protected and must not be mutated by architecture audit work.
+

--- a/docs/architecture/qre_funnel_architecture_audit.md
+++ b/docs/architecture/qre_funnel_architecture_audit.md
@@ -1,0 +1,74 @@
+# QRE Funnel Architecture Audit
+
+## Purpose
+
+This document records the static architecture audit for QRE research funnels. The audit answers what exists today, which modules produce and consume artifacts, where provider-specific assumptions appear, and which paths should be kept, bridged, deprecated, or treated as observability-only.
+
+## Audit Scope
+
+The audit is static and behavior-preserving. It does not run research, create candidates, launch campaigns, validate strategies, register strategies, or touch paper/shadow/live paths.
+
+The audit tool is:
+
+```text
+tools/qre_funnel_architecture_audit.py
+```
+
+Default mode prints JSON and writes nothing:
+
+```powershell
+python tools/qre_funnel_architecture_audit.py
+```
+
+Write mode writes only:
+
+```text
+logs/qre_funnel_architecture_audit/
+```
+
+## Initial Architectural Finding
+
+The repo contains multiple partial funnels rather than one proven, provider-agnostic canonical loop:
+
+- Tiingo hypothesis and candidate research mini-loop
+- daily digest observability funnel
+- run_research / registry / strategy_matrix funnel
+- alpha discovery / campaign / evidence / memory style modules
+- test and smoke fixture paths that may resemble funnel semantics
+
+The Tiingo path is useful and should be kept, but it is provider-specific and should be bridged to canonical contracts before being treated as the general QRE architecture.
+
+## Outputs
+
+Write mode emits:
+
+```text
+logs/qre_funnel_architecture_audit/latest.json
+logs/qre_funnel_architecture_audit/dependency_graph.json
+logs/qre_funnel_architecture_audit/provider_leakage_report.json
+logs/qre_funnel_architecture_audit/contract_map.json
+logs/qre_funnel_architecture_audit/funnel_inventory.json
+logs/qre_funnel_architecture_audit/operator_summary.md
+```
+
+Generated logs are not committed.
+
+## Safety
+
+This audit is architecture diagnosis only:
+
+```text
+audit_only=true
+runtime_behavior_changed=false
+created_candidates=false
+created_strategies=false
+created_presets=false
+created_campaigns=false
+ran_screening=false
+trading_authority=false
+validation_authority=false
+paper_authority=false
+shadow_authority=false
+live_authority=false
+```
+

--- a/docs/architecture/qre_funnel_visual_maps.md
+++ b/docs/architecture/qre_funnel_visual_maps.md
@@ -1,0 +1,170 @@
+# QRE Funnel Visual Maps
+
+This audit uses C4-style context/container/component diagrams, data-flow diagrams, integration/dependency diagrams, and sequence diagrams.
+
+It does not prioritize infrastructure diagrams because this audit is about research architecture, artifact contracts, provider leakage, and funnel ownership, not servers, networks, load balancers, or deployment topology.
+
+## Diagram 1 C4 Context: QRE Research System Boundary
+
+```mermaid
+flowchart LR
+    Operator[Operator]
+    Codex[ChatGPT / Codex workflow]
+    GitHub[GitHub PR / CI]
+    Repo[QRE repo]
+    Providers[Data providers / adapters]
+    Artifacts[Generated research artifacts]
+    Digest[Daily digest / observability]
+    NoLive[No broker / order / live authority]
+
+    Operator --> Codex
+    Codex --> Repo
+    Repo --> GitHub
+    Providers --> Repo
+    Repo --> Artifacts
+    Artifacts --> Digest
+    Digest --> Operator
+    Repo -. safety boundary .-> NoLive
+```
+
+## Diagram 2 C4 Container/Component: Current Detected Funnels
+
+```mermaid
+flowchart TB
+    subgraph TiingoMiniLoop[Tiingo mini-loop]
+        TGen[qre_tiingo_hypothesis_generator_e2e.py]
+        TLife[qre_tiingo_hypothesis_lifecycle.py]
+        TCand[qre_tiingo_candidate_research_loop.py]
+        TArt[logs/qre_tiingo_*]
+        TGen --> TLife --> TCand --> TArt
+    end
+
+    subgraph AlphaCampaign[Alpha discovery / Strategy IR / campaign funnel]
+        Alpha[alpha discovery modules]
+        StrategyIR[Strategy IR semantics]
+        Campaign[campaign modules]
+        Lessons[lesson / memory / disposition modules]
+        Alpha --> StrategyIR --> Campaign --> Lessons
+    end
+
+    subgraph LegacyRun[Canonical or legacy run_research / registry / matrix funnel]
+        Registry[registry.py]
+        Strategies[agent/backtesting/strategies.py]
+        RunResearch[research/run_research.py]
+        Matrix[research_latest.json / strategy_matrix.csv]
+        Registry --> RunResearch
+        Strategies --> RunResearch --> Matrix
+    end
+
+    subgraph Observability[Daily digest observability funnel]
+        Sidecars[logs/**/latest.json]
+        Digest[qre_daily_status_digest.py]
+        Summary[operator_summary.md]
+        Sidecars --> Digest --> Summary
+    end
+```
+
+## Diagram 3 Target Canonical Data-Flow Architecture
+
+```mermaid
+flowchart LR
+    Adapter[DataProviderAdapter]
+    SourceSnapshot[SourceSnapshot]
+    ObservationSnapshot[ObservationSnapshot]
+    Hypothesis[Hypothesis]
+    Contract[ResearchInputContract]
+    Candidate[CandidateSpec]
+    Strategy[StrategySpec / Strategy IR]
+    Preset[PresetSpec]
+    Campaign[CampaignSpec]
+    Run[CampaignRun / ScreeningResult]
+    Evidence[EvidencePack / EvidenceLedger]
+    Feedback[Disposition / FeedbackRecord / LessonMemory]
+    Next[Next HypothesisBatch]
+
+    Adapter --> SourceSnapshot --> ObservationSnapshot --> Hypothesis --> Contract --> Candidate --> Strategy --> Preset --> Campaign --> Run --> Evidence --> Feedback --> Next
+    SourceSnapshot -. provider provenance allowed .-> Adapter
+    Candidate -. provider-specific terms stop before here .- SourceSnapshot
+    Preset -. provider agnostic required .- Campaign
+```
+
+Provider-specific terms stop at SourceSnapshot/provenance. PresetSpec and CampaignSpec must remain provider-agnostic.
+
+## Diagram 4 Integration/Dependency Graph: Producer/Consumer Artifact Map
+
+```mermaid
+flowchart LR
+    TGen[qre_tiingo_hypothesis_generator_e2e] -- adapter edge --> TGenArt[Tiingo generator latest.json]
+    TGenArt -- artifact contract --> TLife[qre_tiingo_hypothesis_lifecycle]
+    TLife -- sidecar --> TLifeArt[Tiingo lifecycle latest.json]
+    TLifeArt -- adapter edge --> TCand[qre_tiingo_candidate_research_loop]
+    Bars[bars.csv] -- adapter data --> TCand
+    TCand -- sidecar --> TCandArt[candidate loop latest/evidence/feedback]
+    TCandArt -- observability edge --> Digest[qre_daily_status_digest]
+    Legacy[run_research / registry] -- canonical unknown --> Matrix[research_latest / strategy_matrix]
+    Campaign[campaign / evidence / memory modules] -- suspicious or unknown edges --> Memory[lesson / research memory]
+```
+
+Canonical edges should converge through provider-agnostic contracts. Adapter edges can remain provider-specific. Observability edges must not become producers. Suspicious/unknown edges require settlement before being treated as canonical.
+
+## Diagram 5 Sequence: Intended Full Canonical Loop
+
+```mermaid
+sequenceDiagram
+    actor Operator
+    participant HypothesisGenerator
+    participant AdmissionBoundary
+    participant CandidateMaterializer
+    participant StrategySpecBuilder
+    participant PresetBuilder
+    participant CampaignPlanner
+    participant CampaignRunner
+    participant EvidenceEvaluator
+    participant FeedbackMemory
+    participant NextHypothesisGenerator
+    participant DailyDigest
+
+    Operator->>HypothesisGenerator: generate hypotheses
+    HypothesisGenerator->>AdmissionBoundary: admit / reject
+    AdmissionBoundary->>CandidateMaterializer: admitted contract
+    CandidateMaterializer->>StrategySpecBuilder: candidate spec
+    StrategySpecBuilder->>PresetBuilder: strategy spec
+    PresetBuilder->>CampaignPlanner: preset spec
+    CampaignPlanner->>CampaignRunner: bounded campaign spec
+    CampaignRunner->>EvidenceEvaluator: screening / campaign result
+    EvidenceEvaluator->>FeedbackMemory: evidence + disposition
+    FeedbackMemory->>NextHypothesisGenerator: feedback memory
+    DailyDigest->>Operator: report status
+
+    Note over CampaignRunner,DailyDigest: No validation/promotion/paper/shadow/live.
+    Note over Operator,DailyDigest: No broker/risk/order authority.
+```
+
+## Diagram 6 Provider Leakage Boundary
+
+```mermaid
+flowchart TB
+    subgraph Allowed[Provider-specific allowed zone]
+        Adapters[adapters]
+        Manifests[source manifests]
+        Snapshots[snapshots]
+        Fingerprints[dataset fingerprints]
+        Provenance[provenance]
+    end
+
+    subgraph Agnostic[Provider-agnostic required zone]
+        CandidateSem[candidate semantics]
+        StrategySpecs[strategy specs]
+        Presets[presets]
+        Campaigns[campaigns]
+        EvidenceDecisions[evidence decisions]
+        FeedbackDecisions[feedback decisions]
+        Readiness[readiness / promotion policy]
+    end
+
+    Adapters --> Manifests --> Snapshots --> Fingerprints --> Provenance
+    Provenance --> CandidateSem
+    CandidateSem --> StrategySpecs --> Presets --> Campaigns --> EvidenceDecisions --> FeedbackDecisions
+    Readiness -. must not depend on provider terms .- Adapters
+```
+

--- a/tests/unit/test_qre_funnel_architecture_audit.py
+++ b/tests/unit/test_qre_funnel_architecture_audit.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_PATH = REPO_ROOT / "tools" / "qre_funnel_architecture_audit.py"
+SPEC = importlib.util.spec_from_file_location("qre_funnel_architecture_audit", TOOL_PATH)
+assert SPEC is not None and SPEC.loader is not None
+audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _fixture_repo(root: Path) -> Path:
+    _write(root / "research" / "qre_tiingo_candidate_research_loop.py", "DEFAULT='logs/qre_tiingo_candidate_research_loop/latest.json'\n")
+    _write(root / "research" / "qre_tiingo_hypothesis_lifecycle.py", "REPORT_KIND='qre_tiingo_hypothesis_lifecycle'\n")
+    _write(root / "research" / "qre_daily_status_digest.py", "INPUT='logs/qre_tiingo_candidate_research_loop/latest.json'\n")
+    _write(root / "research" / "run_research.py", "OUT='research/research_latest.json'\n")
+    _write(root / "registry.py", "REGISTRY={}\n")
+    _write(root / "research" / "qre_campaign_memory.py", "CampaignSpec='x'; LessonMemory='y'\n")
+    _write(root / "tests" / "unit" / "test_qre_tiingo_candidate_research_loop.py", "def test_fixture(): pass\n")
+    _write(root / "docs" / "research" / "tiingo_candidate_research_loop.md", "Tiingo candidate research loop\n")
+    _write(root / "research" / "research_latest.json", "{}\n")
+    _write(root / "research" / "strategy_matrix.csv", "a,b\n")
+    return root
+
+
+def test_default_mode_prints_json_and_writes_nothing(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(TOOL_PATH), "--repo-root", str(repo)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["report_kind"] == "qre_funnel_architecture_audit"
+    assert not (repo / "logs" / "qre_funnel_architecture_audit").exists()
+
+
+def test_write_mode_writes_only_allowed_audit_dir(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    report = audit.build_report(repo)
+
+    paths = audit.write_outputs(report, repo_root=repo)
+
+    assert set(paths) == {
+        "latest",
+        "dependency_graph",
+        "provider_leakage_report",
+        "contract_map",
+        "funnel_inventory",
+        "operator_summary",
+    }
+    assert all(value.startswith("logs/qre_funnel_architecture_audit/") for value in paths.values())
+    assert (repo / "logs" / "qre_funnel_architecture_audit" / "latest.json").is_file()
+
+
+def test_report_kind_and_safety_flags(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+
+    assert report["report_kind"] == "qre_funnel_architecture_audit"
+    assert report["safety"]["audit_only"] is True
+    assert report["safety"]["runtime_behavior_changed"] is False
+    assert report["safety"]["created_candidates"] is False
+    assert report["safety"]["trading_authority"] is False
+
+
+def test_inventory_includes_tiingo_candidate_loop(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    ids = {row["funnel_id"] for row in report["funnel_inventory"]}
+    assert "tiingo_hypothesis_candidate_research_mini_loop" in ids
+
+
+def test_inventory_includes_daily_digest_observability(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    digest = next(
+        row
+        for row in report["funnel_inventory"]
+        if row["funnel_id"] == "daily_status_digest_observability"
+    )
+    assert digest["canonicality"] == "observability_only"
+    assert digest["status_recommendation"] == "OBSERVABILITY_ONLY"
+
+
+def test_contract_map_includes_required_objects(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    for name in audit.CANONICAL_OBJECTS:
+        assert name in report["contract_map"]
+
+
+def test_provider_leakage_allows_adapter_and_provenance_references() -> None:
+    assert audit.classify_provider_reference("research/qre_tiingo_hypothesis_generator_e2e.py", "source_snapshot_id='x'") in {
+        "allowed_adapter_reference",
+        "allowed_provenance_reference",
+        "allowed_source_manifest_reference",
+    }
+
+
+def test_provider_leakage_flags_preset_campaign_semantics() -> None:
+    assert audit.classify_provider_reference("research/preset_builder.py", "tiingo campaign admission policy") == "forbidden_provider_coupling"
+
+
+def test_dependency_graph_has_nodes_and_edges(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    graph = report["dependency_graph"]
+    assert graph["summary"]["nodes"] > 0
+    assert graph["summary"]["edges"] > 0
+
+
+def test_dependency_graph_classifies_observability_edges(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    assert any(edge["classification"] == "observability" for edge in report["dependency_graph"]["edges"])
+
+
+def test_hardcoded_path_scanner_detects_log_path_coupling(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    findings = report["hardcoded_coupling_report"]["hardcoded_coupling_findings"]
+    assert any(item["pattern"] == "hardcoded_artifact_path" for item in findings)
+
+
+def test_reconciliation_plan_contains_decision_categories(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    decisions = {row["decision"] for row in report["reconciliation_plan"]}
+    assert "KEEP_AS_PROVIDER_ADAPTER" in decisions
+    assert "OBSERVABILITY_ONLY" in decisions
+    assert decisions & {"BRIDGE_TO_CANONICAL", "UNKNOWN_REQUIRES_OPERATOR_DECISION"}
+
+
+def test_visual_docs_contain_required_diagram_headings() -> None:
+    text = (REPO_ROOT / "docs" / "architecture" / "qre_funnel_visual_maps.md").read_text(encoding="utf-8")
+    for heading in (
+        "C4 Context",
+        "Current Detected Funnels",
+        "Target Canonical Data-Flow",
+        "Integration/Dependency",
+        "Sequence",
+        "Provider Leakage Boundary",
+    ):
+        assert heading in text
+
+
+def test_audit_does_not_mutate_protected_outputs(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    latest = repo / "research" / "research_latest.json"
+    matrix = repo / "research" / "strategy_matrix.csv"
+    before_latest = latest.read_bytes()
+    before_matrix = matrix.read_bytes()
+
+    audit.build_report(repo)
+
+    assert latest.read_bytes() == before_latest
+    assert matrix.read_bytes() == before_matrix
+
+
+def test_audit_does_not_create_candidate_loop_logs(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    audit.build_report(repo)
+    assert not (repo / "logs" / "qre_tiingo_candidate_research_loop").exists()
+
+
+def test_audit_does_not_create_campaign_screening_validation_artifacts(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    audit.build_report(repo)
+    assert not (repo / "logs" / "qre_validation").exists()
+    assert not (repo / "logs" / "qre_campaign").exists()
+    assert not (repo / "logs" / "qre_tiingo_candidate_research_loop" / "screening_results.jsonl").exists()
+
+
+def test_audit_runs_from_repo_root_on_windows_paths() -> None:
+    report = audit.build_report(REPO_ROOT)
+    assert report["summary"]["audit_verdict"] in {
+        "pass_inventory_complete_with_reconciliation_needed",
+        "partial_inventory_manual_review_required",
+    }
+
+
+def test_operator_summary_contains_required_sections(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    summary = audit.render_operator_summary(report)
+    for heading in (
+        "## Verdict",
+        "## Funnels detected",
+        "## Provider leakage",
+        "## Reconciliation decisions",
+        "## Safety confirmation",
+    ):
+        assert heading in summary
+
+
+def test_output_dir_rejects_non_audit_path(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    report = audit.build_report(repo)
+    try:
+        audit.write_outputs(report, repo_root=repo, output_dir=repo / "logs" / "other")
+    except ValueError as exc:
+        assert "output_dir_must_be_logs_qre_funnel_architecture_audit" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected output dir rejection")
+
+
+def test_contract_answers_include_core_questions(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    answers = report["contract_map"]["_canonical_answers"]
+    assert "Hypothesis" in answers
+    assert "CandidateSpec" in answers
+    assert "StrategySpec_or_StrategyIR" in answers
+    assert "EvidencePack_or_EvidenceLedger" in answers
+
+
+def test_operator_summary_bluntly_reports_parallel_funnels(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    summary = audit.render_operator_summary(report)
+    assert "multiple partial funnels exist" in summary.lower()

--- a/tools/qre_funnel_architecture_audit.py
+++ b/tools/qre_funnel_architecture_audit.py
@@ -119,7 +119,16 @@ def _rel(path: Path, root: Path) -> str:
 
 
 def _iter_text_files(root: Path) -> list[Path]:
-    excluded = {".git", ".venv", "__pycache__", ".pytest_cache", "node_modules"}
+    excluded = {
+        ".git",
+        ".venv",
+        "__pycache__",
+        ".pytest_cache",
+        "node_modules",
+        "logs",
+        "data",
+        "generated_research",
+    }
     files: list[Path] = []
     for path in root.rglob("*"):
         if any(part in excluded for part in path.parts):

--- a/tools/qre_funnel_architecture_audit.py
+++ b/tools/qre_funnel_architecture_audit.py
@@ -561,6 +561,19 @@ def build_dependency_graph(scan: dict[str, Any], funnels: list[dict[str, Any]], 
             edge("doc:" + doc, fid, "documents", "observability" if "digest" in funnel["funnel_id"] else "unknown", [doc])
         for test in funnel["tests"]:
             edge("test:" + test, fid, "tests", "test", [test])
+    for left_index, left in enumerate(funnels):
+        for right in funnels[left_index + 1 :]:
+            if "observability" in {left["canonicality"], right["canonicality"]}:
+                continue
+            overlap = sorted(set(left["canonical_objects"]) & set(right["canonical_objects"]))
+            if overlap:
+                edge(
+                    "funnel:" + left["funnel_id"],
+                    "funnel:" + right["funnel_id"],
+                    "duplicates_semantics_with",
+                    "duplicate",
+                    overlap,
+                )
     for record in scan["files"]:
         if not record["module"]:
             continue

--- a/tools/qre_funnel_architecture_audit.py
+++ b/tools/qre_funnel_architecture_audit.py
@@ -1,0 +1,835 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import contextlib
+import json
+import os
+import re
+import tempfile
+from collections import Counter, defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+REPORT_KIND: Final[str] = "qre_funnel_architecture_audit"
+SCHEMA_VERSION: Final[int] = 1
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_funnel_architecture_audit")
+SAFETY: Final[dict[str, bool]] = {
+    "audit_only": True,
+    "runtime_behavior_changed": False,
+    "created_candidates": False,
+    "created_strategies": False,
+    "created_presets": False,
+    "created_campaigns": False,
+    "ran_screening": False,
+    "trading_authority": False,
+    "validation_authority": False,
+    "paper_authority": False,
+    "shadow_authority": False,
+    "live_authority": False,
+}
+KEYWORDS: Final[tuple[str, ...]] = (
+    "hypothesis",
+    "candidate",
+    "strategy",
+    "preset",
+    "campaign",
+    "screening",
+    "evidence",
+    "ledger",
+    "feedback",
+    "lesson",
+    "memory",
+    "digest",
+    "registry",
+    "matrix",
+    "source",
+    "snapshot",
+    "dataset",
+    "provider",
+)
+PROVIDER_TERMS: Final[tuple[str, ...]] = (
+    "tiingo",
+    "yfinance",
+    "alpaca",
+    "binance",
+    "kraken",
+    "coinbase",
+    "crypto",
+    "equities",
+    "bars.csv",
+    "source_id",
+    "source_snapshot_id",
+    "data/imports",
+    "provider",
+    "dataset",
+)
+CANONICAL_OBJECTS: Final[tuple[str, ...]] = (
+    "DataProvider",
+    "SourceManifest",
+    "SourceSnapshot",
+    "DatasetFingerprint",
+    "ObservationSnapshot",
+    "Hypothesis",
+    "HypothesisSeed",
+    "ResearchInputContract",
+    "CandidateSpec",
+    "StrategySpec",
+    "StrategyIR",
+    "PresetSpec",
+    "CampaignSpec",
+    "CampaignRun",
+    "ScreeningResult",
+    "EvidencePack",
+    "EvidenceLedger",
+    "Disposition",
+    "FeedbackRecord",
+    "LessonMemory",
+    "ResearchMemory",
+    "DailyDigestInput",
+    "OperatorSummary",
+    "RegistryEntry",
+    "StrategyMatrixRow",
+)
+TEXT_SUFFIXES: Final[set[str]] = {".py", ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".csv"}
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _stable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _stable(value[key]) for key in sorted(value)}
+    if isinstance(value, list | tuple):
+        return [_stable(item) for item in value]
+    return value
+
+
+def _json(value: Any) -> str:
+    return json.dumps(_stable(value), indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _iter_text_files(root: Path) -> list[Path]:
+    excluded = {".git", ".venv", "__pycache__", ".pytest_cache", "node_modules"}
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if any(part in excluded for part in path.parts):
+            continue
+        if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES:
+            files.append(path)
+    return sorted(files)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8-sig")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def _module_name(path: Path, root: Path) -> str | None:
+    if path.suffix != ".py":
+        return None
+    rel = path.resolve().relative_to(root.resolve()).with_suffix("")
+    parts = list(rel.parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _imports(path: Path, root: Path) -> list[str]:
+    try:
+        tree = ast.parse(_read(path))
+    except SyntaxError:
+        return []
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.append(node.module)
+    local = []
+    for name in names:
+        if name.startswith(("research", "agent", "packages", "apps", "tools")) or name == "registry":
+            local.append(name)
+    return sorted(set(local))
+
+
+def _artifact_literals(text: str) -> list[str]:
+    patterns = (
+        r"logs/[A-Za-z0-9_\-/\.]+",
+        r"research/[A-Za-z0-9_\-/\.]+",
+        r"generated_research/[A-Za-z0-9_\-/\.]+",
+        r"data/imports/[A-Za-z0-9_\-/\.]+",
+    )
+    values: set[str] = set()
+    for pattern in patterns:
+        values.update(match.group(0).rstrip("'\")`,") for match in re.finditer(pattern, text))
+    return sorted(values)
+
+
+def scan_repo(root: Path) -> dict[str, Any]:
+    files = _iter_text_files(root)
+    records: list[dict[str, Any]] = []
+    module_index: dict[str, str] = {}
+    for path in files:
+        rel = _rel(path, root)
+        text = _read(path)
+        module = _module_name(path, root)
+        if module:
+            module_index[module] = rel
+        records.append(
+            {
+                "path": rel,
+                "suffix": path.suffix.lower(),
+                "module": module,
+                "text": text,
+                "imports": _imports(path, root) if path.suffix == ".py" else [],
+                "artifacts": _artifact_literals(text),
+                "keywords": [term for term in KEYWORDS if term in rel.lower() or term in text.lower()],
+            }
+        )
+    return {"files": records, "module_index": module_index}
+
+
+def _matching(scan: dict[str, Any], *needles: str) -> list[str]:
+    out = []
+    for record in scan["files"]:
+        haystack = (record["path"] + "\n" + record["text"]).lower()
+        if all(needle.lower() in haystack for needle in needles):
+            out.append(record["path"])
+    return sorted(set(out))
+
+
+def build_funnel_inventory(scan: dict[str, Any]) -> list[dict[str, Any]]:
+    def exists(path: str) -> bool:
+        return any(record["path"] == path for record in scan["files"])
+
+    funnels: list[dict[str, Any]] = []
+    tiingo_modules = [
+        path
+        for path in (
+            "research/qre_tiingo_hypothesis_generator_e2e.py",
+            "research/qre_tiingo_hypothesis_lifecycle.py",
+            "research/qre_tiingo_candidate_research_loop.py",
+        )
+        if exists(path)
+    ]
+    if tiingo_modules:
+        funnels.append(
+            _funnel(
+                funnel_id="tiingo_hypothesis_candidate_research_mini_loop",
+                name="Tiingo hypothesis/candidate research mini-loop",
+                description="Provider-specific research-only loop from Tiingo evidence through lifecycle, candidate specs, screening, evidence ledger, feedback, and next-run feedback consumption.",
+                modules=tiingo_modules,
+                tests=_matching(scan, "test_qre_tiingo"),
+                docs=_matching(scan, "tiingo_candidate_research_loop"),
+                input_artifacts=[
+                    "logs/qre_tiingo_hypothesis_generator_e2e/latest.json",
+                    "logs/qre_tiingo_hypothesis_lifecycle/latest.json",
+                    "data/imports/tiingo_eod_equities_free/tiingo_eod_etf_20210101_20251231/bars.csv",
+                ],
+                output_artifacts=[
+                    "logs/qre_tiingo_candidate_research_loop/latest.json",
+                    "logs/qre_tiingo_candidate_research_loop/evidence_ledger.jsonl",
+                    "logs/qre_tiingo_candidate_research_loop/feedback_records.jsonl",
+                ],
+                canonical_objects=["HypothesisSeed", "ResearchInputContract", "CandidateSpec", "ScreeningResult", "EvidenceLedger", "FeedbackRecord"],
+                provider_specificity="provider_specific",
+                canonicality="provider_adapter",
+                loop_claim="mini_loop",
+                runtime_authority={"creates_candidates": True, "runs_screening": True},
+                upstream_dependencies=["Tiingo source snapshot", "Tiingo lifecycle artifact"],
+                downstream_dependencies=["daily status digest observability"],
+                status_recommendation="KEEP_AS_PROVIDER_ADAPTER",
+                evidence=tiingo_modules,
+            )
+        )
+    if exists("research/qre_daily_status_digest.py"):
+        funnels.append(
+            _funnel(
+                funnel_id="daily_status_digest_observability",
+                name="Daily status digest / observability funnel",
+                description="Read-only digest aggregator over research sidecars and governance artifacts.",
+                modules=["research/qre_daily_status_digest.py"],
+                tests=_matching(scan, "test_qre_daily_status_digest"),
+                docs=_matching(scan, "daily status digest"),
+                input_artifacts=["logs/**/latest.json"],
+                output_artifacts=["logs/qre_daily_status_digest/latest.json", "logs/qre_daily_status_digest/operator_summary.md"],
+                canonical_objects=["DailyDigestInput", "OperatorSummary"],
+                provider_specificity="mixed",
+                canonicality="observability_only",
+                loop_claim="observability_only",
+                runtime_authority={},
+                upstream_dependencies=["research sidecars"],
+                downstream_dependencies=["operator"],
+                status_recommendation="OBSERVABILITY_ONLY",
+                evidence=["research/qre_daily_status_digest.py"],
+            )
+        )
+    if exists("research/run_research.py") or exists("registry.py"):
+        funnels.append(
+            _funnel(
+                funnel_id="run_research_registry_matrix",
+                name="run_research / registry / strategy_matrix funnel",
+                description="Legacy or canonical backtest output funnel around registry, strategy execution, research_latest, and strategy_matrix.",
+                modules=[path for path in ("research/run_research.py", "registry.py", "agent/backtesting/strategies.py") if exists(path)],
+                tests=_matching(scan, "run_research"),
+                docs=_matching(scan, "strategy_matrix"),
+                input_artifacts=["registry.py", "agent/backtesting/strategies.py"],
+                output_artifacts=["research/research_latest.json", "research/strategy_matrix.csv"],
+                canonical_objects=["RegistryEntry", "StrategyMatrixRow"],
+                provider_specificity="mixed",
+                canonicality="unknown",
+                loop_claim="partial_loop",
+                runtime_authority={"creates_strategies": False},
+                upstream_dependencies=["strategy registry"],
+                downstream_dependencies=["research reports"],
+                status_recommendation="UNKNOWN_REQUIRES_OPERATOR_DECISION",
+                evidence=["research/research_latest.json", "research/strategy_matrix.csv"],
+            )
+        )
+    alpha_modules = [record["path"] for record in scan["files"] if "alpha" in record["path"].lower() or "strategy_ir" in record["text"].lower()]
+    campaign_modules = [record["path"] for record in scan["files"] if "campaign" in record["path"].lower() and record["suffix"] == ".py"]
+    lesson_modules = [record["path"] for record in scan["files"] if any(term in record["path"].lower() for term in ("lesson", "memory", "disposition")) and record["suffix"] == ".py"]
+    if alpha_modules or campaign_modules or lesson_modules:
+        funnels.append(
+            _funnel(
+                funnel_id="alpha_discovery_strategy_ir_campaign_lesson",
+                name="Alpha discovery / Strategy IR / campaign / lesson funnel",
+                description="Suspected broader discovery funnel spanning alpha discovery, strategy IR semantics, campaign planning, dispositions, lessons, and memory.",
+                modules=sorted(set(alpha_modules + campaign_modules + lesson_modules))[:80],
+                tests=_matching(scan, "campaign") + _matching(scan, "lesson"),
+                docs=_matching(scan, "campaign") + _matching(scan, "memory"),
+                input_artifacts=["generated_research/**", "logs/**"],
+                output_artifacts=["generated_research/**", "logs/**"],
+                canonical_objects=["StrategyIR", "CampaignSpec", "EvidencePack", "Disposition", "LessonMemory", "ResearchMemory"],
+                provider_specificity="mixed",
+                canonicality="unknown",
+                loop_claim="partial_loop",
+                runtime_authority={"creates_campaigns": True},
+                upstream_dependencies=["source authority", "candidate or strategy specs"],
+                downstream_dependencies=["memory/lesson stores"],
+                status_recommendation="BRIDGE_TO_CANONICAL",
+                evidence=sorted(set(alpha_modules + campaign_modules + lesson_modules))[:20],
+            )
+        )
+    smoke = [record["path"] for record in scan["files"] if "smoke" in record["path"].lower() or "fixture" in record["path"].lower()]
+    if smoke:
+        funnels.append(
+            _funnel(
+                funnel_id="test_smoke_fixture_funnels",
+                name="Legacy or smoke/test-only funnel patterns",
+                description="Test fixtures and smoke paths that can mimic funnel semantics without owning production contracts.",
+                modules=[],
+                tests=smoke[:80],
+                docs=[],
+                input_artifacts=[],
+                output_artifacts=[],
+                canonical_objects=[],
+                provider_specificity="unknown",
+                canonicality="test_fixture_only",
+                loop_claim="unknown",
+                runtime_authority={},
+                upstream_dependencies=[],
+                downstream_dependencies=[],
+                status_recommendation="TEST_FIXTURE_ONLY",
+                evidence=smoke[:20],
+            )
+        )
+    return funnels
+
+
+def _funnel(**kwargs: Any) -> dict[str, Any]:
+    authority = {
+        "creates_candidates": False,
+        "creates_strategies": False,
+        "creates_presets": False,
+        "creates_campaigns": False,
+        "runs_screening": False,
+        "runs_validation": False,
+        "trading_authority": False,
+    }
+    authority.update(kwargs.pop("runtime_authority", {}))
+    return {"entrypoints": kwargs.get("modules", []), "runtime_authority": authority, **kwargs}
+
+
+def build_contract_map(scan: dict[str, Any], funnels: list[dict[str, Any]]) -> dict[str, Any]:
+    producers: dict[str, list[str]] = defaultdict(list)
+    consumers: dict[str, list[str]] = defaultdict(list)
+    artifact_paths: dict[str, set[str]] = defaultdict(set)
+    for record in scan["files"]:
+        text = record["text"].lower()
+        path = record["path"]
+        for obj in CANONICAL_OBJECTS:
+            token = obj.lower()
+            snake = re.sub(r"(?<!^)(?=[A-Z])", "_", obj).lower()
+            if token in text or snake in text or snake in path.lower():
+                if any(word in text for word in ("write", "emit", "produce", "return", "build_", "materialize")):
+                    producers[obj].append(path)
+                if any(word in text for word in ("read", "consume", "input", "load", "parse")):
+                    consumers[obj].append(path)
+                for artifact in record["artifacts"]:
+                    artifact_paths[obj].add(artifact)
+    recommended_owner = {
+        "CandidateSpec": "research/qre_tiingo_candidate_research_loop.py",
+        "HypothesisSeed": "research/qre_tiingo_hypothesis_lifecycle.py",
+        "EvidenceLedger": "research/qre_tiingo_candidate_research_loop.py",
+        "FeedbackRecord": "research/qre_tiingo_candidate_research_loop.py",
+        "DailyDigestInput": "research/qre_daily_status_digest.py",
+        "OperatorSummary": "research/qre_daily_status_digest.py",
+        "RegistryEntry": "registry.py",
+        "StrategyMatrixRow": "research/strategy_matrix.csv",
+    }
+    contract_map = {}
+    for obj in CANONICAL_OBJECTS:
+        prod = sorted(set(producers[obj]))
+        cons = sorted(set(consumers[obj]))
+        owner = recommended_owner.get(obj)
+        status = "present" if prod or cons or owner else "missing"
+        if obj in {"StrategySpec", "StrategyIR", "PresetSpec", "CampaignSpec", "EvidencePack", "LessonMemory", "ResearchMemory"} and len(prod) > 1:
+            status = "ambiguous"
+        provider_findings = [
+            path for path in sorted(set(prod + cons)) if any(term in path.lower() for term in ("tiingo", "yfinance", "binance", "crypto"))
+        ]
+        duplicate = []
+        if obj in {"Hypothesis", "CandidateSpec", "EvidenceLedger", "FeedbackRecord", "CampaignSpec"} and len(prod) > 1:
+            duplicate.append("multiple producer modules mention or produce equivalent semantics")
+        action = "KEEP"
+        if status == "missing":
+            action = "DEFINE_CANONICAL_SCHEMA"
+        elif status == "ambiguous" or duplicate:
+            action = "OPERATOR_DECISION_REQUIRED"
+        elif provider_findings and obj not in {"SourceSnapshot", "DatasetFingerprint", "HypothesisSeed"}:
+            action = "GENERALIZE"
+        contract_map[obj] = {
+            "object_name": obj,
+            "status": status,
+            "canonical_owner_module": owner or ("ambiguous" if prod else "missing"),
+            "producer_modules": prod[:50],
+            "consumer_modules": cons[:50],
+            "artifact_paths": sorted(artifact_paths[obj])[:50],
+            "provider_agnostic_expected": obj not in {"DataProvider", "SourceManifest", "SourceSnapshot", "DatasetFingerprint"},
+            "provider_specific_current": bool(provider_findings),
+            "hardcoded_provider_findings": provider_findings[:50],
+            "duplicate_names_or_semantics": duplicate,
+            "recommended_action": action,
+        }
+    contract_map["_canonical_answers"] = {
+        "Hypothesis": contract_map["Hypothesis"]["canonical_owner_module"],
+        "CandidateSpec": contract_map["CandidateSpec"]["canonical_owner_module"],
+        "StrategySpec_or_StrategyIR": {
+            "StrategySpec": contract_map["StrategySpec"]["canonical_owner_module"],
+            "StrategyIR": contract_map["StrategyIR"]["canonical_owner_module"],
+        },
+        "PresetSpec": contract_map["PresetSpec"]["canonical_owner_module"],
+        "CampaignSpec": contract_map["CampaignSpec"]["canonical_owner_module"],
+        "EvidencePack_or_EvidenceLedger": {
+            "EvidencePack": contract_map["EvidencePack"]["canonical_owner_module"],
+            "EvidenceLedger": contract_map["EvidenceLedger"]["canonical_owner_module"],
+        },
+        "FeedbackRecord_or_LessonMemory": {
+            "FeedbackRecord": contract_map["FeedbackRecord"]["canonical_owner_module"],
+            "LessonMemory": contract_map["LessonMemory"]["canonical_owner_module"],
+        },
+    }
+    return contract_map
+
+
+def classify_provider_reference(path: str, line: str) -> str:
+    lowered = (path + " " + line).lower()
+    if "test" in lowered or "fixture" in lowered:
+        return "allowed_test_fixture_reference"
+    if path.endswith(".md"):
+        return "allowed_doc_example_reference"
+    if any(term in lowered for term in ("source_manifest", "source_resolution", "source snapshot", "source_snapshot", "datasetfingerprint", "data_profile")):
+        return "allowed_source_manifest_reference" if "manifest" in lowered else "allowed_provenance_reference"
+    if any(term in lowered for term in ("adapter", "ingest", "imports", "provider", "tiingo_hypothesis_generator", "tiingo_hypothesis_lifecycle")):
+        return "allowed_adapter_reference"
+    if any(term in lowered for term in ("preset", "campaign admission", "promotion", "readiness", "registry")):
+        return "forbidden_provider_coupling"
+    if any(term in lowered for term in ("candidate", "strategy", "campaign", "evidence", "feedback")):
+        return "suspicious_layer_leak"
+    return "allowed_provenance_reference"
+
+
+def build_provider_leakage_report(scan: dict[str, Any]) -> dict[str, Any]:
+    findings = []
+    counts: Counter[str] = Counter()
+    for record in scan["files"]:
+        for lineno, line in enumerate(record["text"].splitlines(), start=1):
+            if not any(term in line.lower() for term in PROVIDER_TERMS):
+                continue
+            classification = classify_provider_reference(record["path"], line)
+            counts[classification] += 1
+            findings.append(
+                {
+                    "file": record["path"],
+                    "line": lineno,
+                    "term": next(term for term in PROVIDER_TERMS if term in line.lower()),
+                    "classification": classification,
+                    "excerpt": line.strip()[:240],
+                }
+            )
+    summary = {key: counts[key] for key in (
+        "allowed_adapter_reference",
+        "allowed_source_manifest_reference",
+        "allowed_provenance_reference",
+        "allowed_test_fixture_reference",
+        "allowed_doc_example_reference",
+        "suspicious_layer_leak",
+        "forbidden_provider_coupling",
+    )}
+    return {"provider_leakage_findings": findings[:1000], "summary": summary}
+
+
+def build_hardcoded_coupling_report(scan: dict[str, Any]) -> dict[str, Any]:
+    findings = []
+    idx = 0
+    for record in scan["files"]:
+        if record["suffix"] != ".py":
+            continue
+        layer = "generic"
+        if "tiingo" in record["path"].lower():
+            layer = "provider_adapter"
+        if "daily_status_digest" in record["path"]:
+            layer = "observability"
+        for lineno, line in enumerate(record["text"].splitlines(), start=1):
+            lowered = line.lower()
+            if "logs/" in lowered or "data/imports" in lowered:
+                idx += 1
+                findings.append(
+                    {
+                        "finding_id": f"coupling_{idx:04d}",
+                        "severity": "info" if layer in {"provider_adapter", "observability"} else "warning",
+                        "file": record["path"],
+                        "line": lineno,
+                        "pattern": "hardcoded_artifact_path",
+                        "layer": layer,
+                        "why_it_matters": "Hardcoded artifact paths can couple layers directly unless documented as sidecar or adapter contracts.",
+                        "recommended_fix": "Route through a canonical contract resolver or mark as sidecar/observability-only.",
+                    }
+                )
+            if "from research.qre_tiingo" in lowered and "tiingo" not in record["path"].lower():
+                idx += 1
+                findings.append(
+                    {
+                        "finding_id": f"coupling_{idx:04d}",
+                        "severity": "warning",
+                        "file": record["path"],
+                        "line": lineno,
+                        "pattern": "generic_imports_provider_specific_module",
+                        "layer": layer,
+                        "why_it_matters": "Provider-specific implementation can leak into provider-agnostic logic.",
+                        "recommended_fix": "Depend on a provider-agnostic interface or artifact contract.",
+                    }
+                )
+    return {"hardcoded_coupling_findings": findings[:1000]}
+
+
+def build_dependency_graph(scan: dict[str, Any], funnels: list[dict[str, Any]], contract_map: dict[str, Any], provider_report: dict[str, Any]) -> dict[str, Any]:
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, Any]] = []
+
+    def node(node_id: str, kind: str) -> None:
+        nodes[node_id] = {"id": node_id, "node_type": kind}
+
+    def edge(source: str, target: str, edge_type: str, classification: str, evidence: list[str]) -> None:
+        node(source, source.split(":", 1)[0])
+        node(target, target.split(":", 1)[0])
+        edges.append({"source": source, "target": target, "edge_type": edge_type, "classification": classification, "evidence": evidence})
+
+    for funnel in funnels:
+        fid = "funnel:" + funnel["funnel_id"]
+        node(fid, "funnel")
+        for module in funnel["modules"]:
+            edge("module:" + module, fid, "claims_loop", funnel["canonicality"], [module])
+        for artifact in funnel["input_artifacts"]:
+            edge("artifact:" + artifact, fid, "consumes", "adapter" if "tiingo" in artifact else "unknown", [artifact])
+        for artifact in funnel["output_artifacts"]:
+            edge(fid, "artifact:" + artifact, "produces", "sidecar" if artifact.startswith("logs/") else "canonical", [artifact])
+        for doc in funnel["docs"]:
+            edge("doc:" + doc, fid, "documents", "observability" if "digest" in funnel["funnel_id"] else "unknown", [doc])
+        for test in funnel["tests"]:
+            edge("test:" + test, fid, "tests", "test", [test])
+    for record in scan["files"]:
+        if not record["module"]:
+            continue
+        for imported in record["imports"]:
+            classification = "adapter" if "tiingo" in imported else "unknown"
+            edge("module:" + record["path"], "module:" + imported.replace(".", "/") + ".py", "imports", classification, [record["path"]])
+        for artifact in record["artifacts"]:
+            edge("module:" + record["path"], "artifact:" + artifact, "consumes", "observability" if "digest" in record["path"] else "unknown", [record["path"]])
+    for obj, payload in contract_map.items():
+        if obj.startswith("_"):
+            continue
+        node("canonical_object:" + obj, "canonical_object")
+        for producer in payload["producer_modules"][:20]:
+            edge("module:" + producer, "canonical_object:" + obj, "produces", "canonical" if payload["recommended_action"] == "KEEP" else "unknown", [producer])
+        for consumer in payload["consumer_modules"][:20]:
+            edge("canonical_object:" + obj, "module:" + consumer, "consumes", "canonical" if payload["recommended_action"] == "KEEP" else "unknown", [consumer])
+    for finding in provider_report["provider_leakage_findings"][:200]:
+        if finding["classification"] in {"suspicious_layer_leak", "forbidden_provider_coupling"}:
+            edge("provider:" + finding["term"], "module:" + finding["file"], "leaks_provider_into", "forbidden" if finding["classification"] == "forbidden_provider_coupling" else "suspicious", [f"{finding['file']}:{finding['line']}"])
+    summary = {
+        "nodes": len(nodes),
+        "edges": len(edges),
+        "suspicious_edges": sum(1 for item in edges if item["classification"] == "suspicious"),
+        "forbidden_edges": sum(1 for item in edges if item["classification"] == "forbidden"),
+        "duplicate_edges": sum(1 for item in edges if item["classification"] == "duplicate"),
+        "unknown_edges": sum(1 for item in edges if item["classification"] == "unknown"),
+    }
+    return {"nodes": sorted(nodes.values(), key=lambda item: item["id"]), "edges": edges, "summary": summary}
+
+
+def build_reconciliation_plan(funnels: list[dict[str, Any]], contract_map: dict[str, Any]) -> list[dict[str, Any]]:
+    plan = []
+    for funnel in funnels:
+        decision = funnel["status_recommendation"]
+        future = {
+            "KEEP_AS_PROVIDER_ADAPTER": "Bridge provider-specific artifacts to provider-agnostic canonical contracts.",
+            "OBSERVABILITY_ONLY": "Keep read-only; do not let digest become a producer.",
+            "BRIDGE_TO_CANONICAL": "Map objects to settled canonical vocabulary before further feature work.",
+            "UNKNOWN_REQUIRES_OPERATOR_DECISION": "Settle ownership before treating this path as canonical.",
+            "TEST_FIXTURE_ONLY": "Quarantine as test-only and avoid architectural claims.",
+        }.get(decision, "Operator decision required.")
+        plan.append(
+            {
+                "funnel": funnel["name"],
+                "current_status": funnel["loop_claim"],
+                "canonicality": funnel["canonicality"],
+                "provider_specificity": funnel["provider_specificity"],
+                "decision": decision,
+                "required_future_pr": future,
+            }
+        )
+    ambiguous = [name for name, payload in contract_map.items() if isinstance(payload, dict) and payload.get("recommended_action") == "OPERATOR_DECISION_REQUIRED"]
+    if ambiguous:
+        plan.append(
+            {
+                "funnel": "canonical contract settlement",
+                "current_status": "ambiguous_contract_ownership",
+                "canonicality": "unknown",
+                "provider_specificity": "mixed",
+                "decision": "UNKNOWN_REQUIRES_OPERATOR_DECISION",
+                "required_future_pr": "Settle canonical ownership for: " + ", ".join(ambiguous[:12]),
+            }
+        )
+    return plan
+
+
+def build_visual_maps() -> dict[str, str]:
+    return {
+        "c4_context": "docs/architecture/qre_funnel_visual_maps.md#diagram-1-c4-context-qre-research-system-boundary",
+        "current_funnels": "docs/architecture/qre_funnel_visual_maps.md#diagram-2-c4-containercomponent-current-detected-funnels",
+        "target_data_flow": "docs/architecture/qre_funnel_visual_maps.md#diagram-3-target-canonical-data-flow-architecture",
+        "integration_graph": "docs/architecture/qre_funnel_visual_maps.md#diagram-4-integrationdependency-graph-producerconsumer-artifact-map",
+        "sequence": "docs/architecture/qre_funnel_visual_maps.md#diagram-5-sequence-intended-full-canonical-loop",
+        "provider_boundary": "docs/architecture/qre_funnel_visual_maps.md#diagram-6-provider-leakage-boundary",
+    }
+
+
+def build_report(repo_root: Path = Path(".")) -> dict[str, Any]:
+    root = repo_root.resolve()
+    try:
+        scan = scan_repo(root)
+    except OSError:
+        return {
+            "report_kind": REPORT_KIND,
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": _utcnow(),
+            "repo_root": str(root),
+            "summary": {
+                "audit_verdict": "blocked_unable_to_scan_repo",
+                "funnels_detected": 0,
+                "canonical_funnels": 0,
+                "provider_specific_funnels": 0,
+                "observability_funnels": 0,
+                "duplicate_semantics_detected": False,
+                "provider_leakage_findings": 0,
+                "hardcoded_coupling_findings": 0,
+                "contract_drift_findings": 0,
+                "unknown_canonical_ownership_findings": 0,
+                "recommended_next_action": "repair_audit_scan_permissions",
+            },
+            "funnel_inventory": [],
+            "contract_map": {},
+            "dependency_graph_summary": {},
+            "provider_leakage_summary": {},
+            "hardcoded_coupling_summary": {},
+            "canonicality_assessment": {},
+            "reconciliation_plan": [],
+            "visual_maps": build_visual_maps(),
+            "safety": dict(SAFETY),
+        }
+    funnels = build_funnel_inventory(scan)
+    contract_map = build_contract_map(scan, funnels)
+    provider_report = build_provider_leakage_report(scan)
+    coupling_report = build_hardcoded_coupling_report(scan)
+    graph = build_dependency_graph(scan, funnels, contract_map, provider_report)
+    reconciliation = build_reconciliation_plan(funnels, contract_map)
+    unknown_contracts = [
+        name
+        for name, payload in contract_map.items()
+        if isinstance(payload, dict) and payload.get("recommended_action") in {"OPERATOR_DECISION_REQUIRED", "DEFINE_CANONICAL_SCHEMA"}
+    ]
+    duplicate_semantics = len(funnels) > 1 or any(
+        isinstance(payload, dict) and payload.get("duplicate_names_or_semantics")
+        for payload in contract_map.values()
+    )
+    summary = {
+        "audit_verdict": "pass_inventory_complete_with_reconciliation_needed",
+        "funnels_detected": len(funnels),
+        "canonical_funnels": sum(1 for funnel in funnels if funnel["canonicality"] == "canonical_candidate"),
+        "provider_specific_funnels": sum(1 for funnel in funnels if funnel["provider_specificity"] == "provider_specific"),
+        "observability_funnels": sum(1 for funnel in funnels if funnel["canonicality"] == "observability_only"),
+        "duplicate_semantics_detected": bool(duplicate_semantics),
+        "provider_leakage_findings": len(provider_report["provider_leakage_findings"]),
+        "hardcoded_coupling_findings": len(coupling_report["hardcoded_coupling_findings"]),
+        "contract_drift_findings": sum(1 for payload in contract_map.values() if isinstance(payload, dict) and payload.get("duplicate_names_or_semantics")),
+        "unknown_canonical_ownership_findings": len(unknown_contracts),
+        "recommended_next_action": "settle_canonical_contract_vocabulary_then_bridge_provider_specific_funnels",
+    }
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _utcnow(),
+        "repo_root": str(root),
+        "summary": summary,
+        "funnel_inventory": funnels,
+        "contract_map": contract_map,
+        "dependency_graph_summary": graph["summary"],
+        "provider_leakage_summary": provider_report["summary"],
+        "hardcoded_coupling_summary": {"findings": len(coupling_report["hardcoded_coupling_findings"])},
+        "canonicality_assessment": {
+            "full_provider_agnostic_loop_exists": False,
+            "assessment": "Multiple partial funnels exist. The Tiingo path is a provider-specific mini-loop; daily digest is observability-only; canonical ownership remains ambiguous for several provider-agnostic contracts.",
+            "unknown_contracts": unknown_contracts,
+        },
+        "reconciliation_plan": reconciliation,
+        "visual_maps": build_visual_maps(),
+        "provider_leakage_report": provider_report,
+        "hardcoded_coupling_report": coupling_report,
+        "dependency_graph": graph,
+        "safety": dict(SAFETY),
+    }
+
+
+def render_operator_summary(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# QRE Funnel Architecture Audit",
+        "",
+        "## Verdict",
+        f"- Audit verdict: {summary['audit_verdict']}",
+        f"- Recommended next action: {summary['recommended_next_action']}",
+        "- Blunt assessment: multiple partial funnels exist; the full provider-agnostic canonical loop is not proven closed.",
+        "",
+        "## Funnels detected",
+    ]
+    for funnel in report.get("funnel_inventory", []):
+        lines.append(f"- {funnel['name']}: {funnel['canonicality']} / {funnel['status_recommendation']}")
+    lines.extend(
+        [
+            "",
+            "## Canonical ownership",
+            f"- Unknown or unsettled canonical ownership findings: {summary['unknown_canonical_ownership_findings']}",
+            f"- Contract drift findings: {summary['contract_drift_findings']}",
+            "",
+            "## Provider leakage",
+            f"- Provider leakage findings: {summary['provider_leakage_findings']}",
+            f"- Suspicious leaks: {report['provider_leakage_summary'].get('suspicious_layer_leak', 0)}",
+            f"- Forbidden coupling: {report['provider_leakage_summary'].get('forbidden_provider_coupling', 0)}",
+            "",
+            "## Hardcoded coupling",
+            f"- Hardcoded coupling findings: {summary['hardcoded_coupling_findings']}",
+            "",
+            "## Duplicate or parallel semantics",
+            f"- Duplicate or parallel semantics detected: {str(summary['duplicate_semantics_detected']).lower()}",
+            "",
+            "## Visual maps",
+        ]
+    )
+    for name, target in report.get("visual_maps", {}).items():
+        lines.append(f"- {name}: {target}")
+    lines.extend(["", "## Reconciliation decisions"])
+    for item in report.get("reconciliation_plan", []):
+        lines.append(f"- {item['funnel']}: {item['decision']} -> {item['required_future_pr']}")
+    lines.extend(
+        [
+            "",
+            "## Recommended next PR",
+            "- PR A: settle canonical contract vocabulary before broadening any funnel.",
+            "",
+            "## Safety confirmation",
+            "- Audit only: true",
+            "- Runtime behavior changed: false",
+            "- No candidates, strategies, presets, campaigns, screening, validation, paper, shadow, live, or trading authority created.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with contextlib.suppress(OSError):  # type: ignore[name-defined]
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(report: dict[str, Any], *, repo_root: Path = Path("."), output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    root = repo_root.resolve()
+    resolved = output_dir if output_dir.is_absolute() else root / output_dir
+    resolved = resolved.resolve()
+    allowed = (root / DEFAULT_OUTPUT_DIR).resolve()
+    if resolved != allowed:
+        raise ValueError("output_dir_must_be_logs_qre_funnel_architecture_audit")
+    outputs = {
+        "latest": resolved / "latest.json",
+        "dependency_graph": resolved / "dependency_graph.json",
+        "provider_leakage_report": resolved / "provider_leakage_report.json",
+        "contract_map": resolved / "contract_map.json",
+        "funnel_inventory": resolved / "funnel_inventory.json",
+        "operator_summary": resolved / "operator_summary.md",
+    }
+    _atomic_write(outputs["latest"], _json(report))
+    _atomic_write(outputs["dependency_graph"], _json(report["dependency_graph"]))
+    _atomic_write(outputs["provider_leakage_report"], _json(report["provider_leakage_report"]))
+    _atomic_write(outputs["contract_map"], _json(report["contract_map"]))
+    _atomic_write(outputs["funnel_inventory"], _json(report["funnel_inventory"]))
+    _atomic_write(outputs["operator_summary"], render_operator_summary(report))
+    return {key: _rel(path, root) for key, path in outputs.items()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Statically audit QRE funnel architecture.")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    root = Path(args.repo_root).resolve()
+    report = build_report(root)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report, repo_root=root, output_dir=Path(args.output_dir))
+    print(json.dumps(_stable(report), indent=2, sort_keys=True, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary:
- adds static QRE funnel architecture audit tooling
- inventories current research funnels, entrypoints, artifacts, docs, and tests
- maps canonical research contract ownership
- scans for provider leakage and hardcoded coupling
- emits dependency graph and reconciliation plan
- adds Mermaid visual maps for current funnels and target canonical architecture
- documents keep/bridge/deprecate/operator-decision recommendations

Validation:
- python -m pytest tests/unit/test_qre_funnel_architecture_audit.py -q
- python -m pytest tests/unit/test_qre_tiingo_candidate_research_loop.py -q
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m ruff check tools/qre_funnel_architecture_audit.py tests/unit/test_qre_funnel_architecture_audit.py
- git diff --check
- manual audit --write run
- visual map heading check

Safety:
- audit_only=true
- runtime_behavior_changed=false
- no candidates created
- no strategies created
- no presets created
- no campaigns created
- no screening run
- no validation/promotion/strategy registration
- no paper/shadow/live authority
- no trading authority
- research/research_latest.json not mutated
- research/strategy_matrix.csv not mutated