### PR TITLE
research: bridge Tiingo artifacts to canonical contracts

### DIFF
--- a/docs/architecture/qre_canonical_contract_map.md
+++ b/docs/architecture/qre_canonical_contract_map.md
@@ -19,6 +19,14 @@ packages/qre_research/canonical_contracts.py
 
 This settlement defines names, required fields, owner/status/recommendation metadata, and provider-leakage boundaries. It does not bridge any existing artifact yet.
 
+PR B adds the first provider-adapter bridge:
+
+```text
+packages/qre_research/tiingo_canonical_bridge.py
+```
+
+This bridge maps Tiingo HypothesisSeed, ResearchInputContract, and CandidateSpec records into canonical Hypothesis, ResearchInputContract, and CandidateSpec payloads. Tiingo-specific identifiers stay in `provenance`; canonical semantics remain provider-agnostic.
+
 ## Canonical Object Ownership
 
 | Object | Current audit status | Current owner evidence | Recommendation |
@@ -28,10 +36,10 @@ This settlement defines names, required fields, owner/status/recommendation meta
 | SourceSnapshot | present | source snapshot provenance fields | KEEP |
 | DatasetFingerprint | inferred | source/data profile digest fields | DEFINE_CANONICAL_SCHEMA |
 | ObservationSnapshot | missing or ambiguous | no single owner proven | DEFINE_CANONICAL_SCHEMA |
-| Hypothesis | ambiguous | Tiingo generator plus older discovery modules | OPERATOR_DECISION_REQUIRED |
+| Hypothesis | bridged from Tiingo provider adapter; broader ownership still ambiguous | Tiingo bridge plus older discovery modules | BRIDGE |
 | HypothesisSeed | present | Tiingo lifecycle | BRIDGE |
-| ResearchInputContract | present | Tiingo candidate loop | BRIDGE |
-| CandidateSpec | present but provider-specific | Tiingo candidate loop | GENERALIZE |
+| ResearchInputContract | bridged from Tiingo provider adapter | Tiingo candidate loop plus canonical bridge | BRIDGE |
+| CandidateSpec | bridged from Tiingo provider adapter; canonical semantic owner still settling | Tiingo candidate loop plus canonical bridge | GENERALIZE |
 | StrategySpec | ambiguous | older strategy/preset/campaign paths | OPERATOR_DECISION_REQUIRED |
 | StrategyIR | ambiguous | alpha discovery / Strategy IR references | OPERATOR_DECISION_REQUIRED |
 | PresetSpec | ambiguous | preset modules and docs | OPERATOR_DECISION_REQUIRED |
@@ -53,7 +61,7 @@ This settlement defines names, required fields, owner/status/recommendation meta
 
 | Funnel | Current status | Canonicality | Provider specificity | Keep/Bridge/Deprecate decision | Required future PR |
 |---|---|---|---|---|---|
-| Tiingo candidate research loop | research-only mini-loop | provider adapter | provider_specific | KEEP_AS_PROVIDER_ADAPTER + BRIDGE_TO_CANONICAL | Bridge Tiingo HypothesisSeed, ResearchInputContract, CandidateSpec, EvidenceLedger, and FeedbackRecord to canonical schemas |
+| Tiingo candidate research loop | research-only mini-loop | provider adapter | provider_specific | KEEP_AS_PROVIDER_ADAPTER + BRIDGE_TO_CANONICAL | HypothesisSeed, ResearchInputContract, and CandidateSpec bridge complete; EvidenceLedger and FeedbackRecord remain for PR D |
 | Daily digest | read-only aggregation | observability_only | mixed | OBSERVABILITY_ONLY | Keep consuming sidecars; do not let digest produce research objects |
 | Alpha discovery / Strategy IR / campaign / lesson funnel | partial funnel | unknown | mixed | BRIDGE_TO_CANONICAL or UNKNOWN_REQUIRES_OPERATOR_DECISION | Map StrategyIR, CampaignSpec, EvidencePack, Disposition, LessonMemory, and ResearchMemory ownership |
 | run_research / registry / strategy_matrix | legacy or canonical backtest/report path | unknown | mixed | OPERATOR_DECISION_REQUIRED | Decide whether registry and strategy_matrix remain canonical for strategy research outputs |
@@ -62,7 +70,7 @@ This settlement defines names, required fields, owner/status/recommendation meta
 ## Recommended PR Sequence
 
 1. PR A: settle canonical contract vocabulary. Status: complete in this vocabulary settlement PR.
