### PR TITLE
research: feed canonical memory into next hypothesis generation

### DIFF
--- a/docs/architecture/qre_canonical_contract_map.md
+++ b/docs/architecture/qre_canonical_contract_map.md
@@ -43,6 +43,14 @@ packages/qre_research/evidence_memory_bridge.py
 
 This bridge maps campaign or screening evidence into EvidencePack, EvidenceLedger, Disposition, FeedbackRecord, LessonMemory, and ResearchMemory payloads. It preserves negative and contradictory evidence and remains memory-only: no synthesis, promotion, validation, paper, shadow, live, broker, risk, order, or execution authority.
 
+PR E adds deterministic memory-aware hypothesis ordering:
+
+```text
+packages/qre_research/memory_aware_hypothesis_generation.py
+```
+
+This adapter lets canonical FeedbackRecord, LessonMemory, and ResearchMemory influence the next hypothesis batch by suppressing repeated failures, deprioritizing dead zones, and boosting near-pass families. Every influence is explainable and deterministic. It does not synthesize strategies, invent indicators, create candidates, promote candidates, or grant execution authority.
+
 ## Canonical Object Ownership
 
 | Object | Current audit status | Current owner evidence | Recommendation |
@@ -89,7 +97,7 @@ This bridge maps campaign or screening evidence into EvidencePack, EvidenceLedge
 2. PR B: bridge Tiingo artifacts to canonical Hypothesis/CandidateSpec. Status: complete for Hypothesis, ResearchInputContract, and CandidateSpec.
 3. PR C: bridge canonical CandidateSpec to StrategySpec/PresetSpec/CampaignSpec. Status: complete at planning-contract level.
 4. PR D: connect campaign evidence to FeedbackMemory/LessonMemory. Status: complete at contract/memory bridge level.
-5. PR E: make next hypothesis generation consume canonical memory.
+5. PR E: make next hypothesis generation consume canonical memory. Status: complete at deterministic ordering/context level.
 6. PR F: deprecate or quarantine duplicate legacy funnels.
 
 ## Rules For Future Work

