### PR TITLE
research: connect campaign evidence to feedback and lesson memory

### DIFF
--- a/docs/architecture/qre_canonical_contract_map.md
+++ b/docs/architecture/qre_canonical_contract_map.md
@@ -35,6 +35,14 @@ packages/qre_research/candidate_planning_bridge.py
 
 This bridge maps canonical CandidateSpec records into StrategySpec, PresetSpec, and bounded CampaignSpec payloads. It is planning-only: no registry mutation, campaign execution, screening run, validation, promotion, paper, shadow, live, broker, risk, or order authority.
 
+PR D adds the evidence and memory bridge:
+
+```text
+packages/qre_research/evidence_memory_bridge.py
+```
+
+This bridge maps campaign or screening evidence into EvidencePack, EvidenceLedger, Disposition, FeedbackRecord, LessonMemory, and ResearchMemory payloads. It preserves negative and contradictory evidence and remains memory-only: no synthesis, promotion, validation, paper, shadow, live, broker, risk, order, or execution authority.
+
 ## Canonical Object Ownership
 
 | Object | Current audit status | Current owner evidence | Recommendation |
@@ -54,12 +62,12 @@ This bridge maps canonical CandidateSpec records into StrategySpec, PresetSpec, 
 | CampaignSpec | bridged from canonical PresetSpec; execution owner still separate | candidate planning bridge plus campaign modules | BRIDGE |
 | CampaignRun | inferred | campaign run/report modules | DEFINE_CANONICAL_SCHEMA |
 | ScreeningResult | present | Tiingo candidate loop and other screening modules | GENERALIZE |
-| EvidencePack | ambiguous | campaign/evidence modules | OPERATOR_DECISION_REQUIRED |
-| EvidenceLedger | present provider-specific | Tiingo candidate loop evidence ledger | BRIDGE |
-| Disposition | inferred | disposition modules | DEFINE_CANONICAL_SCHEMA |
-| FeedbackRecord | present provider-specific | Tiingo candidate loop feedback records | BRIDGE |
-| LessonMemory | ambiguous | lesson/memory modules | OPERATOR_DECISION_REQUIRED |
-| ResearchMemory | ambiguous | research memory modules | OPERATOR_DECISION_REQUIRED |
+| EvidencePack | bridged from canonical screening/campaign evidence | evidence memory bridge plus campaign/evidence modules | BRIDGE |
+| EvidenceLedger | bridged from canonical screening/campaign evidence | Tiingo candidate loop plus evidence memory bridge | BRIDGE |
+| Disposition | bridged from EvidencePack | evidence memory bridge plus disposition modules | BRIDGE |
+| FeedbackRecord | bridged from Disposition | Tiingo candidate loop plus evidence memory bridge | BRIDGE |
+| LessonMemory | bridged from FeedbackRecord; broader memory owner still ambiguous | evidence memory bridge plus lesson/memory modules | BRIDGE |
+| ResearchMemory | bridged from LessonMemory; broader memory store owner still ambiguous | evidence memory bridge plus research memory modules | BRIDGE |
 | DailyDigestInput | present | daily digest sidecars | KEEP_AS_OBSERVABILITY |
 | OperatorSummary | present | digest and sidecar summaries | KEEP_AS_OBSERVABILITY |
 | RegistryEntry | present | registry.py | KEEP_PENDING_SCOPE_CONFIRMATION |
@@ -80,7 +88,7 @@ This bridge maps canonical CandidateSpec records into StrategySpec, PresetSpec, 
 1. PR A: settle canonical contract vocabulary. Status: complete in this vocabulary settlement PR.
 2. PR B: bridge Tiingo artifacts to canonical Hypothesis/CandidateSpec. Status: complete for Hypothesis, ResearchInputContract, and CandidateSpec.
 3. PR C: bridge canonical CandidateSpec to StrategySpec/PresetSpec/CampaignSpec. Status: complete at planning-contract level.
