### PR TITLE
research: bridge canonical candidates to strategy preset campaign specs

### DIFF
--- a/docs/architecture/qre_canonical_contract_map.md
+++ b/docs/architecture/qre_canonical_contract_map.md
@@ -27,6 +27,14 @@ packages/qre_research/tiingo_canonical_bridge.py
 
 This bridge maps Tiingo HypothesisSeed, ResearchInputContract, and CandidateSpec records into canonical Hypothesis, ResearchInputContract, and CandidateSpec payloads. Tiingo-specific identifiers stay in `provenance`; canonical semantics remain provider-agnostic.
 
+PR C adds the provider-agnostic planning bridge:
+
+```text
+packages/qre_research/candidate_planning_bridge.py
+```
+
+This bridge maps canonical CandidateSpec records into StrategySpec, PresetSpec, and bounded CampaignSpec payloads. It is planning-only: no registry mutation, campaign execution, screening run, validation, promotion, paper, shadow, live, broker, risk, or order authority.
+
 ## Canonical Object Ownership
 
 | Object | Current audit status | Current owner evidence | Recommendation |
@@ -40,10 +48,10 @@ This bridge maps Tiingo HypothesisSeed, ResearchInputContract, and CandidateSpec
 | HypothesisSeed | present | Tiingo lifecycle | BRIDGE |
 | ResearchInputContract | bridged from Tiingo provider adapter | Tiingo candidate loop plus canonical bridge | BRIDGE |
 | CandidateSpec | bridged from Tiingo provider adapter; canonical semantic owner still settling | Tiingo candidate loop plus canonical bridge | GENERALIZE |
-| StrategySpec | ambiguous | older strategy/preset/campaign paths | OPERATOR_DECISION_REQUIRED |
+| StrategySpec | bridged from canonical CandidateSpec; broader legacy owner still ambiguous | candidate planning bridge plus older strategy paths | BRIDGE |
 | StrategyIR | ambiguous | alpha discovery / Strategy IR references | OPERATOR_DECISION_REQUIRED |
-| PresetSpec | ambiguous | preset modules and docs | OPERATOR_DECISION_REQUIRED |
-| CampaignSpec | ambiguous | campaign modules | OPERATOR_DECISION_REQUIRED |
+| PresetSpec | bridged from canonical StrategySpec; broader legacy owner still ambiguous | candidate planning bridge plus preset modules | BRIDGE |
+| CampaignSpec | bridged from canonical PresetSpec; execution owner still separate | candidate planning bridge plus campaign modules | BRIDGE |
 | CampaignRun | inferred | campaign run/report modules | DEFINE_CANONICAL_SCHEMA |
 | ScreeningResult | present | Tiingo candidate loop and other screening modules | GENERALIZE |
 | EvidencePack | ambiguous | campaign/evidence modules | OPERATOR_DECISION_REQUIRED |
@@ -71,7 +79,7 @@ This bridge maps Tiingo HypothesisSeed, ResearchInputContract, and CandidateSpec
 
 1. PR A: settle canonical contract vocabulary. Status: complete in this vocabulary settlement PR.
 2. PR B: bridge Tiingo artifacts to canonical Hypothesis/CandidateSpec. Status: complete for Hypothesis, ResearchInputContract, and CandidateSpec.
-3. PR C: bridge canonical CandidateSpec to StrategySpec/PresetSpec/CampaignSpec.
+3. PR C: bridge canonical CandidateSpec to StrategySpec/PresetSpec/CampaignSpec. Status: complete at planning-contract level.
 4. PR D: connect campaign evidence to FeedbackMemory/LessonMemory.
 5. PR E: make next hypothesis generation consume canonical memory.
 6. PR F: deprecate or quarantine duplicate legacy funnels.