--- a/packages/qre_research/memory_aware_hypothesis_generation.py
+++ b/packages/qre_research/memory_aware_hypothesis_generation.py
@@ -1,0 +1,159 @@
+"""Deterministic canonical-memory influence for next hypothesis batches."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+PROVIDER_TERMS: Final[tuple[str, ...]] = ("tiingo", "yfinance", "alpaca", "binance", "kraken", "coinbase")
+SAFETY: Final[dict[str, bool]] = {
+    "research_only": True,
+    "memory_context_only": True,
+    "creates_candidates": False,
+    "creates_strategies": False,
+    "creates_presets": False,
+    "creates_campaigns": False,
+    "runs_screening": False,
+    "strategy_synthesis_authority": False,
+    "stochastic_selector": False,
+    "trading_authority": False,
+    "validation_authority": False,
+    "paper_authority": False,
+    "shadow_authority": False,
+    "live_authority": False,
+}
+
+
+class MemoryAwareGenerationError(ValueError):
+    """Raised when memory-aware ordering cannot be safely computed."""
+
+
+def _stable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _stable(value[key]) for key in sorted(value)}
+    if isinstance(value, list | tuple):
+        return [_stable(item) for item in value]
+    return value
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(_stable(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _assert_no_provider_leakage(payload: Any, path: tuple[str, ...] = ()) -> None:
+    if "provenance" in path:
+        return
+    if isinstance(payload, Mapping):
+        for key, value in payload.items():
+            if any(term in str(key).lower() for term in PROVIDER_TERMS):
+                raise MemoryAwareGenerationError("provider_leakage:" + ".".join((*path, str(key))))
+            _assert_no_provider_leakage(value, (*path, str(key)))
+        return
+    if isinstance(payload, list | tuple):
+        for index, value in enumerate(payload):
+            _assert_no_provider_leakage(value, (*path, str(index)))
+        return
+    if any(term in str(payload).lower() for term in PROVIDER_TERMS):
+        raise MemoryAwareGenerationError("provider_leakage:" + ".".join(path))
+
+
+def _family(payload: Mapping[str, Any]) -> str:
+    value = payload.get("feature_family") or payload.get("mechanism_family") or payload.get("candidate_family")
+    if not value and isinstance(payload.get("mechanism"), Mapping):
+        value = payload["mechanism"].get("feature_family")
+    text = str(value or "").strip()
+    if not text:
+        raise MemoryAwareGenerationError("missing_hypothesis_family")
+    return text
+
+
+def _memory_rules(memory: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not memory:
+        return {}
+    _assert_no_provider_leakage(memory)
+    rules: dict[str, dict[str, Any]] = {}
+    for record in memory.get("feedback_records", []) if isinstance(memory.get("feedback_records"), list) else []:
+        if not isinstance(record, Mapping):
+            continue
+        family = str(record.get("hypothesis_family") or record.get("candidate_family") or "").strip()
+        if not family:
+            continue
+        decision = str(record.get("feedback_decision") or "")
+        if decision in {"reject_for_now", "block_until_repaired"}:
+            rules[family] = {"action": "suppress", "reason": decision}
+        elif decision in {"modify_or_deprioritize", "needs_more_evidence"}:
+            rules.setdefault(family, {"action": "deprioritize", "reason": decision})
+        elif decision == "retain_for_more_research":
+            rules.setdefault(family, {"action": "boost", "reason": decision})
+    for lesson in memory.get("lessons", []) if isinstance(memory.get("lessons"), list) else []:
+        if not isinstance(lesson, Mapping):
+            continue
+        for family in lesson.get("do_not_repeat_families", []) if isinstance(lesson.get("do_not_repeat_families"), list) else []:
+            rules[str(family)] = {"action": "suppress", "reason": "negative_lesson_memory"}
+        for family in lesson.get("dead_zone_families", []) if isinstance(lesson.get("dead_zone_families"), list) else []:
+            rules.setdefault(str(family), {"action": "deprioritize", "reason": "dead_zone_memory"})
+        for family in lesson.get("near_pass_families", []) if isinstance(lesson.get("near_pass_families"), list) else []:
+            rules.setdefault(str(family), {"action": "boost", "reason": "near_pass_feedback"})
+    return rules
+
+
+def prioritize_hypothesis_batch(
+    hypotheses: Sequence[Mapping[str, Any]],
+    memory: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Apply canonical memory to a hypothesis batch deterministically."""
+
+    if not hypotheses:
+        raise MemoryAwareGenerationError("missing_hypotheses")
+    for hypothesis in hypotheses:
+        _assert_no_provider_leakage(hypothesis)
+    rules = _memory_rules(memory)
+    rows: list[dict[str, Any]] = []
+    for index, hypothesis in enumerate(hypotheses):
+        family = _family(hypothesis)
+        rule = rules.get(family, {"action": "baseline", "reason": "no_memory_match"})
+        base_priority = float(hypothesis.get("base_priority", 1.0))
+        adjustment = {"boost": 0.25, "deprioritize": -0.35, "suppress": -1.0, "baseline": 0.0}[rule["action"]]
+        final_priority = base_priority + adjustment
+        suppressed = rule["action"] == "suppress"
+        rows.append(
+            {
+                "hypothesis_id": str(hypothesis.get("hypothesis_id") or f"hypothesis_{index}"),
+                "hypothesis_family": family,
+                "base_priority": base_priority,
+                "memory_action": rule["action"],
+                "memory_reason": rule["reason"],
+                "final_priority": final_priority,
+                "suppressed": suppressed,
+                "explanation": f"memory_action={rule['action']}; reason={rule['reason']}",
+                "source_index": index,
+            }
+        )
+    ordered = sorted(rows, key=lambda row: (row["suppressed"], -float(row["final_priority"]), row["hypothesis_id"]))
+    payload = {
+        "canonical_name": "HypothesisBatchMemoryView",
+        "schema_version": 1,
+        "batch_view_id": "hbatch_" + _digest({"hypotheses": rows, "memory": memory or {}}),
+        "hypotheses": ordered,
+        "suppressed_count": sum(1 for row in ordered if row["suppressed"]),
+        "memory_applied_count": sum(1 for row in ordered if row["memory_action"] != "baseline"),
+        "warnings": _contradiction_warnings(memory),
+        "safety": dict(SAFETY),
+    }
+    _assert_no_provider_leakage(payload)
+    return payload
+
+
+def _contradiction_warnings(memory: Mapping[str, Any] | None) -> list[str]:
+    if not memory:
+        return []
+    warnings = []
+    for item in memory.get("contradictions", []) if isinstance(memory.get("contradictions"), list) else []:
+        warnings.append("contradictory_memory:" + str(item))
+    return sorted(warnings)
+
+
+__all__ = ["MemoryAwareGenerationError", "SAFETY", "prioritize_hypothesis_batch"]

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -202,6 +202,7 @@ def test_package_migration_001_qre_research_has_only_bounded_read_only_seed() ->
         "generated_primitive_paths.py",
         "generated_strategy_paths.py",
         "hypothesis_lifecycle.py",
