### PR TITLE
research: quarantine duplicate legacy funnel claims

### DIFF
--- a/docs/architecture/qre_canonical_contract_map.md
+++ b/docs/architecture/qre_canonical_contract_map.md
@@ -51,6 +51,14 @@ packages/qre_research/memory_aware_hypothesis_generation.py
 
 This adapter lets canonical FeedbackRecord, LessonMemory, and ResearchMemory influence the next hypothesis batch by suppressing repeated failures, deprioritizing dead zones, and boosting near-pass families. Every influence is explainable and deterministic. It does not synthesize strategies, invent indicators, create candidates, promote candidates, or grant execution authority.
 
+PR F adds the funnel classification registry:
+
+```text
+packages/qre_research/funnel_classification.py
+```
+
+This registry quarantines duplicate funnel claims. It records exactly one canonical provider-agnostic contract/bridge/memory loop at the contract level, keeps Tiingo as a provider adapter, keeps daily digest as observability-only, protects legacy `research/research_latest.json` and `research/strategy_matrix.csv`, and marks fixture/smoke funnels as fixture-only. It does not delete legacy code or change runtime behavior.
+
 ## Canonical Object Ownership
 
 | Object | Current audit status | Current owner evidence | Recommendation |
@@ -85,11 +93,12 @@ This adapter lets canonical FeedbackRecord, LessonMemory, and ResearchMemory inf
 
 | Funnel | Current status | Canonicality | Provider specificity | Keep/Bridge/Deprecate decision | Required future PR |
 |---|---|---|---|---|---|
-| Tiingo candidate research loop | research-only mini-loop | provider adapter | provider_specific | KEEP_AS_PROVIDER_ADAPTER + BRIDGE_TO_CANONICAL | HypothesisSeed, ResearchInputContract, and CandidateSpec bridge complete; EvidenceLedger and FeedbackRecord remain for PR D |
+| Canonical provider-agnostic contract/bridge/memory loop | contract-level loop | canonical_contract_loop | provider_agnostic | KEEP_AS_CANONICAL | PR A-E complete: vocabulary, Tiingo bridge, planning bridge, evidence/memory bridge, and memory-aware next hypothesis ordering |
+| Tiingo candidate research loop | research-only mini-loop | provider adapter | provider_specific | KEEP_AS_PROVIDER_ADAPTER + BRIDGE_TO_CANONICAL | Bridge complete through canonical Hypothesis, ResearchInputContract, CandidateSpec, Evidence/Feedback, and memory-aware next-run context |
 | Daily digest | read-only aggregation | observability_only | mixed | OBSERVABILITY_ONLY | Keep consuming sidecars; do not let digest produce research objects |
 | Alpha discovery / Strategy IR / campaign / lesson funnel | partial funnel | unknown | mixed | BRIDGE_TO_CANONICAL or UNKNOWN_REQUIRES_OPERATOR_DECISION | Map StrategyIR, CampaignSpec, EvidencePack, Disposition, LessonMemory, and ResearchMemory ownership |
-| run_research / registry / strategy_matrix | legacy or canonical backtest/report path | unknown | mixed | OPERATOR_DECISION_REQUIRED | Decide whether registry and strategy_matrix remain canonical for strategy research outputs |
-| test/smoke fixture funnels | fixture semantics | test_fixture_only | unknown | TEST_FIXTURE_ONLY | Quarantine fixture-only claims from architecture docs |
+| run_research / registry / strategy_matrix | legacy protected output path | legacy_protected | mixed | KEEP_AS_LEGACY_OUTPUT_CONTRACT | Frozen outputs remain protected; separate operator-scoped settlement required before ownership changes |
+| test/smoke fixture funnels | fixture semantics | test_fixture_only | unknown | TEST_FIXTURE_ONLY | Fixture-only claims are quarantined and cannot masquerade as canonical |
 
 ## Recommended PR Sequence
 