--- a/packages/qre_research/candidate_planning_bridge.py
+++ b/packages/qre_research/candidate_planning_bridge.py
@@ -1,0 +1,190 @@
+"""Bridge canonical CandidateSpec records into planning contracts.
+
+The bridge produces deterministic StrategySpec, PresetSpec, and CampaignSpec
+payloads for research planning. It is schema-level only: no registry mutation,
+campaign execution, screening, validation, promotion, or trading authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any, Final
+
+SCHEMA_VERSION: Final[int] = 1
+PROVIDER_TERMS: Final[tuple[str, ...]] = ("tiingo", "yfinance", "alpaca", "binance", "kraken", "coinbase")
+SAFETY: Final[dict[str, bool]] = {
+    "research_only": True,
+    "planning_only": True,
+    "creates_candidates": False,
+    "creates_strategies": False,
+    "creates_presets": False,
+    "creates_campaigns": False,
+    "mutates_registry": False,
+    "runs_campaign": False,
+    "runs_screening": False,
+    "trading_authority": False,
+    "validation_authority": False,
+    "paper_authority": False,
+    "shadow_authority": False,
+    "live_authority": False,
+}
+
+
+class CandidatePlanningBridgeError(ValueError):
+    """Raised when a canonical candidate cannot be safely planned."""
+
+
+def _stable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _stable(value[key]) for key in sorted(value)}
+    if isinstance(value, list | tuple):
+        return [_stable(item) for item in value]
+    return value
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(_stable(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _required(payload: Mapping[str, Any], fields: tuple[str, ...]) -> None:
+    missing = [field for field in fields if payload.get(field) in (None, "", [])]
+    if missing:
+        raise CandidatePlanningBridgeError("missing_required_fields:" + ",".join(missing))
+
+
+def _assert_no_provider_leakage(payload: Any, path: tuple[str, ...] = ()) -> None:
+    if "provenance" in path:
+        return
+    if isinstance(payload, Mapping):
+        for key, value in payload.items():
+            if any(term in str(key).lower() for term in PROVIDER_TERMS):
+                raise CandidatePlanningBridgeError("provider_leakage:" + ".".join((*path, str(key))))
+            _assert_no_provider_leakage(value, (*path, str(key)))
+        return
+    if isinstance(payload, list | tuple):
+        for index, value in enumerate(payload):
+            _assert_no_provider_leakage(value, (*path, str(index)))
+        return
+    if any(term in str(payload).lower() for term in PROVIDER_TERMS):
+        raise CandidatePlanningBridgeError("provider_leakage:" + ".".join(path))
+
+
+def validate_canonical_candidate(candidate: Mapping[str, Any]) -> None:
+    _required(candidate, ("canonical_name", "candidate_id", "signal_definition", "selection_rule"))
+    if candidate.get("canonical_name") != "CandidateSpec":
+        raise CandidatePlanningBridgeError("not_candidate_spec")
+    if candidate.get("trading_authority") is True or candidate.get("research_only") is False:
+        raise CandidatePlanningBridgeError("unsafe_candidate_authority")
+    _assert_no_provider_leakage(candidate)
+
+
+def candidate_to_strategy_spec(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    """Map canonical CandidateSpec to provider-agnostic StrategySpec."""
+
+    validate_canonical_candidate(candidate)
+    semantics = {
+        "signal_semantics": candidate["signal_definition"],
+        "selection_semantics": candidate["selection_rule"],
+        "rebalance_semantics": candidate.get("rebalance_rule", {}),
+        "holding_semantics": candidate.get("holding_period", {}),
+        "benchmark_semantics": candidate.get("benchmark", {}),
+    }
+    payload = {
+        "canonical_name": "StrategySpec",
+        "schema_version": SCHEMA_VERSION,
+        "strategy_spec_id": "strat_" + _digest({"candidate_id": candidate["candidate_id"], "semantics": semantics}),
+        "candidate_id": candidate["candidate_id"],
+        "signal_semantics": semantics["signal_semantics"],
+        "position_semantics": {
+            "selection_rule": semantics["selection_semantics"],
+            "holding_period": semantics["holding_semantics"],
+        },
+        "entry_semantics": {"derived_from": "candidate_selection_rule"},
+        "exit_semantics": {"derived_from": "candidate_rebalance_and_holding_period"},
+        "portfolio_semantics": {"benchmark": semantics["benchmark_semantics"]},
+        "provenance": {"candidate_id": candidate["candidate_id"], "parent_contract_id": candidate.get("parent_contract_id")},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def strategy_spec_to_preset_spec(strategy_spec: Mapping[str, Any]) -> dict[str, Any]:
+    """Map StrategySpec to deterministic declarative PresetSpec."""
+
+    _required(strategy_spec, ("canonical_name", "strategy_spec_id", "candidate_id", "signal_semantics", "position_semantics"))
+    if strategy_spec.get("canonical_name") != "StrategySpec":
+        raise CandidatePlanningBridgeError("not_strategy_spec")
+    _assert_no_provider_leakage(strategy_spec)
+    parameters = {
+        "signal_semantics": strategy_spec["signal_semantics"],
+        "position_semantics": strategy_spec["position_semantics"],
+    }
+    payload = {
+        "canonical_name": "PresetSpec",
+        "schema_version": SCHEMA_VERSION,
+        "preset_id": "preset_" + _digest({"strategy_spec_id": strategy_spec["strategy_spec_id"], "parameters": parameters}),
+        "strategy_spec_id": strategy_spec["strategy_spec_id"],
+        "parameter_values": parameters,
+        "execution_tier": "research_screening_only",
+        "cost_model_ref": "research_cost_model_required",
+        "slippage_model_ref": "research_slippage_model_required",
+        "provenance": {"strategy_spec_id": strategy_spec["strategy_spec_id"]},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def preset_spec_to_campaign_spec(preset_spec: Mapping[str, Any]) -> dict[str, Any]:
+    """Map PresetSpec to bounded policy-inspectable CampaignSpec."""
+
+    _required(preset_spec, ("canonical_name", "preset_id", "strategy_spec_id", "execution_tier"))
+    if preset_spec.get("canonical_name") != "PresetSpec":
+        raise CandidatePlanningBridgeError("not_preset_spec")
+    _assert_no_provider_leakage(preset_spec)
+    policy = {
+        "max_windows": 3,
+        "max_parameter_variants": 1,
+        "requires_null_controls": True,
+        "requires_cost_model": True,
+        "screening_only": True,
+    }
+    payload = {
+        "canonical_name": "CampaignSpec",
+        "schema_version": SCHEMA_VERSION,
+        "campaign_spec_id": "campaign_" + _digest({"preset_id": preset_spec["preset_id"], "policy": policy}),
+        "preset_id": preset_spec["preset_id"],
+        "screening_protocol": "canonical_research_screening_v1",
+        "evidence_requirements": ["screening_metrics", "null_controls", "cost_and_slippage_notes"],
+        "budget": policy,
+        "null_controls": {"required": True, "minimum_iterations": 16},
+        "stopping_rules": ["stop_on_missing_required_evidence", "stop_on_provider_leakage"],
+        "provenance": {"preset_id": preset_spec["preset_id"], "strategy_spec_id": preset_spec["strategy_spec_id"]},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def candidate_to_planning_bundle(candidate: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    """Build the full deterministic planning bundle for one canonical candidate."""
+
+    strategy = candidate_to_strategy_spec(candidate)
+    preset = strategy_spec_to_preset_spec(strategy)
+    campaign = preset_spec_to_campaign_spec(preset)
+    return {"strategy_spec": strategy, "preset_spec": preset, "campaign_spec": campaign}
+
+
+__all__ = [
+    "CandidatePlanningBridgeError",
+    "SAFETY",
+    "candidate_to_planning_bundle",
+    "candidate_to_strategy_spec",
+    "preset_spec_to_campaign_spec",
+    "strategy_spec_to_preset_spec",
+    "validate_canonical_candidate",
+]

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -192,6 +192,7 @@ def test_package_migration_001_qre_research_has_only_bounded_read_only_seed() ->
         "autonomous_orchestration.py",
         "autonomous_readiness_closure.py",
         "bounded_strategy_synthesis.py",
+        "candidate_planning_bridge.py",
         "canonical_contracts.py",
         "decision_calibration.py",
         "empirical_evidence_pack.py",
@@ -215,6 +216,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_research/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_research/opportunity_value.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/canonical_contracts.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_research/candidate_planning_bridge.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/research_memory.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/tiingo_canonical_bridge.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/retrieval_coverage.py") == DOMAIN_QRE
@@ -240,6 +242,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
 
     assert classify_module("packages.qre_research.opportunity_value") == DOMAIN_QRE
     assert classify_module("packages.qre_research.canonical_contracts") == DOMAIN_QRE
+    assert classify_module("packages.qre_research.candidate_planning_bridge") == DOMAIN_QRE
     assert classify_module("packages.qre_research.research_memory") == DOMAIN_QRE
     assert classify_module("packages.qre_research.tiingo_canonical_bridge") == DOMAIN_QRE
     assert classify_module("packages.qre_research.universe") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -61,6 +61,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "autonomous_orchestration.py",
         "autonomous_readiness_closure.py",
         "bounded_strategy_synthesis.py",
+        "candidate_planning_bridge.py",
         "canonical_contracts.py",
         "decision_calibration.py",
         "empirical_evidence_pack.py",

--- a/tests/unit/test_qre_candidate_planning_bridge.py
+++ b/tests/unit/test_qre_candidate_planning_bridge.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from packages.qre_research import canonical_contracts
+from packages.qre_research.candidate_planning_bridge import (
+    CandidatePlanningBridgeError,
+    candidate_to_planning_bundle,
+    candidate_to_strategy_spec,
+    preset_spec_to_campaign_spec,
+    strategy_spec_to_preset_spec,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _candidate() -> dict[str, object]:
+    return {
+        "canonical_name": "CandidateSpec",
+        "schema_version": 1,
+        "candidate_id": "cand_123",
+        "parent_contract_id": "ric_123",
+        "signal_definition": {"lookback_window": 60, "return_basis": "adjusted_return"},
+        "selection_rule": {"rank": "top", "count": 3},
+        "rebalance_rule": {"every_n_trading_days": 20},
+        "holding_period": {"trading_days": 20},
+        "benchmark": {"kind": "equal_weight_universe"},
+        "research_only": True,
+        "screening_only": True,
+        "not_trade_signal": True,
+        "provenance": {"source": "fixture"},
+        "safety": {"trading_authority": False},
+    }
+
+
+def test_canonical_candidate_to_strategy_spec() -> None:
+    strategy = candidate_to_strategy_spec(_candidate())
+
+    assert strategy["canonical_name"] == "StrategySpec"
+    assert str(strategy["strategy_spec_id"]).startswith("strat_")
+    assert strategy["candidate_id"] == "cand_123"
+    assert strategy["safety"]["trading_authority"] is False
+
+
+def test_strategy_spec_to_preset_spec() -> None:
+    strategy = candidate_to_strategy_spec(_candidate())
+
+    preset = strategy_spec_to_preset_spec(strategy)
+
+    assert preset["canonical_name"] == "PresetSpec"
+    assert str(preset["preset_id"]).startswith("preset_")
+    assert preset["execution_tier"] == "research_screening_only"
+    assert preset["safety"]["creates_presets"] is False
+
+
+def test_preset_spec_to_campaign_spec() -> None:
+    preset = strategy_spec_to_preset_spec(candidate_to_strategy_spec(_candidate()))
+
+    campaign = preset_spec_to_campaign_spec(preset)
+
+    assert campaign["canonical_name"] == "CampaignSpec"
+    assert str(campaign["campaign_spec_id"]).startswith("campaign_")
+    assert campaign["budget"]["max_parameter_variants"] == 1
+    assert campaign["budget"]["requires_null_controls"] is True
+    assert campaign["safety"]["runs_campaign"] is False
+
+
+def test_planning_bundle_is_deterministic() -> None:
+    assert candidate_to_planning_bundle(_candidate()) == candidate_to_planning_bundle(_candidate())
+
+
+def test_required_field_failure() -> None:
+    bad = _candidate()
+    bad.pop("signal_definition")
+
+    with pytest.raises(CandidatePlanningBridgeError, match="missing_required_fields"):
+        candidate_to_strategy_spec(bad)
+
+
+def test_provider_leakage_failure() -> None:
+    bad = _candidate()
+    bad["selection_rule"] = {"provider": "tiingo"}
+
+    with pytest.raises(CandidatePlanningBridgeError, match="provider_leakage"):
+        candidate_to_strategy_spec(bad)
+
+
+def test_no_registry_or_frozen_contract_mutation() -> None:
+    registry = REPO_ROOT / "research" / "registry.py"
+    before = {"research/registry.py": registry.read_bytes()} | {
+        path: (REPO_ROOT / path).read_bytes()
+        for path in canonical_contracts.FROZEN_LEGACY_OUTPUTS
+    }
+
+    candidate_to_planning_bundle(_candidate())
+
+    after = {"research/registry.py": registry.read_bytes()} | {
+        path: (REPO_ROOT / path).read_bytes()
+        for path in canonical_contracts.FROZEN_LEGACY_OUTPUTS
+    }
+    assert after == before
+
+
+def test_no_live_paper_shadow_risk_broker_execution_authority() -> None:
+    bundle = candidate_to_planning_bundle(_candidate())
+
+    for payload in bundle.values():
+        safety = payload["safety"]
+        assert safety["trading_authority"] is False
+        assert safety["validation_authority"] is False
+        assert safety["paper_authority"] is False
+        assert safety["shadow_authority"] is False
+        assert safety["live_authority"] is False
+        assert safety["runs_screening"] is False


### PR DESCRIPTION
Summary:
- adds deterministic provider-agnostic planning bridge from canonical CandidateSpec to StrategySpec, PresetSpec, and bounded CampaignSpec
- keeps planning semantics read-only and policy-inspectable
- blocks missing required fields and provider leakage
- proves no registry or frozen public output mutation
- updates canonical contract map and bounded package inventory tests

Validation:
- python -m pytest tests/unit/test_qre_canonical_contract_vocabulary.py -q
- python -m pytest tests/unit/test_qre_tiingo_canonical_bridge.py -q
- python -m pytest tests/unit/test_qre_candidate_planning_bridge.py -q
- python -m pytest tests/unit/test_qre_funnel_architecture_audit.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py tests/architecture/test_package_migration_010_closure_decision.py -q
- python -m ruff check packages/qre_research/canonical_contracts.py packages/qre_research/tiingo_canonical_bridge.py packages/qre_research/candidate_planning_bridge.py tests/unit/test_qre_candidate_planning_bridge.py
- git diff --check

Safety:
- planning-only and read-only
- no strategy registration
- no campaign execution
- no screening run
- no validation/promotion/strategy registration
- no paper/shadow/live authority
- no broker/risk/order/capital allocation changes
- research/research_latest.json not mutated
- research/strategy_matrix.csv not mutated