+        "memory_aware_hypothesis_generation.py",
         "opportunity_value.py",
         "research_memory.py",
         "retrieval_coverage.py",
@@ -218,6 +219,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_research/opportunity_value.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/canonical_contracts.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/candidate_planning_bridge.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_research/memory_aware_hypothesis_generation.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/research_memory.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/evidence_memory_bridge.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/tiingo_canonical_bridge.py") == DOMAIN_QRE
@@ -245,6 +247,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_module("packages.qre_research.opportunity_value") == DOMAIN_QRE
     assert classify_module("packages.qre_research.canonical_contracts") == DOMAIN_QRE
     assert classify_module("packages.qre_research.candidate_planning_bridge") == DOMAIN_QRE
+    assert classify_module("packages.qre_research.memory_aware_hypothesis_generation") == DOMAIN_QRE
     assert classify_module("packages.qre_research.research_memory") == DOMAIN_QRE
     assert classify_module("packages.qre_research.evidence_memory_bridge") == DOMAIN_QRE
     assert classify_module("packages.qre_research.tiingo_canonical_bridge") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -71,6 +71,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "generated_primitive_paths.py",
         "generated_strategy_paths.py",
         "hypothesis_lifecycle.py",
+        "memory_aware_hypothesis_generation.py",
         "opportunity_value.py",
         "research_memory.py",
         "retrieval_coverage.py",