@@ -98,7 +107,9 @@ This adapter lets canonical FeedbackRecord, LessonMemory, and ResearchMemory inf
 3. PR C: bridge canonical CandidateSpec to StrategySpec/PresetSpec/CampaignSpec. Status: complete at planning-contract level.
 4. PR D: connect campaign evidence to FeedbackMemory/LessonMemory. Status: complete at contract/memory bridge level.
 5. PR E: make next hypothesis generation consume canonical memory. Status: complete at deterministic ordering/context level.
-6. PR F: deprecate or quarantine duplicate legacy funnels.
+6. PR F: deprecate or quarantine duplicate legacy funnels. Status: complete at classification/quarantine level.
+
+After PR F, the provider-agnostic QRE research loop is reconciled at the contract, bridge, memory, and funnel-classification level. This does not mean strategy-authoritative, validation-ready, paper-ready, shadow-ready, live-ready, or trading-ready.
 
 ## Rules For Future Work
 

--- a/docs/architecture/qre_funnel_architecture_audit.md
+++ b/docs/architecture/qre_funnel_architecture_audit.md
@@ -38,6 +38,27 @@ The repo contains multiple partial funnels rather than one proven, provider-agno
 
 The Tiingo path is useful and should be kept, but it is provider-specific and should be bridged to canonical contracts before being treated as the general QRE architecture.
 
+## Classification Settlement
+
+PR F adds a read-only funnel classification registry:
+
+```text
+packages/qre_research/funnel_classification.py
+```
+
+The registry records:
+
+- one canonical provider-agnostic contract/bridge/memory loop at the contract level
+- Tiingo as a provider adapter bridged to canonical contracts
+- daily digest as observability-only
+- `research/research_latest.json` and `research/strategy_matrix.csv` as protected legacy output contracts
+- smoke and fixture paths as fixture-only
+- ambiguous alpha discovery / Strategy IR / campaign / lesson ownership as requiring bridge or operator decision
+
+The classification registry does not execute research, create candidates, create strategies, launch campaigns, run screening, validate, promote, register strategies, or grant paper/shadow/live/trading authority.
+
+The full runtime architecture still remains bounded by the no-execution safety rules. The settlement is a contract/bridge/memory/funnel-classification reconciliation, not a production trading readiness claim.
+
 ## Outputs
 
 Write mode emits:

--- a/packages/qre_research/funnel_classification.py
+++ b/packages/qre_research/funnel_classification.py
@@ -1,0 +1,211 @@
+"""Canonical QRE funnel classification metadata.
+
+This module quarantines duplicate funnel claims with declarative metadata. It
+does not run research, create artifacts, launch campaigns, or grant execution
+authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+Classification = Literal[
+    "canonical_contract_loop",
+    "provider_adapter",
+    "observability_only",
+    "legacy_protected",
+    "fixture_only",
+    "operator_decision_required",
+]
+Decision = Literal[
+    "KEEP_AS_CANONICAL",
+    "KEEP_AS_PROVIDER_ADAPTER",
+    "OBSERVABILITY_ONLY",
+    "KEEP_AS_LEGACY_OUTPUT_CONTRACT",
+    "TEST_FIXTURE_ONLY",
+    "BRIDGE_TO_CANONICAL",
+    "UNKNOWN_REQUIRES_OPERATOR_DECISION",
+]
+
+SAFETY: Final[dict[str, bool]] = {
+    "classification_only": True,
+    "runtime_behavior_changed": False,
+    "creates_candidates": False,
+    "creates_strategies": False,
+    "creates_presets": False,
+    "creates_campaigns": False,
+    "runs_screening": False,
+    "runs_validation": False,
+    "trading_authority": False,
+    "paper_authority": False,
+    "shadow_authority": False,
+    "live_authority": False,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class FunnelClassification:
+    funnel_id: str
+    name: str
+    classification: Classification
+    decision: Decision
+    canonical_claim_allowed: bool
+    modules: tuple[str, ...]
+    protected_outputs: tuple[str, ...]
+    rationale: str
+    next_action: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "funnel_id": self.funnel_id,
+            "name": self.name,
+            "classification": self.classification,
+            "decision": self.decision,
+            "canonical_claim_allowed": self.canonical_claim_allowed,
+            "modules": list(self.modules),
+            "protected_outputs": list(self.protected_outputs),
+            "rationale": self.rationale,
+            "next_action": self.next_action,
+        }
+
+
+FUNNEL_CLASSIFICATIONS: Final[tuple[FunnelClassification, ...]] = (
+    FunnelClassification(
+        funnel_id="canonical_provider_agnostic_contract_bridge_loop",
+        name="Canonical provider-agnostic contract/bridge/memory loop",
+        classification="canonical_contract_loop",
+        decision="KEEP_AS_CANONICAL",
+        canonical_claim_allowed=True,
+        modules=(
+            "packages/qre_research/canonical_contracts.py",
+            "packages/qre_research/tiingo_canonical_bridge.py",
+            "packages/qre_research/candidate_planning_bridge.py",
+            "packages/qre_research/evidence_memory_bridge.py",
+            "packages/qre_research/memory_aware_hypothesis_generation.py",
+        ),
+        protected_outputs=(),
+        rationale=(
+            "PR A-E established canonical vocabulary and deterministic bridges "
+            "through memory-aware next hypothesis ordering at the contract level."
+        ),
+        next_action="Use this contract path for future provider bridges; do not treat it as trading or validation authority.",
+    ),
+    FunnelClassification(
+        funnel_id="tiingo_hypothesis_candidate_research_mini_loop",
+        name="Tiingo hypothesis/candidate research mini-loop",
+        classification="provider_adapter",
+        decision="KEEP_AS_PROVIDER_ADAPTER",
+        canonical_claim_allowed=False,
+        modules=(
+            "research/qre_tiingo_hypothesis_generator_e2e.py",
+            "research/qre_tiingo_hypothesis_lifecycle.py",
+            "research/qre_tiingo_candidate_research_loop.py",
+            "packages/qre_research/tiingo_canonical_bridge.py",
+        ),
+        protected_outputs=(),
+        rationale="Provider-specific research mini-loop remains valuable only through canonical bridge contracts.",
+        next_action="Keep bridged to canonical Hypothesis, ResearchInputContract, CandidateSpec, Evidence, and Feedback contracts.",
+    ),
+    FunnelClassification(
+        funnel_id="daily_status_digest_observability",
+        name="Daily status digest / observability funnel",
+        classification="observability_only",
+        decision="OBSERVABILITY_ONLY",
+        canonical_claim_allowed=False,
+        modules=("research/qre_daily_status_digest.py",),
+        protected_outputs=(),
+        rationale="Digest consumes sidecars and summarizes status; it must not produce research objects.",
+        next_action="Continue read-only status aggregation only.",
+    ),
+    FunnelClassification(
+        funnel_id="run_research_registry_matrix",
+        name="run_research / registry / strategy_matrix funnel",
+        classification="legacy_protected",
+        decision="KEEP_AS_LEGACY_OUTPUT_CONTRACT",
+        canonical_claim_allowed=False,
+        modules=("research/run_research.py", "registry.py", "agent/backtesting/strategies.py"),
+        protected_outputs=("research/research_latest.json", "research/strategy_matrix.csv"),
+        rationale="Legacy research outputs remain protected and are not mutated by canonical reconciliation work.",
+        next_action="Keep protected until a separate operator-scoped settlement changes ownership.",
+    ),
+    FunnelClassification(
+        funnel_id="alpha_discovery_strategy_ir_campaign_lesson",
+        name="Alpha discovery / Strategy IR / campaign / lesson funnel",
+        classification="operator_decision_required",
+        decision="BRIDGE_TO_CANONICAL",
+        canonical_claim_allowed=False,
+        modules=("packages/qre_research/alpha_discovery",),
+        protected_outputs=(),
+        rationale="Older partial funnel semantics overlap canonical contracts but ownership is not fully settled.",
+        next_action="Bridge or explicitly quarantine individual surfaces before treating them as canonical.",
+    ),
+    FunnelClassification(
+        funnel_id="test_smoke_fixture_funnels",
+        name="Legacy or smoke/test-only funnel patterns",
+        classification="fixture_only",
+        decision="TEST_FIXTURE_ONLY",
+        canonical_claim_allowed=False,
+        modules=("tests/",),
+        protected_outputs=(),
+        rationale="Fixture and smoke paths may mimic funnel semantics but cannot own production architecture.",
+        next_action="Keep fixture-only assertions from becoming canonical claims.",
+    ),
+)
+
+
+def classifications_as_dict() -> dict[str, dict[str, object]]:
+    return {row.funnel_id: row.as_dict() for row in FUNNEL_CLASSIFICATIONS}
+
+
+def classification_by_id(funnel_id: str) -> FunnelClassification:
+    for row in FUNNEL_CLASSIFICATIONS:
+        if row.funnel_id == funnel_id:
+            return row
+    raise KeyError(funnel_id)
+
+
+def canonical_classifications() -> tuple[FunnelClassification, ...]:
+    return tuple(row for row in FUNNEL_CLASSIFICATIONS if row.canonical_claim_allowed)
+
+
+def validate_funnel_classifications() -> list[str]:
+    errors: list[str] = []
+    seen: set[str] = set()
+    for row in FUNNEL_CLASSIFICATIONS:
+        if row.funnel_id in seen:
+            errors.append(f"duplicate_funnel_id:{row.funnel_id}")
+        seen.add(row.funnel_id)
+        if row.classification != "canonical_contract_loop" and row.canonical_claim_allowed:
+            errors.append(f"noncanonical_claim_allowed:{row.funnel_id}")
+        if row.classification == "observability_only" and row.canonical_claim_allowed:
+            errors.append(f"observability_claims_canonical:{row.funnel_id}")
+        if row.classification == "fixture_only" and row.canonical_claim_allowed:
+            errors.append(f"fixture_claims_canonical:{row.funnel_id}")
+    if len(canonical_classifications()) != 1:
+        errors.append("expected_exactly_one_canonical_contract_loop")
+    return errors
+
+
+def classification_summary() -> dict[str, object]:
+    counts: dict[str, int] = {}
+    for row in FUNNEL_CLASSIFICATIONS:
+        counts[row.classification] = counts.get(row.classification, 0) + 1
+    return {
+        "classifications": counts,
+        "canonical_contract_loop": canonical_classifications()[0].funnel_id if len(canonical_classifications()) == 1 else None,
+        "duplicate_canonical_claims": len(canonical_classifications()) > 1,
+        "safety": dict(SAFETY),
+    }
+
+
+__all__ = [
+    "FUNNEL_CLASSIFICATIONS",
+    "SAFETY",
+    "FunnelClassification",
+    "canonical_classifications",
+    "classification_by_id",
+    "classification_summary",
+    "classifications_as_dict",
+    "validate_funnel_classifications",
+]

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -198,6 +198,7 @@ def test_package_migration_001_qre_research_has_only_bounded_read_only_seed() ->
         "empirical_evidence_pack.py",
         "empirical_research_flywheel.py",
         "evidence_memory_bridge.py",
+        "funnel_classification.py",
         "generated_hypothesis_paths.py",
         "generated_primitive_paths.py",
         "generated_strategy_paths.py",
@@ -222,6 +223,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_research/memory_aware_hypothesis_generation.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/research_memory.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/evidence_memory_bridge.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_research/funnel_classification.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/tiingo_canonical_bridge.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/retrieval_coverage.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/universe.py") == DOMAIN_QRE
@@ -250,6 +252,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_module("packages.qre_research.memory_aware_hypothesis_generation") == DOMAIN_QRE
     assert classify_module("packages.qre_research.research_memory") == DOMAIN_QRE
     assert classify_module("packages.qre_research.evidence_memory_bridge") == DOMAIN_QRE
+    assert classify_module("packages.qre_research.funnel_classification") == DOMAIN_QRE
     assert classify_module("packages.qre_research.tiingo_canonical_bridge") == DOMAIN_QRE
     assert classify_module("packages.qre_research.universe") == DOMAIN_QRE
     assert classify_module("packages.qre_data.cache_manifest") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -67,6 +67,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "empirical_evidence_pack.py",
         "empirical_research_flywheel.py",
         "evidence_memory_bridge.py",
+        "funnel_classification.py",
         "generated_hypothesis_paths.py",
         "generated_primitive_paths.py",
         "generated_strategy_paths.py",

--- a/tests/unit/test_qre_funnel_architecture_audit.py
+++ b/tests/unit/test_qre_funnel_architecture_audit.py
@@ -192,6 +192,7 @@ def test_operator_summary_contains_required_sections(tmp_path: Path) -> None:
         "## Verdict",
         "## Funnels detected",
         "## Provider leakage",
+        "## Funnel classification",
         "## Reconciliation decisions",
         "## Safety confirmation",
     ):
@@ -222,3 +223,21 @@ def test_operator_summary_bluntly_reports_parallel_funnels(tmp_path: Path) -> No
     report = audit.build_report(_fixture_repo(tmp_path))
     summary = audit.render_operator_summary(report)
     assert "multiple partial funnels exist" in summary.lower()
+
+
+def test_audit_includes_funnel_classification_registry(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    classification = report["funnel_classification"]
+
+    assert classification["summary"]["canonical_contract_loop"] == "canonical_provider_agnostic_contract_bridge_loop"
+    assert classification["summary"]["duplicate_canonical_claims"] is False
+    assert classification["classifications"]["tiingo_hypothesis_candidate_research_mini_loop"]["classification"] == "provider_adapter"
+    assert classification["classifications"]["daily_status_digest_observability"]["classification"] == "observability_only"
+
+
+def test_audit_does_not_claim_runtime_loop_is_closed(tmp_path: Path) -> None:
+    report = audit.build_report(_fixture_repo(tmp_path))
+    assessment = report["canonicality_assessment"]
+
+    assert assessment["canonical_contract_bridge_loop_classified"] is True
+    assert assessment["full_provider_agnostic_loop_exists"] is False

--- a/tests/unit/test_qre_funnel_classification.py
+++ b/tests/unit/test_qre_funnel_classification.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+from packages.qre_research import funnel_classification as fc
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_canonical_loop_classification_exists() -> None:
+    canonical = fc.canonical_classifications()
+
+    assert len(canonical) == 1
+    assert canonical[0].funnel_id == "canonical_provider_agnostic_contract_bridge_loop"
+    assert canonical[0].decision == "KEEP_AS_CANONICAL"
+
+
+def test_tiingo_is_provider_adapter_not_canonical() -> None:
+    row = fc.classification_by_id("tiingo_hypothesis_candidate_research_mini_loop")
+
+    assert row.classification == "provider_adapter"
+    assert row.decision == "KEEP_AS_PROVIDER_ADAPTER"
+    assert row.canonical_claim_allowed is False
+
+
+def test_daily_digest_is_observability_only() -> None:
+    row = fc.classification_by_id("daily_status_digest_observability")
+
+    assert row.classification == "observability_only"
+    assert row.decision == "OBSERVABILITY_ONLY"
+    assert row.canonical_claim_allowed is False
+
+
+def test_fixture_funnels_are_fixture_only() -> None:
+    row = fc.classification_by_id("test_smoke_fixture_funnels")
+
+    assert row.classification == "fixture_only"
+    assert row.decision == "TEST_FIXTURE_ONLY"
+    assert row.canonical_claim_allowed is False
+
+
+def test_legacy_frozen_outputs_are_protected() -> None:
+    row = fc.classification_by_id("run_research_registry_matrix")
+
+    assert row.classification == "legacy_protected"
+    assert "research/research_latest.json" in row.protected_outputs
+    assert "research/strategy_matrix.csv" in row.protected_outputs
+    assert (REPO_ROOT / "research" / "research_latest.json").exists()
+    assert (REPO_ROOT / "research" / "strategy_matrix.csv").exists()
+
+
+def test_duplicate_canonical_claims_fail_validation(monkeypatch: MonkeyPatch) -> None:
+    duplicate = fc.FunnelClassification(
+        funnel_id="duplicate_canonical",
+        name="Duplicate canonical claim",
+        classification="canonical_contract_loop",
+        decision="KEEP_AS_CANONICAL",
+        canonical_claim_allowed=True,
+        modules=(),
+        protected_outputs=(),
+        rationale="test duplicate",
+        next_action="fail validation",
+    )
+    monkeypatch.setattr(fc, "FUNNEL_CLASSIFICATIONS", (*fc.FUNNEL_CLASSIFICATIONS, duplicate))
+
+    assert "expected_exactly_one_canonical_contract_loop" in fc.validate_funnel_classifications()
+
+
+def test_ambiguous_owners_remain_operator_decision_required() -> None:
+    row = fc.classification_by_id("alpha_discovery_strategy_ir_campaign_lesson")
+
+    assert row.classification == "operator_decision_required"
+    assert row.canonical_claim_allowed is False
+    assert row.decision == "BRIDGE_TO_CANONICAL"
+
+
+def test_classification_registry_validates_cleanly() -> None:
+    assert fc.validate_funnel_classifications() == []
+
+
+def test_no_execution_authority_introduced() -> None:
+    assert fc.SAFETY["classification_only"] is True
+    assert fc.SAFETY["runtime_behavior_changed"] is False
+    assert fc.SAFETY["creates_campaigns"] is False
+    assert fc.SAFETY["runs_screening"] is False
+    assert fc.SAFETY["trading_authority"] is False
+    assert fc.SAFETY["paper_authority"] is False
+    assert fc.SAFETY["shadow_authority"] is False
+    assert fc.SAFETY["live_authority"] is False
+
+
+def test_classification_summary_reports_no_duplicate_canonical_claims() -> None:
+    summary = fc.classification_summary()
+
+    assert summary["canonical_contract_loop"] == "canonical_provider_agnostic_contract_bridge_loop"
+    assert summary["duplicate_canonical_claims"] is False

--- a/tools/qre_funnel_architecture_audit.py
+++ b/tools/qre_funnel_architecture_audit.py
@@ -12,6 +12,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
+from packages.qre_research.funnel_classification import (
+    classification_summary,
+    classifications_as_dict,
+)
+
 REPORT_KIND: Final[str] = "qre_funnel_architecture_audit"
 SCHEMA_VERSION: Final[int] = 1
 DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_funnel_architecture_audit")
@@ -649,6 +654,15 @@ def build_reconciliation_plan(funnels: list[dict[str, Any]], contract_map: dict[
     return plan
 
 
+def build_funnel_classification_report() -> dict[str, Any]:
+    classifications = classifications_as_dict()
+    return {
+        "summary": classification_summary(),
+        "classifications": classifications,
+        "canonical_contract_loop": classifications.get("canonical_provider_agnostic_contract_bridge_loop", {}),
+    }
+
+
 def build_visual_maps() -> dict[str, str]:
     return {
         "c4_context": "docs/architecture/qre_funnel_visual_maps.md#diagram-1-c4-context-qre-research-system-boundary",
@@ -690,6 +704,7 @@ def build_report(repo_root: Path = Path(".")) -> dict[str, Any]:
             "hardcoded_coupling_summary": {},
             "canonicality_assessment": {},
             "reconciliation_plan": [],
+            "funnel_classification": build_funnel_classification_report(),
             "visual_maps": build_visual_maps(),
             "safety": dict(SAFETY),
         }
@@ -699,6 +714,7 @@ def build_report(repo_root: Path = Path(".")) -> dict[str, Any]:
     coupling_report = build_hardcoded_coupling_report(scan)
     graph = build_dependency_graph(scan, funnels, contract_map, provider_report)
     reconciliation = build_reconciliation_plan(funnels, contract_map)
+    funnel_classification = build_funnel_classification_report()
     unknown_contracts = [
         name
         for name, payload in contract_map.items()
@@ -734,10 +750,12 @@ def build_report(repo_root: Path = Path(".")) -> dict[str, Any]:
         "hardcoded_coupling_summary": {"findings": len(coupling_report["hardcoded_coupling_findings"])},
         "canonicality_assessment": {
             "full_provider_agnostic_loop_exists": False,
-            "assessment": "Multiple partial funnels exist. The Tiingo path is a provider-specific mini-loop; daily digest is observability-only; canonical ownership remains ambiguous for several provider-agnostic contracts.",
+            "canonical_contract_bridge_loop_classified": True,
+            "assessment": "Multiple runtime funnels still exist. PR A-F classify one provider-agnostic contract/bridge/memory path as canonical at the contract level; the Tiingo path remains a provider adapter; daily digest is observability-only.",
             "unknown_contracts": unknown_contracts,
         },
         "reconciliation_plan": reconciliation,
+        "funnel_classification": funnel_classification,
         "visual_maps": build_visual_maps(),
         "provider_leakage_report": provider_report,
         "hardcoded_coupling_report": coupling_report,
@@ -777,6 +795,10 @@ def render_operator_summary(report: dict[str, Any]) -> str:
             "",
             "## Duplicate or parallel semantics",
             f"- Duplicate or parallel semantics detected: {str(summary['duplicate_semantics_detected']).lower()}",
+            "",
+            "## Funnel classification",
+            f"- Canonical contract loop: {report['funnel_classification']['summary'].get('canonical_contract_loop')}",
+            f"- Duplicate canonical claims: {str(report['funnel_classification']['summary'].get('duplicate_canonical_claims')).lower()}",
             "",
             "## Visual maps",
         ]

--- a/tools/qre_funnel_architecture_audit.py
+++ b/tools/qre_funnel_architecture_audit.py
@@ -6,13 +6,18 @@ import contextlib
 import json
 import os
 import re
+import sys
 import tempfile
 from collections import Counter, defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
-from packages.qre_research.funnel_classification import (
+REPO_ROOT_FOR_IMPORT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT_FOR_IMPORT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT_FOR_IMPORT))
+
+from packages.qre_research.funnel_classification import (  # noqa: E402
     classification_summary,
     classifications_as_dict,
 )


### PR DESCRIPTION
Summary:
- adds read-only QRE funnel classification metadata
- classifies the canonical provider-agnostic contract/bridge/memory path
- keeps Tiingo as a provider adapter bridged to canonical contracts
- keeps daily digest observability-only
- protects legacy run_research / registry / strategy_matrix outputs
- quarantines fixture/smoke funnel claims as fixture-only
- updates architecture audit output and docs with classification settlement

Validation:
- python -m pytest tests/unit/test_qre_funnel_classification.py -q
- python -m pytest tests/unit/test_qre_funnel_architecture_audit.py -q
- python -m pytest tests/unit/test_qre_canonical_contract_vocabulary.py -q
- python -m pytest tests/unit/test_qre_tiingo_canonical_bridge.py -q
- python -m pytest tests/unit/test_qre_candidate_planning_bridge.py -q
- python -m pytest tests/unit/test_qre_evidence_memory_bridge.py -q
- python -m pytest tests/unit/test_qre_memory_aware_hypothesis_generation.py -q
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py tests/architecture/test_package_migration_010_closure_decision.py -q
- python -m ruff check tools/qre_funnel_architecture_audit.py packages/qre_research/funnel_classification.py tests/unit/test_qre_funnel_classification.py tests/unit/test_qre_funnel_architecture_audit.py
- git diff --check

Safety:
- classification_only=true
- runtime_behavior_changed=false
- no candidates created
- no strategies created
- no presets created
- no campaigns created
- no screening run
- no validation/promotion/strategy registration
- no paper/shadow/live authority
- no trading authority
- research/research_latest.json not mutated
- research/strategy_matrix.csv not mutated