-2. PR B: bridge Tiingo artifacts to canonical Hypothesis/CandidateSpec.
+2. PR B: bridge Tiingo artifacts to canonical Hypothesis/CandidateSpec. Status: complete for Hypothesis, ResearchInputContract, and CandidateSpec.
 3. PR C: bridge canonical CandidateSpec to StrategySpec/PresetSpec/CampaignSpec.
 4. PR D: connect campaign evidence to FeedbackMemory/LessonMemory.
 5. PR E: make next hypothesis generation consume canonical memory.

--- a/docs/architecture/qre_canonical_contract_vocabulary.md
+++ b/docs/architecture/qre_canonical_contract_vocabulary.md
@@ -108,6 +108,33 @@ The vocabulary tests assert:
 - `research/research_latest.json` and `research/strategy_matrix.csv` are not mutated by vocabulary validation;
 - no contract grants broker, risk, order, validation, promotion, paper, shadow, live, or trading authority.
 
+## Tiingo Bridge
+
+The Tiingo provider-adapter bridge lives in:
+
+```text
+packages/qre_research/tiingo_canonical_bridge.py
+```
+
+It maps:
+
+```text
+Tiingo HypothesisSeed -> canonical Hypothesis
+Tiingo ResearchInputContract -> canonical ResearchInputContract
+Tiingo CandidateSpec -> canonical CandidateSpec
+```
+
+Bridge rules:
+
+- Tiingo identifiers and source references are retained only in `provenance`.
+- canonical Hypothesis and CandidateSpec semantics must not contain provider-specific terms;
+- canonical IDs are deterministic and do not include provider names;
+- missing required fields fail closed;
+- unsafe authority flags fail closed;
+- the bridge writes nothing and does not run screening.
+
+Tiingo EvidenceLedger and FeedbackRecord bridging is intentionally left for the evidence/memory bridge PR.
+
 ## What This PR Does Not Build
 
 This settlement does not create:

--- a/packages/qre_research/tiingo_canonical_bridge.py
+++ b/packages/qre_research/tiingo_canonical_bridge.py
@@ -1,0 +1,229 @@
+"""Bridge Tiingo research artifacts to canonical QRE contracts.
+
+The bridge is deterministic and read-only. It maps existing Tiingo mini-loop
+records into provider-agnostic canonical payloads while keeping Tiingo-specific
+identifiers inside provenance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any, Final
+
+PROVIDER_TERM: Final[str] = "tiingo"
+SCHEMA_VERSION: Final[int] = 1
+SAFETY: Final[dict[str, bool]] = {
+    "research_only": True,
+    "bridge_only": True,
+    "creates_candidates": False,
+    "creates_strategies": False,
+    "creates_presets": False,
+    "creates_campaigns": False,
+    "runs_screening": False,
+    "trading_authority": False,
+    "validation_authority": False,
+    "paper_authority": False,
+    "shadow_authority": False,
+    "live_authority": False,
+}
+
+
+class CanonicalBridgeError(ValueError):
+    """Raised when a provider artifact cannot be safely canonicalized."""
+
+
+def _stable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _stable(value[key]) for key in sorted(value)}
+    if isinstance(value, list | tuple):
+        return [_stable(item) for item in value]
+    return value
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(_stable(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _required(payload: Mapping[str, Any], fields: tuple[str, ...]) -> None:
+    missing = [field for field in fields if payload.get(field) in (None, "", [])]
+    if missing:
+        raise CanonicalBridgeError("missing_required_fields:" + ",".join(missing))
+
+
+def _assert_provider_terms_only_in_provenance(payload: Mapping[str, Any]) -> None:
+    def walk(value: Any, path: tuple[str, ...]) -> None:
+        if "provenance" in path:
+            return
+        if isinstance(value, Mapping):
+            for key, child in value.items():
+                if PROVIDER_TERM in str(key).lower():
+                    raise CanonicalBridgeError("provider_leakage:" + ".".join((*path, str(key))))
+                walk(child, (*path, str(key)))
+            return
+        if isinstance(value, list | tuple):
+            for index, child in enumerate(value):
+                walk(child, (*path, str(index)))
+            return
+        if PROVIDER_TERM in str(value).lower():
+            raise CanonicalBridgeError("provider_leakage:" + ".".join(path))
+
+    walk(payload, ())
+
+
+def canonicalize_tiingo_hypothesis_seed(seed: Mapping[str, Any]) -> dict[str, Any]:
+    """Map a Tiingo admitted seed/lifecycle row to canonical Hypothesis."""
+
+    _required(seed, ("hypothesis_seed_id", "source_hypothesis_id", "source_snapshot_id", "feature_family"))
+    digest = seed.get("source_hypothesis_digest")
+    identity_basis = {
+        "source_hypothesis_id": seed["source_hypothesis_id"],
+        "source_snapshot_id": seed["source_snapshot_id"],
+        "feature_family": seed["feature_family"],
+        "digest": digest.get("digest") if isinstance(digest, Mapping) else digest,
+    }
+    payload = {
+        "canonical_name": "Hypothesis",
+        "schema_version": SCHEMA_VERSION,
+        "hypothesis_id": "hyp_" + _digest(identity_basis),
+        "mechanism": {
+            "feature_family": str(seed["feature_family"]),
+            "statement": "Research hypothesis admitted by provider adapter lifecycle boundary.",
+        },
+        "predicted_effect": "provider_neutral_research_effect_to_screen",
+        "falsification_conditions": ["fails_screening_protocol", "does_not_beat_null_control"],
+        "provenance": {
+            "source": "qre_tiingo_hypothesis_lifecycle",
+            "provider_adapter": PROVIDER_TERM,
+            "hypothesis_seed_id": seed["hypothesis_seed_id"],
+            "source_hypothesis_id": seed["source_hypothesis_id"],
+            "source_snapshot_id": seed["source_snapshot_id"],
+            "source_hypothesis_digest": digest or {},
+        },
+        "safety": dict(SAFETY),
+    }
+    _assert_provider_terms_only_in_provenance(payload)
+    return payload
+
+
+def canonicalize_tiingo_research_input_contract(contract: Mapping[str, Any]) -> dict[str, Any]:
+    """Map a Tiingo input contract to canonical ResearchInputContract."""
+
+    _required(contract, ("contract_id", "hypothesis_seed_id", "source_hypothesis_id", "source_snapshot_id", "decision"))
+    if contract.get("decision") != "admitted":
+        raise CanonicalBridgeError("not_admitted_contract")
+    hypothesis = canonicalize_tiingo_hypothesis_seed(contract)
+    identity_basis = {
+        "hypothesis_id": hypothesis["hypothesis_id"],
+        "decision": contract["decision"],
+        "required_candidate_spec_fields": contract.get("required_candidate_spec_fields", []),
+    }
+    payload = {
+        "canonical_name": "ResearchInputContract",
+        "schema_version": SCHEMA_VERSION,
+        "contract_id": "ric_" + _digest(identity_basis),
+        "hypothesis_id": hypothesis["hypothesis_id"],
+        "decision": "admitted",
+        "required_candidate_spec_fields": list(contract.get("required_candidate_spec_fields") or []),
+        "allowed_candidate_families": list(contract.get("allowed_candidate_families") or []),
+        "forbidden_authorities": list(contract.get("forbidden_authorities") or []),
+        "provenance": {
+            "source": "qre_tiingo_candidate_research_loop",
+            "provider_adapter": PROVIDER_TERM,
+            "source_contract_id": contract["contract_id"],
+            "hypothesis_seed_id": contract["hypothesis_seed_id"],
+            "source_hypothesis_id": contract["source_hypothesis_id"],
+            "source_snapshot_id": contract["source_snapshot_id"],
+        },
+        "safety": dict(SAFETY),
+    }
+    _assert_provider_terms_only_in_provenance(payload)
+    return payload
+
+
+def canonicalize_tiingo_candidate_spec(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    """Map a Tiingo candidate spec to canonical CandidateSpec."""
+
+    _required(
+        candidate,
+        (
+            "candidate_id",
+            "parent_contract_id",
+            "parent_hypothesis_seed_id",
+            "source_hypothesis_id",
+            "source_snapshot_id",
+            "signal_definition",
+            "selection_rule",
+        ),
+    )
+    if candidate.get("trading_authority") is not False or candidate.get("research_only") is not True:
+        raise CanonicalBridgeError("unsafe_candidate_authority")
+    semantic_payload = {
+        "signal_definition": candidate["signal_definition"],
+        "selection_rule": candidate["selection_rule"],
+        "rebalance_rule": candidate.get("rebalance_rule", {}),
+        "holding_period": candidate.get("holding_period", {}),
+        "benchmark": candidate.get("benchmark", {}),
+        "variant_parameters": candidate.get("variant_parameters", {}),
+    }
+    semantic_probe = {"canonical_name": "CandidateSpec", **semantic_payload}
+    _assert_provider_terms_only_in_provenance(semantic_probe)
+    identity_basis = {
+        "parent_contract_id": candidate["parent_contract_id"],
+        "semantics": semantic_payload,
+    }
+    payload = {
+        "canonical_name": "CandidateSpec",
+        "schema_version": SCHEMA_VERSION,
+        "candidate_id": "cand_" + _digest(identity_basis),
+        "parent_contract_id": "ric_" + _digest(
+            {
+                "source_contract_id": candidate["parent_contract_id"],
+                "hypothesis_seed_id": candidate["parent_hypothesis_seed_id"],
+            }
+        ),
+        **semantic_payload,
+        "screening_protocol": candidate.get("screening_protocol", "canonical_research_screening_v1"),
+        "research_only": True,
+        "screening_only": True,
+        "not_trade_signal": True,
+        "provenance": {
+            "source": "qre_tiingo_candidate_research_loop",
+            "provider_adapter": PROVIDER_TERM,
+            "source_candidate_id": candidate["candidate_id"],
+            "source_contract_id": candidate["parent_contract_id"],
+            "hypothesis_seed_id": candidate["parent_hypothesis_seed_id"],
+            "source_hypothesis_id": candidate["source_hypothesis_id"],
+            "source_snapshot_id": candidate["source_snapshot_id"],
+            "candidate_digest": candidate.get("candidate_digest"),
+        },
+        "safety": dict(SAFETY),
+    }
+    _assert_provider_terms_only_in_provenance(payload)
+    return payload
+
+
+def canonicalize_tiingo_report(report: Mapping[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Canonicalize bridgeable Tiingo report collections without side effects."""
+
+    input_contracts = report.get("input_contracts")
+    candidate_specs = report.get("candidate_specs")
+    if not isinstance(input_contracts, list) or not isinstance(candidate_specs, list):
+        raise CanonicalBridgeError("missing_bridge_collections")
+    return {
+        "hypotheses": [canonicalize_tiingo_hypothesis_seed(row) for row in input_contracts],
+        "research_input_contracts": [canonicalize_tiingo_research_input_contract(row) for row in input_contracts],
+        "candidate_specs": [canonicalize_tiingo_candidate_spec(row) for row in candidate_specs],
+    }
+
+
+__all__ = [
+    "CanonicalBridgeError",
+    "SAFETY",
+    "canonicalize_tiingo_candidate_spec",
+    "canonicalize_tiingo_hypothesis_seed",
+    "canonicalize_tiingo_report",
+    "canonicalize_tiingo_research_input_contract",
+]

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -204,6 +204,7 @@ def test_package_migration_001_qre_research_has_only_bounded_read_only_seed() ->
         "research_memory.py",
         "retrieval_coverage.py",
         "second_preregistered_campaign.py",