-4. PR D: connect campaign evidence to FeedbackMemory/LessonMemory.
+4. PR D: connect campaign evidence to FeedbackMemory/LessonMemory. Status: complete at contract/memory bridge level.
 5. PR E: make next hypothesis generation consume canonical memory.
 6. PR F: deprecate or quarantine duplicate legacy funnels.
 

--- a/packages/qre_research/evidence_memory_bridge.py
+++ b/packages/qre_research/evidence_memory_bridge.py
@@ -1,0 +1,256 @@
+"""Bridge campaign or screening evidence into canonical memory contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+SCHEMA_VERSION: Final[int] = 1
+PROVIDER_TERMS: Final[tuple[str, ...]] = ("tiingo", "yfinance", "alpaca", "binance", "kraken", "coinbase")
+NEGATIVE_DECISIONS: Final[frozenset[str]] = frozenset({"screening_fail", "null_not_beaten", "blocked_unsafe_input"})
+SAFETY: Final[dict[str, bool]] = {
+    "research_only": True,
+    "memory_only": True,
+    "creates_candidates": False,
+    "creates_strategies": False,
+    "creates_presets": False,
+    "creates_campaigns": False,
+    "runs_campaign": False,
+    "runs_screening": False,
+    "promotes_candidates": False,
+    "trading_authority": False,
+    "validation_authority": False,
+    "paper_authority": False,
+    "shadow_authority": False,
+    "live_authority": False,
+}
+
+
+class EvidenceMemoryBridgeError(ValueError):
+    """Raised when evidence cannot be safely canonicalized."""
+
+
+def _stable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _stable(value[key]) for key in sorted(value)}
+    if isinstance(value, list | tuple):
+        return [_stable(item) for item in value]
+    return value
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(_stable(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _required(payload: Mapping[str, Any], fields: tuple[str, ...]) -> None:
+    missing = [field for field in fields if payload.get(field) in (None, "", [])]
+    if missing:
+        raise EvidenceMemoryBridgeError("missing_required_fields:" + ",".join(missing))
+
+
+def _assert_no_provider_leakage(payload: Any, path: tuple[str, ...] = ()) -> None:
+    if "provenance" in path:
+        return
+    if isinstance(payload, Mapping):
+        for key, value in payload.items():
+            if any(term in str(key).lower() for term in PROVIDER_TERMS):
+                raise EvidenceMemoryBridgeError("provider_leakage:" + ".".join((*path, str(key))))
+            _assert_no_provider_leakage(value, (*path, str(key)))
+        return
+    if isinstance(payload, list | tuple):
+        for index, value in enumerate(payload):
+            _assert_no_provider_leakage(value, (*path, str(index)))
+        return
+    if any(term in str(payload).lower() for term in PROVIDER_TERMS):
+        raise EvidenceMemoryBridgeError("provider_leakage:" + ".".join(path))
+
+
+def evidence_pack_from_screening_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Create canonical EvidencePack from a screening or campaign result."""
+
+    _required(result, ("screening_result_id", "candidate_id", "decision", "metrics"))
+    _assert_no_provider_leakage(result)
+    evidence_refs = [str(result["screening_result_id"])]
+    payload = {
+        "canonical_name": "EvidencePack",
+        "schema_version": SCHEMA_VERSION,
+        "evidence_pack_id": "epack_" + _digest({"screening": result["screening_result_id"], "metrics": result["metrics"]}),
+        "campaign_run_id": result.get("campaign_run_id", "campaign_run_not_executed"),
+        "screening_result_refs": evidence_refs,
+        "decision_basis": {
+            "screening_decision": result["decision"],
+            "metrics": result["metrics"],
+            "null_control": result.get("null_control", {}),
+            "negative_result_preserved": result["decision"] in NEGATIVE_DECISIONS,
+            "contradictions": list(result.get("contradictions") or []),
+        },
+        "diagnostics_refs": list(result.get("diagnostics_refs") or []),
+        "ledger_refs": [],
+        "provenance": {"candidate_id": result["candidate_id"], "screening_result_id": result["screening_result_id"]},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def evidence_ledger_entry_from_screening_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Create a canonical EvidenceLedger entry from a screening result."""
+
+    pack = evidence_pack_from_screening_result(result)
+    decision = str(result["decision"])
+    evidence_decision = {
+        "screening_pass": "retain_research_evidence",
+        "null_not_beaten": "weak_research_evidence",
+        "screening_fail": "weak_research_evidence",
+        "insufficient_evidence": "insufficient_research_evidence",
+        "blocked_unsafe_input": "blocked_research_evidence",
+    }.get(decision, "insufficient_research_evidence")
+    payload = {
+        "canonical_name": "EvidenceLedger",
+        "schema_version": SCHEMA_VERSION,
+        "evidence_id": "evid_" + _digest({"pack": pack["evidence_pack_id"], "decision": evidence_decision}),
+        "evidence_kind": "canonical_screening_evidence",
+        "metrics_digest": "sha256:" + _digest(result["metrics"]),
+        "evidence_decision": evidence_decision,
+        "metrics_summary": dict(result["metrics"]),
+        "null_control_summary": dict(result.get("null_control", {})),
+        "audit_flags": dict(SAFETY),
+        "provenance": {"evidence_pack_id": pack["evidence_pack_id"], "screening_result_id": result["screening_result_id"]},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def disposition_from_evidence_pack(evidence_pack: Mapping[str, Any]) -> dict[str, Any]:
+    """Create deterministic Disposition from canonical EvidencePack."""
+
+    _required(evidence_pack, ("canonical_name", "evidence_pack_id", "decision_basis"))
+    if evidence_pack.get("canonical_name") != "EvidencePack":
+        raise EvidenceMemoryBridgeError("not_evidence_pack")
+    _assert_no_provider_leakage(evidence_pack)
+    basis = evidence_pack["decision_basis"]
+    if not isinstance(basis, Mapping):
+        raise EvidenceMemoryBridgeError("invalid_decision_basis")
+    screening_decision = str(basis.get("screening_decision") or "insufficient_evidence")
+    disposition = {
+        "screening_pass": "retain_for_more_research",
+        "null_not_beaten": "modify_or_deprioritize",
+        "screening_fail": "reject_for_now",
+        "insufficient_evidence": "needs_more_evidence",
+        "blocked_unsafe_input": "block_until_repaired",
+    }.get(screening_decision, "needs_more_evidence")
+    payload = {
+        "canonical_name": "Disposition",
+        "schema_version": SCHEMA_VERSION,
+        "disposition_id": "disp_" + _digest({"pack": evidence_pack["evidence_pack_id"], "decision": disposition}),
+        "evidence_pack_id": evidence_pack["evidence_pack_id"],
+        "decision": disposition,
+        "reason_codes": [screening_decision],
+        "next_actions": ["write_feedback_record"],
+        "operator_notes": [],
+        "provenance": {"evidence_pack_id": evidence_pack["evidence_pack_id"]},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def feedback_record_from_disposition(disposition: Mapping[str, Any]) -> dict[str, Any]:
+    """Create canonical FeedbackRecord from a valid Disposition."""
+
+    _required(disposition, ("canonical_name", "disposition_id", "decision", "evidence_pack_id"))
+    if disposition.get("canonical_name") != "Disposition":
+        raise EvidenceMemoryBridgeError("not_disposition")
+    _assert_no_provider_leakage(disposition)
+    decision = str(disposition["decision"])
+    next_action = {
+        "retain_for_more_research": "retain_hypothesis_family",
+        "modify_or_deprioritize": "modify_hypothesis_parameters_later",
+        "reject_for_now": "suppress_matching_candidate_family",
+        "needs_more_evidence": "collect_more_data",
+        "block_until_repaired": "repair_input_contract",
+    }.get(decision, "collect_more_data")
+    payload = {
+        "canonical_name": "FeedbackRecord",
+        "schema_version": SCHEMA_VERSION,
+        "feedback_id": "fb_" + _digest({"disposition": disposition["disposition_id"], "decision": decision}),
+        "subject_id": disposition["evidence_pack_id"],
+        "feedback_decision": decision,
+        "next_action": next_action,
+        "feedback_reasons": list(disposition.get("reason_codes") or []),
+        "consumable_by_next_run": True,
+        "provenance": {"disposition_id": disposition["disposition_id"], "evidence_pack_id": disposition["evidence_pack_id"]},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def lesson_memory_from_feedback_records(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Compress feedback records into deterministic LessonMemory."""
+
+    if not records:
+        raise EvidenceMemoryBridgeError("missing_feedback_records")
+    for record in records:
+        _required(record, ("canonical_name", "feedback_id", "feedback_decision", "next_action"))
+        if record.get("canonical_name") != "FeedbackRecord":
+            raise EvidenceMemoryBridgeError("not_feedback_record")
+        _assert_no_provider_leakage(record)
+    counts = Counter(str(record["feedback_decision"]) for record in records)
+    negative = [record["feedback_id"] for record in records if record["feedback_decision"] in {"reject_for_now", "modify_or_deprioritize"}]
+    payload = {
+        "canonical_name": "LessonMemory",
+        "schema_version": SCHEMA_VERSION,
+        "lesson_id": "lesson_" + _digest({"feedback": [record["feedback_id"] for record in records], "counts": dict(counts)}),
+        "disposition_id": str(records[-1].get("provenance", {}).get("disposition_id", "multiple_dispositions")),
+        "lesson_type": "research_feedback_summary",
+        "do_not_repeat": list(negative),
+        "generator_constraints": ["preserve_negative_results", "explain_memory_influence"],
+        "recommended_next_question": "Use canonical feedback before proposing adjacent hypotheses.",
+        "provenance": {"feedback_ids": [record["feedback_id"] for record in records]},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def research_memory_from_lessons(lessons: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Create read-only ResearchMemory from LessonMemory records."""
+
+    if not lessons:
+        raise EvidenceMemoryBridgeError("missing_lesson_memory")
+    for lesson in lessons:
+        _required(lesson, ("canonical_name", "lesson_id", "do_not_repeat"))
+        if lesson.get("canonical_name") != "LessonMemory":
+            raise EvidenceMemoryBridgeError("not_lesson_memory")
+        _assert_no_provider_leakage(lesson)
+    payload = {
+        "canonical_name": "ResearchMemory",
+        "schema_version": SCHEMA_VERSION,
+        "research_memory_id": "rmem_" + _digest({"lessons": [lesson["lesson_id"] for lesson in lessons]}),
+        "lesson_refs": [lesson["lesson_id"] for lesson in lessons],
+        "feedback_refs": [feedback_id for lesson in lessons for feedback_id in lesson.get("provenance", {}).get("feedback_ids", [])],
+        "terminal_outcomes": [],
+        "active_contradictions": [],
+        "provenance": {"lesson_count": len(lessons)},
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+__all__ = [
+    "EvidenceMemoryBridgeError",
+    "SAFETY",
+    "disposition_from_evidence_pack",
+    "evidence_ledger_entry_from_screening_result",
+    "evidence_pack_from_screening_result",
+    "feedback_record_from_disposition",
+    "lesson_memory_from_feedback_records",
+    "research_memory_from_lessons",
+]

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -197,6 +197,7 @@ def test_package_migration_001_qre_research_has_only_bounded_read_only_seed() ->
         "decision_calibration.py",
         "empirical_evidence_pack.py",
         "empirical_research_flywheel.py",
+        "evidence_memory_bridge.py",
         "generated_hypothesis_paths.py",
         "generated_primitive_paths.py",
         "generated_strategy_paths.py",
@@ -218,6 +219,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_research/canonical_contracts.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/candidate_planning_bridge.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/research_memory.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_research/evidence_memory_bridge.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/tiingo_canonical_bridge.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/retrieval_coverage.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/universe.py") == DOMAIN_QRE
@@ -244,6 +246,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_module("packages.qre_research.canonical_contracts") == DOMAIN_QRE
     assert classify_module("packages.qre_research.candidate_planning_bridge") == DOMAIN_QRE
     assert classify_module("packages.qre_research.research_memory") == DOMAIN_QRE
+    assert classify_module("packages.qre_research.evidence_memory_bridge") == DOMAIN_QRE
     assert classify_module("packages.qre_research.tiingo_canonical_bridge") == DOMAIN_QRE
     assert classify_module("packages.qre_research.universe") == DOMAIN_QRE
     assert classify_module("packages.qre_data.cache_manifest") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -66,6 +66,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "decision_calibration.py",
         "empirical_evidence_pack.py",
         "empirical_research_flywheel.py",
+        "evidence_memory_bridge.py",
         "generated_hypothesis_paths.py",
         "generated_primitive_paths.py",
         "generated_strategy_paths.py",

--- a/tests/unit/test_qre_evidence_memory_bridge.py
+++ b/tests/unit/test_qre_evidence_memory_bridge.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from packages.qre_research import canonical_contracts
+from packages.qre_research.evidence_memory_bridge import (
+    EvidenceMemoryBridgeError,
+    disposition_from_evidence_pack,
+    evidence_ledger_entry_from_screening_result,
+    evidence_pack_from_screening_result,
+    feedback_record_from_disposition,
+    lesson_memory_from_feedback_records,
+    research_memory_from_lessons,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _screening(decision: str = "screening_fail") -> dict[str, object]:
+    return {
+        "screening_result_id": "screen_001",
+        "campaign_run_id": "campaign_run_001",
+        "candidate_id": "cand_001",
+        "decision": decision,
+        "metrics": {
+            "candidate_total_return": -0.1,
+            "benchmark_total_return": 0.02,
+            "excess_return": -0.12,
+            "candidate_sharpe_like": -0.4,
+        },
+        "null_control": {"beats_null_p50": False},
+        "contradictions": ["benchmark_positive_candidate_negative"],
+    }
+
+
+def test_evidence_pack_from_fixture_campaign_result() -> None:
+    pack = evidence_pack_from_screening_result(_screening())
+
+    assert pack["canonical_name"] == "EvidencePack"
+    assert str(pack["evidence_pack_id"]).startswith("epack_")
+    assert pack["decision_basis"]["negative_result_preserved"] is True
+    assert pack["decision_basis"]["contradictions"] == ["benchmark_positive_candidate_negative"]
+
+
+def test_evidence_ledger_from_screening_result() -> None:
+    ledger = evidence_ledger_entry_from_screening_result(_screening("null_not_beaten"))
+
+    assert ledger["canonical_name"] == "EvidenceLedger"
+    assert ledger["evidence_decision"] == "weak_research_evidence"
+    assert ledger["audit_flags"]["trading_authority"] is False
+
+
+def test_disposition_from_evidence() -> None:
+    disposition = disposition_from_evidence_pack(evidence_pack_from_screening_result(_screening()))
+
+    assert disposition["canonical_name"] == "Disposition"
+    assert disposition["decision"] == "reject_for_now"
+    assert disposition["reason_codes"] == ["screening_fail"]
+
+
+def test_feedback_record_from_disposition() -> None:
+    feedback = feedback_record_from_disposition(
+        disposition_from_evidence_pack(evidence_pack_from_screening_result(_screening()))
+    )
+
+    assert feedback["canonical_name"] == "FeedbackRecord"
+    assert feedback["feedback_decision"] == "reject_for_now"
+    assert feedback["next_action"] == "suppress_matching_candidate_family"
+    assert feedback["consumable_by_next_run"] is True
+
+
+def test_lesson_memory_from_repeated_or_classified_failures() -> None:
+    feedback = feedback_record_from_disposition(
+        disposition_from_evidence_pack(evidence_pack_from_screening_result(_screening()))
+    )
+
+    lesson = lesson_memory_from_feedback_records([feedback, feedback])
+
+    assert lesson["canonical_name"] == "LessonMemory"
+    assert lesson["do_not_repeat"] == [feedback["feedback_id"], feedback["feedback_id"]]
+    assert "preserve_negative_results" in lesson["generator_constraints"]
+
+
+def test_research_memory_from_lessons() -> None:
+    feedback = feedback_record_from_disposition(
+        disposition_from_evidence_pack(evidence_pack_from_screening_result(_screening()))
+    )
+    lesson = lesson_memory_from_feedback_records([feedback])
+
+    memory = research_memory_from_lessons([lesson])
+
+    assert memory["canonical_name"] == "ResearchMemory"
+    assert memory["lesson_refs"] == [lesson["lesson_id"]]
+    assert memory["feedback_refs"] == [feedback["feedback_id"]]
+
+
+def test_missing_evidence_fails_closed() -> None:
+    bad = _screening()
+    bad.pop("metrics")
+
+    with pytest.raises(EvidenceMemoryBridgeError, match="missing_required_fields"):
+        evidence_pack_from_screening_result(bad)
+
+
+def test_provider_leakage_is_blocked() -> None:
+    bad = _screening()
+    bad["metrics"] = {"provider": "tiingo"}
+
+    with pytest.raises(EvidenceMemoryBridgeError, match="provider_leakage"):
+        evidence_pack_from_screening_result(bad)
+
+
+def test_frozen_contracts_are_not_mutated() -> None:
+    before = {path: (REPO_ROOT / path).read_bytes() for path in canonical_contracts.FROZEN_LEGACY_OUTPUTS}
+
+    feedback = feedback_record_from_disposition(
+        disposition_from_evidence_pack(evidence_pack_from_screening_result(_screening()))
+    )
+    lesson = lesson_memory_from_feedback_records([feedback])
+    research_memory_from_lessons([lesson])
+
+    after = {path: (REPO_ROOT / path).read_bytes() for path in canonical_contracts.FROZEN_LEGACY_OUTPUTS}
+    assert after == before
+
+
+def test_no_execution_or_promotion_authority() -> None:
+    feedback = feedback_record_from_disposition(
+        disposition_from_evidence_pack(evidence_pack_from_screening_result(_screening()))
+    )
+    lesson = lesson_memory_from_feedback_records([feedback])
+    memory = research_memory_from_lessons([lesson])
+
+    for payload in (feedback, lesson, memory):
+        safety = payload["safety"]
+        assert safety["runs_campaign"] is False
+        assert safety["runs_screening"] is False
+        assert safety["promotes_candidates"] is False
+        assert safety["trading_authority"] is False
+        assert safety["validation_authority"] is False


### PR DESCRIPTION
Summary:
- adds deterministic evidence/memory bridge from screening or campaign evidence into canonical memory contracts
- maps ScreeningResult/Campaign evidence to EvidencePack, EvidenceLedger, Disposition, FeedbackRecord, LessonMemory, and ResearchMemory
- preserves negative and contradictory evidence
- fails closed on missing evidence and provider leakage
- updates canonical contract map and bounded package inventory tests

Validation:
- python -m pytest tests/unit/test_qre_canonical_contract_vocabulary.py -q
- python -m pytest tests/unit/test_qre_candidate_planning_bridge.py -q
- python -m pytest tests/unit/test_qre_evidence_memory_bridge.py -q
- python -m pytest tests/unit/test_qre_funnel_architecture_audit.py -q
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py tests/architecture/test_package_migration_010_closure_decision.py -q
- python -m ruff check packages/qre_research/canonical_contracts.py packages/qre_research/evidence_memory_bridge.py tests/unit/test_qre_evidence_memory_bridge.py
- git diff --check

Safety:
- memory-only and read-only
- no synthesis authorization
- no candidate promotion
- no campaign execution
- no screening run
- no validation/promotion/strategy registration
- no paper/shadow/live authority
- no broker/risk/order/capital allocation changes
- research/research_latest.json not mutated
- research/strategy_matrix.csv not mutated