--- a/tests/unit/test_qre_memory_aware_hypothesis_generation.py
+++ b/tests/unit/test_qre_memory_aware_hypothesis_generation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from packages.qre_research.memory_aware_hypothesis_generation import (
+    MemoryAwareGenerationError,
+    prioritize_hypothesis_batch,
+)
+
+
+def _hypotheses() -> list[dict[str, object]]:
+    return [
+        {"hypothesis_id": "h1", "feature_family": "momentum", "base_priority": 0.5},
+        {"hypothesis_id": "h2", "feature_family": "defensive", "base_priority": 0.6},
+        {"hypothesis_id": "h3", "feature_family": "breakout", "base_priority": 0.4},
+    ]
+
+
+def test_memory_absent_produces_stable_baseline_ordering() -> None:
+    first = prioritize_hypothesis_batch(_hypotheses())
+    second = prioritize_hypothesis_batch(_hypotheses())
+
+    assert first == second
+    assert [row["hypothesis_id"] for row in first["hypotheses"]] == ["h2", "h1", "h3"]
+    assert first["memory_applied_count"] == 0
+
+
+def test_negative_lesson_memory_suppresses_matching_family() -> None:
+    memory = {"lessons": [{"do_not_repeat_families": ["defensive"]}]}
+
+    view = prioritize_hypothesis_batch(_hypotheses(), memory)
+
+    defensive = next(row for row in view["hypotheses"] if row["hypothesis_family"] == "defensive")
+    assert defensive["suppressed"] is True
+    assert defensive["memory_reason"] == "negative_lesson_memory"
+
+
+def test_positive_or_near_pass_feedback_increases_priority_without_certifying_alpha() -> None:
+    memory = {"lessons": [{"near_pass_families": ["breakout"]}]}
+
+    view = prioritize_hypothesis_batch(_hypotheses(), memory)
+    breakout = next(row for row in view["hypotheses"] if row["hypothesis_family"] == "breakout")
+
+    assert breakout["memory_action"] == "boost"
+    assert breakout["final_priority"] > breakout["base_priority"]
+    assert view["safety"]["strategy_synthesis_authority"] is False
+
+
+def test_duplicate_prior_hypothesis_can_be_suppressed() -> None:
+    memory = {"feedback_records": [{"hypothesis_family": "momentum", "feedback_decision": "reject_for_now"}]}
+
+    view = prioritize_hypothesis_batch(_hypotheses(), memory)
+    momentum = next(row for row in view["hypotheses"] if row["hypothesis_family"] == "momentum")
+
+    assert momentum["suppressed"] is True
+    assert momentum["memory_action"] == "suppress"
+
+
+def test_dead_zone_memory_reduces_priority() -> None:
+    memory = {"lessons": [{"dead_zone_families": ["momentum"]}]}
+
+    view = prioritize_hypothesis_batch(_hypotheses(), memory)
+    momentum = next(row for row in view["hypotheses"] if row["hypothesis_family"] == "momentum")
+
+    assert momentum["memory_action"] == "deprioritize"
+    assert momentum["final_priority"] < momentum["base_priority"]
+
+
+def test_contradictory_memory_creates_warning() -> None:
+    memory = {"contradictions": ["family_supported_and_rejected"]}
+
+    view = prioritize_hypothesis_batch(_hypotheses(), memory)
+
+    assert view["warnings"] == ["contradictory_memory:family_supported_and_rejected"]
+
+
+def test_provider_leakage_is_blocked() -> None:
+    with pytest.raises(MemoryAwareGenerationError, match="provider_leakage"):
+        prioritize_hypothesis_batch([{"hypothesis_id": "h", "feature_family": "tiingo_momentum"}])
+
+
+def test_no_hidden_stochasticity_or_execution_authority() -> None:
+    view = prioritize_hypothesis_batch(_hypotheses(), {"lessons": [{"near_pass_families": ["breakout"]}]})
+
+    assert view == prioritize_hypothesis_batch(_hypotheses(), {"lessons": [{"near_pass_families": ["breakout"]}]})
+    safety = view["safety"]
+    assert safety["stochastic_selector"] is False
+    assert safety["creates_candidates"] is False
+    assert safety["creates_strategies"] is False
+    assert safety["runs_screening"] is False
+    assert safety["trading_authority"] is False


### PR DESCRIPTION
Summary:
- adds deterministic memory-aware hypothesis batch ordering
- consumes canonical feedback, lesson, and research memory context
- suppresses repeated failures, deprioritizes dead zones, and boosts near-pass families with explanations
- blocks provider leakage and keeps all influence deterministic
- updates canonical contract map and bounded package inventory tests

Validation:
- python -m pytest tests/unit/test_qre_canonical_contract_vocabulary.py -q
- python -m pytest tests/unit/test_qre_evidence_memory_bridge.py -q
- python -m pytest tests/unit/test_qre_memory_aware_hypothesis_generation.py -q
- python -m pytest tests/unit/test_qre_tiingo_candidate_research_loop.py -q
- python -m pytest tests/unit/test_qre_funnel_architecture_audit.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py tests/architecture/test_package_migration_010_closure_decision.py -q
- python -m ruff check packages/qre_research/canonical_contracts.py packages/qre_research/memory_aware_hypothesis_generation.py tests/unit/test_qre_memory_aware_hypothesis_generation.py
- git diff --check

Safety:
- memory-context only
- no hidden stochasticity
- no strategy synthesis
- no automatic indicator invention
- no candidates created or promoted
- no campaign execution
- no screening run
- no validation/promotion/strategy registration
- no paper/shadow/live authority
- no broker/risk/order/capital allocation changes
- research/research_latest.json not mutated
- research/strategy_matrix.csv not mutated