+        "tiingo_canonical_bridge.py",
         "universe.py",
     ], target
 
@@ -215,6 +216,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_research/opportunity_value.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/canonical_contracts.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/research_memory.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_research/tiingo_canonical_bridge.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/retrieval_coverage.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/universe.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/README.md") == DOMAIN_QRE
@@ -239,6 +241,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_module("packages.qre_research.opportunity_value") == DOMAIN_QRE
     assert classify_module("packages.qre_research.canonical_contracts") == DOMAIN_QRE
     assert classify_module("packages.qre_research.research_memory") == DOMAIN_QRE
+    assert classify_module("packages.qre_research.tiingo_canonical_bridge") == DOMAIN_QRE
     assert classify_module("packages.qre_research.universe") == DOMAIN_QRE
     assert classify_module("packages.qre_data.cache_manifest") == DOMAIN_QRE
     assert classify_module("packages.qre_data.contracts") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -73,6 +73,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "research_memory.py",
         "retrieval_coverage.py",
         "second_preregistered_campaign.py",
+        "tiingo_canonical_bridge.py",
         "universe.py",
     ],
     "qre_data": [

--- a/tests/unit/test_qre_tiingo_canonical_bridge.py
+++ b/tests/unit/test_qre_tiingo_canonical_bridge.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from packages.qre_research import canonical_contracts
+from packages.qre_research.tiingo_canonical_bridge import (
+    CanonicalBridgeError,
+    canonicalize_tiingo_candidate_spec,
+    canonicalize_tiingo_hypothesis_seed,
+    canonicalize_tiingo_report,
+    canonicalize_tiingo_research_input_contract,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _contract() -> dict[str, object]:
+    return {
+        "contract_id": "contract_tiingo_abc",
+        "schema_version": 1,
+        "source": "qre_tiingo_hypothesis_lifecycle",
+        "hypothesis_seed_id": "seed_tiingo_cross_sectional_momentum",
+        "source_hypothesis_id": "tiingo_hyp_001",
+        "source_snapshot_id": "qdsnap_tiingo_001",
+        "feature_family": "cross_sectional_momentum",
+        "status": "admissible_for_research_candidate_formulation",
+        "decision": "admitted",
+        "source_hypothesis_digest": {"digest": "sha256:source"},
+        "required_candidate_spec_fields": ["signal_definition", "selection_rule"],
+        "allowed_candidate_families": ["cross_sectional_momentum"],
+        "forbidden_authorities": ["trading_authority"],
+        "research_only": True,
+        "screening_only": True,
+        "trading_authority": False,
+    }
+
+
+def _candidate() -> dict[str, object]:
+    return {
+        "candidate_id": "cand_tiingo_abc",
+        "candidate_schema_version": 1,
+        "parent_contract_id": "contract_tiingo_abc",
+        "parent_hypothesis_seed_id": "seed_tiingo_cross_sectional_momentum",
+        "source_hypothesis_id": "tiingo_hyp_001",
+        "source_snapshot_id": "qdsnap_tiingo_001",
+        "feature_family": "cross_sectional_momentum",
+        "candidate_family": "cross_sectional_momentum",
+        "signal_definition": {"lookback_window": 60, "return_basis": "adjusted_return"},
+        "selection_rule": {"rank": "top", "count": 3},
+        "rebalance_rule": {"every_n_trading_days": 20},
+        "holding_period": {"trading_days": 20},
+        "benchmark": {"kind": "equal_weight_universe"},
+        "variant_parameters": {},
+        "screening_protocol": "research_candidate_screening_v1",
+        "research_only": True,
+        "screening_only": True,
+        "not_trade_signal": True,
+        "trading_authority": False,
+        "candidate_digest": "sha256:candidate",
+    }
+
+
+def _assert_no_provider_terms_outside_provenance(payload: object, in_provenance: bool = False) -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            nested = in_provenance or key == "provenance"
+            if not nested:
+                assert "tiingo" not in str(key).lower()
+            _assert_no_provider_terms_outside_provenance(value, nested)
+        return
+    if isinstance(payload, list):
+        for item in payload:
+            _assert_no_provider_terms_outside_provenance(item, in_provenance)
+        return
+    if not in_provenance:
+        assert "tiingo" not in str(payload).lower()
+
+
+def test_canonicalize_tiingo_hypothesis_seed() -> None:
+    payload = canonicalize_tiingo_hypothesis_seed(_contract())
+
+    assert payload["canonical_name"] == "Hypothesis"
+    assert str(payload["hypothesis_id"]).startswith("hyp_")
+    assert payload["mechanism"]["feature_family"] == "cross_sectional_momentum"
+    assert payload["provenance"]["provider_adapter"] == "tiingo"
+    _assert_no_provider_terms_outside_provenance(payload)
+
+
+def test_canonicalize_tiingo_research_input_contract() -> None:
+    payload = canonicalize_tiingo_research_input_contract(_contract())
+
+    assert payload["canonical_name"] == "ResearchInputContract"
+    assert str(payload["contract_id"]).startswith("ric_")
+    assert payload["decision"] == "admitted"
+    assert payload["provenance"]["source_contract_id"] == "contract_tiingo_abc"
+    _assert_no_provider_terms_outside_provenance(payload)
+
+
+def test_canonicalize_tiingo_candidate_spec() -> None:
+    payload = canonicalize_tiingo_candidate_spec(_candidate())
+
+    assert payload["canonical_name"] == "CandidateSpec"
+    assert str(payload["candidate_id"]).startswith("cand_")
+    assert "tiingo" not in str(payload["candidate_id"]).lower()
+    assert payload["research_only"] is True
+    assert payload["safety"]["trading_authority"] is False
+    assert payload["provenance"]["source_candidate_id"] == "cand_tiingo_abc"
+    _assert_no_provider_terms_outside_provenance(payload)
+
+
+def test_canonical_ids_are_deterministic() -> None:
+    assert canonicalize_tiingo_hypothesis_seed(_contract()) == canonicalize_tiingo_hypothesis_seed(_contract())
+    assert canonicalize_tiingo_research_input_contract(_contract()) == canonicalize_tiingo_research_input_contract(_contract())
+    assert canonicalize_tiingo_candidate_spec(_candidate()) == canonicalize_tiingo_candidate_spec(_candidate())
+
+
+def test_missing_required_fields_fail_closed() -> None:
+    bad = _contract()
+    bad.pop("source_snapshot_id")
+
+    with pytest.raises(CanonicalBridgeError, match="missing_required_fields"):
+        canonicalize_tiingo_hypothesis_seed(bad)
+
+
+def test_forbidden_provider_leakage_fails_closed() -> None:
+    bad = _candidate()
+    bad["signal_definition"] = {"provider": "tiingo"}
+
+    with pytest.raises(CanonicalBridgeError, match="provider_leakage"):
+        canonicalize_tiingo_candidate_spec(bad)
+
+
+def test_unsafe_candidate_authority_fails_closed() -> None:
+    bad = _candidate()
+    bad["trading_authority"] = True
+
+    with pytest.raises(CanonicalBridgeError, match="unsafe_candidate_authority"):
+        canonicalize_tiingo_candidate_spec(bad)
+
+
+def test_report_bridge_is_stable_and_read_only() -> None:
+    report = {"input_contracts": [_contract()], "candidate_specs": [_candidate()]}
+
+    first = canonicalize_tiingo_report(report)
+    second = canonicalize_tiingo_report(report)
+
+    assert first == second
+    assert len(first["hypotheses"]) == 1
+    assert len(first["research_input_contracts"]) == 1
+    assert len(first["candidate_specs"]) == 1
+
+
+def test_daily_digest_remains_observability_only() -> None:
+    digest = canonical_contracts.contract_by_name("DailyDigestInput")
+    summary = canonical_contracts.contract_by_name("OperatorSummary")
+
+    assert canonical_contracts.observability_contract_is_read_only(digest)
+    assert canonical_contracts.observability_contract_is_read_only(summary)
+
+
+def test_frozen_outputs_are_untouched_by_bridge() -> None:
+    before = {path: (REPO_ROOT / path).read_bytes() for path in canonical_contracts.FROZEN_LEGACY_OUTPUTS}
+
+    canonicalize_tiingo_report({"input_contracts": [_contract()], "candidate_specs": [_candidate()]})
+
+    after = {path: (REPO_ROOT / path).read_bytes() for path in canonical_contracts.FROZEN_LEGACY_OUTPUTS}
+    assert after == before


### PR DESCRIPTION
Summary:
- adds a deterministic read-only bridge from Tiingo mini-loop artifacts to canonical QRE contracts
- maps Tiingo HypothesisSeed, ResearchInputContract, and CandidateSpec to canonical Hypothesis, ResearchInputContract, and CandidateSpec
- keeps Tiingo-specific identifiers in provenance only
- blocks missing required fields, provider leakage in canonical semantics, and unsafe authority flags
- updates contract docs and bounded package inventory tests

Validation:
- python -m pytest tests/unit/test_qre_canonical_contract_vocabulary.py -q
- python -m pytest tests/unit/test_qre_tiingo_canonical_bridge.py -q
- python -m pytest tests/unit/test_qre_tiingo_candidate_research_loop.py -q
- python -m pytest tests/unit/test_qre_funnel_architecture_audit.py -q
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py tests/architecture/test_package_migration_010_closure_decision.py -q
- python -m ruff check packages/qre_research/canonical_contracts.py packages/qre_research/tiingo_canonical_bridge.py tests/unit/test_qre_tiingo_canonical_bridge.py
- git diff --check

Safety:
- bridge-only and read-only
- no candidates created by the bridge
- no strategies, presets, or campaigns created
- no screening run
- no validation/promotion/strategy registration
- no paper/shadow/live authority
- no broker/risk/order/capital allocation changes
- daily digest remains observability-only
- research/research_latest.json not mutated
- research/strategy_matrix.csv not mutated